### PR TITLE
Correct redundant plural.

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -755,8 +755,8 @@
   - { name: event_type, type: string, isRequired: true, isList: true}
   - { name: destination, type: string, isRequired: true}
   - { name: destination_type, type: string, isRequired: true}
-  - { name: filters_prefix, type: string}
-  - { name: filters_suffix, type: string}
+  - { name: filter_prefix, type: string}
+  - { name: filter_suffix, type: string}
 
 - name: ACMDomain_v1
   fields:

--- a/schemas/aws/s3-1.yml
+++ b/schemas/aws/s3-1.yml
@@ -47,9 +47,9 @@ properties:
           enum:
           - sns
           - sqs
-        filters_prefix:
+        filter_prefix:
           type: string
-        filters_suffix:
+        filter_suffix:
           type: string
   sqs_identifier:
     type: string

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -85,9 +85,9 @@ properties:
           enum:
           - sns
           - sqs
-        filters_prefix:
+        filter_prefix:
           type: string
-        filters_suffix:
+        filter_suffix:
           type: string
   sqs_identifier:
     type: string


### PR DESCRIPTION
This was not consistent with the [terraform resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification)