### PR TITLE
add optional partition field to aws account schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -676,6 +676,7 @@
   - { name: deleteKeys, type: string, isList: true }
   - { name: resetPasswords, type: AWSAccountResetPassword_v1, isList: true }
   - { name: premiumSupport, type: boolean, isRequired: true }
+  - { name: partition, type: string }
   - name: ecrs
     type: AWSECR_v1
     isList: true

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -80,6 +80,12 @@ properties:
       - requestId
   premiumSupport:
     type: boolean
+  partition:
+    type: string
+    description: the partition used in ARNs in the account (arn:aws:...)
+    enum:
+    - aws
+    - aws-us-gov
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4008

we need to support `aws` + `aws-us-gov` in our terraform integrations.