### PR TITLE
[terraform-resources] add schemas for route53-zone

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -847,6 +847,7 @@
       alb: NamespaceTerraformResourceALB_v1
       secrets-manager: NamespaceTerraformResourceSecretsManager_v1
       asg: NamespaceTerraformResourceASG_v1
+      route53-zone: NamespaceTerraformResourceRoute53Zone_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: account, type: string, isRequired: true }
@@ -1121,6 +1122,16 @@
   - { name: targets, type: NamespaceTerraformResourceALBTargets_v1, isRequired: true, isList: true }
   - { name: rules, type: NamespaceTerraformResourceALBRules_v1, isRequired: true, isList: true }
   - { name: vpc, type: AWSVPC_v1, isRequired: true }
+  - { name: output_resource_name, type: string }
+  - { name: annotations, type: json }
+
+- name: NamespaceTerraformResourceRoute53Zone_v1
+  interface: NamespaceTerraformResource_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: account, type: string, isRequired: true }
+  - { name: region, type: string }
+  - { name: identifier, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
   - { name: annotations, type: json }
 

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -774,5 +774,24 @@ oneOf:
   - account
   - identifier
   - defaults
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - route53-zone
+    account:
+      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
+    identifier:
+      type: string
+    region:
+      "$ref": "/aws/regions-1.yml#/properties/region"
+    output_resource_name:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    annotations:
+      "$ref": "/common-1.json#/definitions/annotations"
+  required:
+  - account
+  - identifier
 required:
 - provider


### PR DESCRIPTION
related to https://issues.redhat.com/browse/OSD-8770

required for https://github.com/app-sre/qontract-reconcile/pull/1962

this PR adds schemas required to support a new terraform-resources provider: `route53-zone`