### PR TITLE
Add support for pipeline provider defaults

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1623,6 +1623,8 @@
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
   - { name: provider, type: string, isRequired: true }
+  # This will be removed, it is only here so that the schema change
+  # is backwards compatible
   - { name: retention, type: PipelinesProviderRetention_v1 }
 
 - name: PipelinesProviderTekton_v1
@@ -1634,12 +1636,12 @@
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
   - { name: provider, type: string, isRequired: true }
+  - { name: defaults, type: PipelinesProviderTektonProviderDefaults_v1 }
   - { name: namespace, type: Namespace_v1, isRequired: true }
   - { name: retention, type: PipelinesProviderRetention_v1 }
-  - { name: deployResources, type: DeployResources_v1 }
-  # these two will need to be required at some point
   - { name: taskTemplates, type: PipelinesProviderTektonObjectTemplate_v1, isList: true }
   - { name: pipelineTemplates, type: PipelinesProviderPipelineTemplates_v1 }
+  - { name: deployResources, type: DeployResources_v1 }
 
 - name: PipelinesProviderRetention_v1
   fields:
@@ -1656,6 +1658,16 @@
 - name: PipelinesProviderPipelineTemplates_v1
   fields:
   - { name: openshiftSaasDeploy, type: PipelinesProviderTektonObjectTemplate_v1, isRequired: true }
+
+- name: PipelinesProviderTektonProviderDefaults_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: labels, type: json, isRequired: true }
+  - { name: description, type: string, isRequired: true }
+  - { name: retention, type: PipelinesProviderRetention_v1, isRequired: true }
+  - { name: taskTemplates, type: PipelinesProviderTektonObjectTemplate_v1, isRequired: true, isList: true }
+  - { name: pipelineTemplates, type: PipelinesProviderPipelineTemplates_v1, isRequired: true }
+  - { name: deployResources, type: DeployResources_v1 }
 
 - name: Permission_v1
   isInterface: true

--- a/schemas/app-sre/pipelines-provider-1.yml
+++ b/schemas/app-sre/pipelines-provider-1.yml
@@ -20,15 +20,21 @@ properties:
     type: string
     enum:
     - tekton
+  defaults:
+    description: "Pipeline provider defaults"
+    "$ref": "/common-1.json#/definitions/crossref"
   namespace:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/openshift/namespace-1.yml"
   retention:
+    description: "Describes the amount of builds that will be kept"
     additionalProperties: false
     properties:
       days:
+        description: "Maximum retention expressed in days"
         type: integer
       minimum:
+        description: "Minimum amount of builds that will be kept no matter what 'days' says"
         type: integer
     required:
     - days
@@ -51,14 +57,32 @@ oneOf:
       type: string
       enum:
       - tekton
+    defaults:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/app-sre/tekton-provider-defaults-1.yml"
     namespace:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/openshift/namespace-1.yml"
+    retention:
+      additionalProperties: false
+      properties:
+        days:
+          type: integer
+        minimum:
+          type: integer
+      required:
+      - days
     taskTemplates:
+      description: |
+        Tekton Task jinja2 templates that will be used to create the corresponding
+        objects in the provider namespace
       type: array
       items:
         "$ref": "/app-sre/tekton-object-template-1.yml"
     pipelineTemplates:
+      description: |
+        Tekton Pipeline jinja2 templates that will be used to create the corresponding
+        objects in the provider namespace
       additionalProperties: false
       properties:
         openshiftSaasDeploy:
@@ -66,16 +90,17 @@ oneOf:
       required:
       - openshiftSaasDeploy
     deployResources:
+      description:
+        CPU and memory resources used by the openshift-saas-deploy step of the
+        openshift-saas-deploy tasks created by the openshit-tekton-resources integration
       "$ref": "/openshift/deploy-resources-1.yml"
   required:
   - namespace
-  # These two will need to be required eventually
-  # - taskTemplates
-  # - pipelineTemplates
+  # This will need to be addded in a subsequent step
+  #- defaults
 required:
 - $schema
 - labels
 - name
 - description
 - provider
-- retention

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -174,6 +174,9 @@ properties:
   use_channel_in_image_tag:
     type: boolean
   deployResources:
+    description:
+      CPU and memory resources used by the openshift-saas-deploy step of the
+      openshift-saas-deploy tasks created by the openshit-tekton-resources integration
     "$ref": "/openshift/deploy-resources-1.yml"
 required:
 - "$schema"

--- a/schemas/app-sre/tekton-object-template-1.yml
+++ b/schemas/app-sre/tekton-object-template-1.yml
@@ -4,7 +4,9 @@ version: '1.0'
 type: object
 
 additionalProperties: false
-description: TODO
+description: |
+  Properties of tekton object templates deployed in tekton pipelines providers
+  namespaces
 properties:
   "$schema":
     type: string

--- a/schemas/app-sre/tekton-provider-defaults-1.yml
+++ b/schemas/app-sre/tekton-provider-defaults-1.yml
@@ -1,0 +1,48 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /app-sre/tekton-provider-defaults-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    type: string
+  description:
+    type: string
+  retention:
+    additionalProperties: false
+    properties:
+      days:
+        type: integer
+      minimum:
+        type: integer
+    required:
+    - days
+  taskTemplates:
+    type: array
+    items:
+      "$ref": "/app-sre/tekton-object-template-1.yml"
+  pipelineTemplates:
+    additionalProperties: false
+    properties:
+      openshiftSaasDeploy:
+        "$ref": "/app-sre/tekton-object-template-1.yml"
+    required:
+    - openshiftSaasDeploy
+  deployResources:
+    "$ref": "/openshift/deploy-resources-1.yml"
+required:
+- $schema
+- labels
+- name
+- description
+- retention
+- taskTemplates
+- pipelineTemplates

--- a/schemas/openshift/deploy-resources-1.yml
+++ b/schemas/openshift/deploy-resources-1.yml
@@ -6,8 +6,7 @@ type: object
 additionalProperties: false
 
 description: |
-  CPU and memory resources used by the openshift-saas-deploy step of the
-  openshift-saas-deploy tasks created by the openshit-tekton-resources integration
+  CPU and memory resources used in openshift objects
 
 properties:
   "$schema":


### PR DESCRIPTION
The choice here is to have mandatory defaults that cover for everything a
tekton provider needs and let the pipeline provider redefine whatever it
needs.  In this way we don't need to do hardcode any field in
qontract-reconcile outside of the graphql query as we know that all providers
will always have everything from the defaults.

Part of [APPSRE-4165](https://issues.redhat.com/browse/APPSRE-4165)

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>