### PR TITLE
Introduce schemas for status pages and their components

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1350,6 +1350,7 @@
   - { name: endPoints, type: AppEndPoints_v1, isList: true }
   - { name: codeComponents, type: AppCodeComponents_v1, isList: true }
   - { name: sentryProjects, type: AppSentryProjects_v1, isList: true }
+  - { name: statusPageComponents, type: StatusPageComponent_v1, isList: true }
   - name: namespaces
     type: Namespace_v1
     isList: true
@@ -1966,6 +1967,8 @@
   - { name: pagerduty_instances_v1, type: PagerDutyInstance_v1, isList: true, datafileSchema: /dependencies/pagerduty-instance-1.yml }
   - { name: ocm_instances_v1, type: OpenShiftClusterManager_v1, isList: true, datafileSchema: /openshift/openshift-cluster-manager-1.yml }
   - { name: dyn_traffic_directors_v1, type: DynTrafficDirector_v1, isList: true, datafileSchema: /dependencies/dyn-traffic-director-1.yml }
+  - { name: status_page_v1, type: StatusPage_v1, isList: true, datafileSchema: /dependencies/status-page-1.yml }
+  - { name: status_page_component_v1, type: StatusPageComponent_v1, isList: true, datafileSchema: /dependencies/status-page-component-1.yml }
 
 - name: SentryTeam_v1
   fields:
@@ -2096,3 +2099,40 @@
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: ttl, type: int }
   - { name: records, type: DynTrafficDirectorRecord_v1, isRequired: true, isList: true }
+
+- name: StatusPage_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: labels, type: json }
+  - { name: name, type: string, isRequired: true, isUnique: true }
+  - { name: description, type: string, isRequired: true }
+  - { name: url, type: string }
+  - { name: provider, type: string, isRequired: true }
+  - { name: apiUrl, type: string, isRequired: true }
+  - { name: credentials, type: VaultSecret_v1, isRequired: true }
+  - { name: pageId, type: string, isRequired: true, isUnique: true }
+  - name: components
+    type: StatusPageComponent_v1
+    isList: true
+    synthetic:
+      schema: /dependencies/status-page-component-1.yml
+      subAttr: page
+
+- name: StatusPageComponent_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: labels, type: json }
+  - { name: name, type: string, isRequired: true, isUnique: true }
+  - { name: displayName, type: string, isRequired: true }
+  - { name: description, type: string }
+  - { name: instructions, type: string, isRequired: true }
+  - { name: page, type: StatusPage_v1, isRequired: true }
+  - { name: groupName, type: string }
+  - name: apps
+    type: App_v1
+    isList: true
+    synthetic:
+      schema: /app-sre/app-1.yml
+      subAttr: statusPageComponents

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -95,6 +95,12 @@ properties:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/dependencies/dependency-1.yml"
 
+  statusPageComponents:
+    type: array
+    items:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/dependencies/status-page-component-1.yml"
+
   gcrRepos:
     type: array
     items:

--- a/schemas/dependencies/status-page-1.yml
+++ b/schemas/dependencies/status-page-1.yml
@@ -1,0 +1,37 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /dependencies/status-page-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    type: string
+  description:
+    type: string
+  url:
+    type: string
+  provider:
+    type: string
+  apiUrl:
+    type: string
+  credentials:
+    "$ref": "/common-1.json#/definitions/vaultSecret"
+  pageId:
+    type: string
+required:
+- "$schema"
+- labels
+- name
+- description
+- url
+- provider
+- apiUrl
+- credentials
+- pageId

--- a/schemas/dependencies/status-page-component-1.yml
+++ b/schemas/dependencies/status-page-component-1.yml
@@ -1,0 +1,34 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /dependencies/status-page-component-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    type: string
+  displayName:
+    type: string
+  description:
+    type: string
+  instructions:
+    type: string
+  groupName:
+    type: string
+  page:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/dependencies/status-page-1.yml"
+
+required:
+- "$schema"
+- labels
+- name
+- displayName
+- instructions
+- page


### PR DESCRIPTION
Implementation based on the design doc coverd in APPSRE-3908
* dependencies/status-page-1.yml includes all required information to connect to a status page instance
* dependencies/status-page-component-1.yml represents a component on a status page
* app-sre/app-1.yml references status page components for documentation purposes

Ref APPSRE-3902

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>