### PR TITLE
Remove Tekton objects from openshift resources

### DIFF
--- a/schemas/openshift/namespace-1.yml
+++ b/schemas/openshift/namespace-1.yml
@@ -59,6 +59,8 @@ properties:
     type: array
     items:
       type: string
+      pattern: "[^Task|^Pipeline].+"
+
   managedResourceTypeOverrides:
     type: array
     items:


### PR DESCRIPTION
There's a dedicated integration for this, so we shouldn't need to use
openshift-resources to manage tekton objects.

In case we have to, we could just revert this and make sure that both
integrations do not crash by using managed resource names in the
namespace file

APPSRE-3389

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>