### PR TITLE
terraform/alb: add support for targetting an openshift_service

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1068,7 +1068,8 @@
   - { name: name, type: string, isRequired: true }
   - { name: default, type: boolean, isRequired: true }
   - { name: weights, type: NamespaceTerraformResourceALBTargetWeights_v1, isRequired: true }
-  - { name: ips, type: string, isRequired: true, isList: true }
+  - { name: ips, type: string, isList: true }
+  - { name: openshift_service, type: string }
 
 - name: NamespaceTerraformResourceALBTargetWeights_v1
   fields:

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -615,11 +615,17 @@ oneOf:
             type: array
             items:
               type: string
+          openshift_service:
+            type: string
         required:
         - name
         - default
         - weights
-        - ips
+        oneOf:
+        - required:
+          - ips
+        - required:
+          - openshift_service
     paths:
       type: object
       additionalProperties: false


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4107

This allows for setting an OpenShift Service name as the target for an ALB