### PR TITLE
add identifier to dns-zone

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2136,6 +2136,7 @@
   - { name: schema, type: string, isRequired: true }
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
+  - { name: identifier, type: string }
   - { name: description, type: string, isRequired: true }
   - { name: provider, type: string, isRequired: true }
   - { name: account, type: AWSAccount_v1, isRequired: true }

--- a/schemas/dependencies/dns-zone-1.yml
+++ b/schemas/dependencies/dns-zone-1.yml
@@ -13,6 +13,8 @@ properties:
     "$ref": "/common-1.json#/definitions/labels"
   name:
     type: string
+  identifier:
+    type: string
   description:
     type: string
   account:


### PR DESCRIPTION
with a unique identifier, we can specify multiple zones of the same name to support features such as split view DNS: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-considerations.html#hosted-zone-private-considerations-split-view-dns