### PR TITLE
Add Add support for SNS event notification for S3 and consolidate it with SQS

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -749,6 +749,14 @@
   - { name: description, type: string }
   - { name: region, type: string, isRequired: true }
 
+- name: AWSS3EventNotification_v1
+  fields:
+  - { name: event_type, type: string, isRequired: true, isList: true}
+  - { name: destination, type: string, isRequired: true}
+  - { name: destination_type, type: string, isRequired: true}
+  - { name: filters_prefix, type: string}
+  - { name: filters_suffix, type: string}
+
 - name: ACMDomain_v1
   fields:
   - { name: domain_name, type: string, isRequired: true }
@@ -930,6 +938,7 @@
   - { name: identifier, type: string, isRequired: true }
   - { name: defaults, type: string, isRequired: true }
   - { name: overrides, type: json }
+  - { name: event_notifications, type: AWSS3EventNotification_v1, isList: true }
   - { name: sqs_identifier, type: string }
   - { name: s3_events, type: string, isList: true }
   - { name: bucket_policy, type: json }

--- a/schemas/aws/s3-1.yml
+++ b/schemas/aws/s3-1.yml
@@ -31,6 +31,26 @@ properties:
         enum:
         - private
         - public-read
+  event_notifications:
+    type: array
+    items:
+      type: object
+      properties:
+        event_type:
+          type: array
+          items:
+            type: string
+        destination:
+          type: string
+        destination_type:
+          type: string
+          enum:
+          - sns
+          - sqs
+        filters_prefix:
+          type: string
+        filters_suffix:
+          type: string
   sqs_identifier:
     type: string
   s3_events:

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -23,6 +23,10 @@ properties:
     type: array
     items:
       type: string
+  policy:
+    type: object
+  fifo_topic:
+    type: boolean 
   user_policy:
     type: object
   assume_role:
@@ -65,6 +69,26 @@ properties:
     type: array
     items:
       type: string
+  event_notifications:
+    type: array
+    items:
+      type: object
+      properties:
+        event_type:
+          type: array
+          items:
+            type: string 
+        destination:
+          type: string
+        destination_type:
+          type: string
+          enum:
+          - sns
+          - sqs
+        filters_prefix:
+          type: string
+        filters_suffix:
+          type: string
   sqs_identifier:
     type: string
   bucket_policy:


### PR DESCRIPTION
### Why & What:
It is requested in [APPSRE-3780](https://issues.redhat.com/browse/APPSRE-3780) by to add support for s3://insights-warehouse-prod and s3://insights-ingress-prod buckets to able to publish to a couple of SNS topics via arn.

This schema update will allow adding event notification as an array that configure SNS or SQS event notification to the bucket.