### PR TITLE
Remove configurable resources option

### DIFF
--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -158,11 +158,6 @@ properties:
       pattern: '^(quay\.io|registry\.redhat\.io|[^.]+\.dkr\.ecr\.[^.]+\.amazonaws\.com).*$'
   use_channel_in_image_tag:
     type: boolean
-  configurableResources:
-    description: |
-      If set to true, tekton resources associated with this file will be managed
-      by openshift-tekton-resources
-    type: boolean
   deployResources:
     "$ref": "/openshift/deploy-resources-1.yml"
 required:


### PR DESCRIPTION
This was just a way to do a progressive rollout of the deployResources
option. Since all tekton resources are now controlled by the
openshift-tekton-resources integration, this is no longer needed

[APPSRE-3389](https://issues.redhat.com/browse/APPSRE-3389)

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>