### PR TITLE
terraform resource aws-iam-role assume_role to array

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -923,7 +923,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: account, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
-  - { name: assume_role, type: string, isRequired: true }
+  - { name: assume_role, type: string, isRequired: true, isList: true }
   - { name: inline_policy, type: json }
   - { name: output_resource_name, type: string }
   - { name: annotations, type: json }

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -26,7 +26,9 @@ properties:
   user_policy:
     type: object
   assume_role:
-    type: string
+    type: array
+    items:
+      type: string
   inline_policy:
     type: object
   output_resource_name:
@@ -154,7 +156,9 @@ oneOf:
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     assume_role:
-      type: string
+      type: array
+      items:
+        type: string
     inline_policy:
       type: object
     output_resource_name:


### PR DESCRIPTION
this PR changes the `assume_role` field of an AWS IAM role resource from string to an array of strings.
this is to allow defining a role with multiple IAM users that can assume it.

the `aws-iam-role` provider is currently not in use in the main app-interface repo, but only in use in the FedRamp environment.

the usage:
we mimic the AWS infrastructure access feature of OSD by creating an IAM role with the same [permissions](https://github.com/openshift/aws-account-operator/blob/84b11ddceb6baa5a2ee4fae56ce6fe686b415db8/hack/olm-registry/olm-artifacts-template.yaml#L105-L269) and permit usage of it to multiple users:
- the app-interface terraform user
- the hive iam user used to manage various VPC related resources in the cluster's aws account as part of the PrivateLink functionality: https://github.com/openshift/hive/blob/master/docs/awsprivatelink.md#configuring-hive-to-enable-aws-private-link