### PR TITLE
Add skip property to permission schema to be able to skip placeholder.

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1628,6 +1628,7 @@
   - { name: channels, type: string, isList: true }
   - { name: ownersFromRepos, type: string, isList: true }
   - { name: schedule, type: Schedule_v1 }
+  - { name: skip, type: boolean }
   - name: roles
     type: Role_v1
     isList: true

--- a/schemas/access/permission-1.yml
+++ b/schemas/access/permission-1.yml
@@ -67,6 +67,8 @@ properties:
   schedule:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/app-sre/schedule-1.yml"
+  skip:
+    type: boolean
 oneOf:
 - properties:
     service:
@@ -165,6 +167,8 @@ oneOf:
     description:
       type: string
       maxLength: 140
+    skip:
+      type: boolean
   required:
   - handle
   - description


### PR DESCRIPTION
### Why&What
To be able to skip placeholder. Specifically for slakc-usergroup integration in this case, therefore updating the PermissionSlackUsergroup_v1 schema.