### PR TITLE
Add support for pod and port selectors in network policies

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1210,6 +1210,15 @@
   - { name: openshiftServiceAccountTokens, type: ServiceAccountTokenSpec_v1, isList: true }
   - { name: terraformResources, type: NamespaceTerraformResource_v1, isList: true, isInterface: true }
 
+- name: PodSelector_v1
+  fields:
+    - { name: matchLabels, isRequired: true, type: json }
+
+- name: NetworkPoliciesAllow_v1
+  fields:
+    - { name: namespace, type: Namespace_v1 }
+    - { name: pods, type: PodSelector_v1, isList: false, isRequired: false }
+
 - name: Namespace_v1
   fields:
   - { name: schema, type: string, isRequired: true }
@@ -1224,7 +1233,7 @@
   - { name: environment, type: Environment_v1, isRequired: true}
   - { name: limitRanges, type: LimitRange_v1 }
   - { name: quota, type: ResourceQuota_v1 }
-  - { name: networkPoliciesAllow, type: Namespace_v1, isList: true }
+  - { name: networkPoliciesAllow, type: NetworkPoliciesAllow_v1, isList: true }
   - { name: clusterAdmin, type: boolean }
   - { name: managedRoles, type: boolean }
   - { name: managedResourceTypes, type: string, isList: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1214,17 +1214,23 @@
   fields:
     - { name: matchLabels, isRequired: true, type: json }
 
+- name: NetworkPort_v1
+  fields:
+    - { name: protocol, type: string, isRequired: true }
+    - { name: port, type: int, isRequired: true }
+
 - name: NetworkPoliciesAllow_v1
   fields:
-    - { name: namespace, type: Namespace_v1 }
+    - { name: namespace, type: Namespace_v1, isRequired: true }
     - { name: pods, type: PodSelector_v1, isList: false, isRequired: false }
+    - { name: ports, type: NetworkPort_v1, isList: true, isRequired: false }
 
 - name: Namespace_v1
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
-  - { name: name, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isSearchable: true }
   - { name: delete, type: boolean }
   - { name: description, type: string, isRequired: true }
   - { name: grafanaUrl, type: string }

--- a/schemas/openshift/namespace-1.yml
+++ b/schemas/openshift/namespace-1.yml
@@ -66,20 +66,22 @@ properties:
           required:
           - matchLabels
         ports:
-          type: object
-          properties:
-            protocol:
-              type: string
-              enum:
-              - TCP
-              - UDP
-            port:
-              type: integer
-              minimum: 0
-              maximum: 65535
-          required:
-            - protocol
-            - port
+          type: array
+          items: 
+            type: object
+            properties:
+              protocol:
+                type: string
+                enum:
+                  - TCP
+                  - UDP
+              port:
+                type: integer
+                minimum: 0
+                maximum: 65535
+                required:
+                  - protocol
+                  - port
 
   clusterAdmin:
     type: boolean

--- a/schemas/openshift/namespace-1.yml
+++ b/schemas/openshift/namespace-1.yml
@@ -49,8 +49,37 @@ properties:
   networkPoliciesAllow:
     type: array
     items:
-      "$ref": "/common-1.json#/definitions/crossref"
-      "$schemaRef": "/openshift/namespace-1.yml"
+      type: object
+      required:
+        - namespace
+      properties:
+        namespace:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/openshift/namespace-1.yml"
+        pods:
+          type: object
+          properties:
+            matchLabels:
+              type: object
+              additionalProperties:
+                type: string
+          required:
+          - matchLabels
+        ports:
+          type: object
+          properties:
+            protocol:
+              type: string
+              enum:
+              - TCP
+              - UDP
+            port:
+              type: integer
+              minimum: 0
+              maximum: 65535
+          required:
+            - protocol
+            - port
 
   clusterAdmin:
     type: boolean


### PR DESCRIPTION
For the time being pod selectors only with `matchLabel`.

Refs https://issues.redhat.com/browse/APPSRE-3408
