### PR TITLE
Add per-path targets for ALB

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1113,7 +1113,7 @@
   - { name: certificate_arn, type: string, isRequired: true }
   - { name: idle_timeout, type: int }
   - { name: targets, type: NamespaceTerraformResourceALBTargets_v1, isRequired: true, isList: true }
-  - { name: paths, type: NamespaceTerraformResourceALBPaths_v1 }
+  - { name: rules, type: NamespaceTerraformResourceALBRules_v1, isRequired: true, isList: true }
   - { name: vpc, type: AWSVPC_v1, isRequired: true }
   - { name: output_resource_name, type: string }
   - { name: annotations, type: json }
@@ -1122,19 +1122,23 @@
   fields:
   - { name: name, type: string, isRequired: true }
   - { name: default, type: boolean, isRequired: true }
-  - { name: weights, type: NamespaceTerraformResourceALBTargetWeights_v1, isRequired: true }
   - { name: ips, type: string, isList: true }
   - { name: openshift_service, type: string }
 
-- name: NamespaceTerraformResourceALBTargetWeights_v1
+- name: NamespaceTerraformResourceALBRules_v1
   fields:
-  - { name: read, type: int, isRequired: true }
-  - { name: write, type: int, isRequired: true }
+  - { name: condition: type: NamespaceTerraformResourceALBConditon_v1, isRequired: true}
+  - { name: action: type: NamespaceTerraformResourceALBAction_v1, isRequired: true, isList: true}
 
-- name: NamespaceTerraformResourceALBPaths_v1
+- name: NamespaceTerraformResourceALBConditon_v1
   fields:
-  - { name: read, type: string, isList: true }
-  - { name: write, type: string, isList: true }
+  - { name: path: type: string, isRequired: true}
+  - { name: methods: type: string, isRequired: true}
+
+- name: NamespaceTerraformResourceALBAction_v1
+  fields:
+  - { name: target: type: string, isRequired: true}
+  - { name: weight: type: int, isRequired: true}
 
 - name: ResourceValues_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1127,18 +1127,18 @@
 
 - name: NamespaceTerraformResourceALBRules_v1
   fields:
-  - { name: condition: type: NamespaceTerraformResourceALBConditon_v1, isRequired: true}
-  - { name: action: type: NamespaceTerraformResourceALBAction_v1, isRequired: true, isList: true}
+  - { name: condition, type: NamespaceTerraformResourceALBConditon_v1, isRequired: true}
+  - { name: action, type: NamespaceTerraformResourceALBAction_v1, isRequired: true, isList: true}
 
 - name: NamespaceTerraformResourceALBConditon_v1
   fields:
-  - { name: path: type: string, isRequired: true}
-  - { name: methods: type: string, isRequired: true}
+  - { name: path, type: string, isRequired: true}
+  - { name: methods, type: string, isRequired: true}
 
 - name: NamespaceTerraformResourceALBAction_v1
   fields:
-  - { name: target: type: string, isRequired: true}
-  - { name: weight: type: int, isRequired: true}
+  - { name: target, type: string, isRequired: true}
+  - { name: weight, type: int, isRequired: true}
 
 - name: ResourceValues_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1133,7 +1133,7 @@
 - name: NamespaceTerraformResourceALBConditon_v1
   fields:
   - { name: path, type: string, isRequired: true}
-  - { name: methods, type: string, isRequired: true}
+  - { name: methods, type: string, isRequired: false}
 
 - name: NamespaceTerraformResourceALBAction_v1
   fields:

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -646,14 +646,6 @@ oneOf:
             type: string
           default:
             type: boolean
-          weights:
-            type: object
-            additionalProperties: false
-            properties:
-              read:
-                type: integer
-              write:
-                type: integer
           ips:
             type: array
             items:
@@ -663,24 +655,47 @@ oneOf:
         required:
         - name
         - default
-        - weights
         oneOf:
         - required:
           - ips
         - required:
           - openshift_service
-    paths:
-      type: object
-      additionalProperties: false
-      properties:
-        read:
-          type: array
-          items:
-            type: string
-        write:
-          type: array
-          items:
-            type: string
+    rules:
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          condition:
+            type: object
+            additionalProperties: false
+            properties:
+              path:
+                type: string
+              methods:
+                type: string
+                enum:
+                - read
+                - write
+            required:
+            - path
+            - methods
+          action:
+            type: array
+            items:
+              type: object
+              additionalProperties: false
+              properties:
+                target:
+                  type: string
+                weight:
+                  type: integer
+              required:
+              - target
+              - weight
+        required:
+        - condition
+        - action 
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
@@ -689,6 +704,7 @@ oneOf:
   - vpc
   - certificate_arn
   - targets
+  - rules
 - additionalProperties: false
   properties:
     provider:

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -683,6 +683,8 @@ oneOf:
             - path
           action:
             type: array
+            # https://github.com/hashicorp/terraform-provider-aws/pull/12574#issuecomment-639642524
+            minItems: 2
             items:
               type: object
               additionalProperties: false

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -679,10 +679,8 @@ oneOf:
                 enum:
                 - read
                 - write
-                - all
             required:
             - path
-            - methods
           action:
             type: array
             items:

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -26,7 +26,7 @@ properties:
   policy:
     type: object
   fifo_topic:
-    type: boolean 
+    type: boolean
   user_policy:
     type: object
   assume_role:
@@ -77,7 +77,7 @@ properties:
         event_type:
           type: array
           items:
-            type: string 
+            type: string
         destination:
           type: string
         destination_type:
@@ -123,8 +123,10 @@ properties:
     type: array
     items:
       type: object
-  paths:
-    type: object
+  rules:
+    type: array
+    items:
+      type: object
   cloudinit_configs:
     type: array
     items:
@@ -695,7 +697,7 @@ oneOf:
               - weight
         required:
         - condition
-        - action 
+        - action
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -679,6 +679,7 @@ oneOf:
                 enum:
                 - read
                 - write
+                - all
             required:
             - path
             - methods


### PR DESCRIPTION
ref: https://github.com/app-sre/qontract-reconcile/pull/2057
JIRA: APPSRE-3695

This schema change adds per-path targets instead of read/write targets. A sample config looks something like this:

```
provider: alb
...
targets:
- name: py2
  openshift_service: py2-svc
  default: true
- name: py3
  openshift_service: py3-svc
rules:
- condition:
    path: /v2/auth*
    methods: read
  action:
  - target: py2
    weight: 100
- condition:
    path: /v2*
    methods: read
  action:
  - target: py3
    weight: 100
  - target: py2
    weight: 0
```