### PR TITLE
[terraform-vpc-peerings] add support to provide role to assume for account-vpc

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -515,6 +515,7 @@
   - { name: vpc, type: AWSVPC_v1, isRequired: true }
   - { name: manageRoutes, type: boolean }
   - { name: delete, type: boolean }
+  - { name: assumeRole, type: string }
 
 - name: ClusterPeeringConnectionAccountVPCMesh_v1
   interface: ClusterPeeringConnection_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -548,6 +548,7 @@
   - { name: cluster, type: Cluster_v1, isRequired: true }
   - { name: manageRoutes, type: boolean }
   - { name: delete, type: boolean }
+  - { name: assumeRole, type: string }
 
 - name: ClusterPeeringConnectionClusterAccepter_v1
   interface: ClusterPeeringConnection_v1
@@ -557,6 +558,7 @@
   - { name: cluster, type: Cluster_v1, isRequired: true }
   - { name: manageRoutes, type: boolean }
   - { name: delete, type: boolean }
+  - { name: assumeRole, type: string }
 
 - name: ClusterPeering_v1
   fields:

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -391,6 +391,8 @@ properties:
                 type: boolean
               delete:
                 type: boolean
+              assumeRole:
+                type: string
             required:
             - provider
             - name
@@ -409,6 +411,8 @@ properties:
                 type: boolean
               delete:
                 type: boolean
+              assumeRole:
+                type: string
             required:
             - provider
             - name

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -325,6 +325,8 @@ properties:
                 type: boolean
               delete:
                 type: boolean
+              assumeRole:
+                type: string
             required:
             - provider
             - name


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4092

to be able to create vpc peerings without OCM using the account-vpc provider.