### PR TITLE
Make tekton provider defaults mandatory

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1623,9 +1623,6 @@
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
   - { name: provider, type: string, isRequired: true }
-  # This will be removed, it is only here so that the schema change
-  # is backwards compatible
-  - { name: retention, type: PipelinesProviderRetention_v1 }
 
 - name: PipelinesProviderTekton_v1
   interface: PipelinesProvider_v1
@@ -1636,7 +1633,7 @@
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
   - { name: provider, type: string, isRequired: true }
-  - { name: defaults, type: PipelinesProviderTektonProviderDefaults_v1 }
+  - { name: defaults, type: PipelinesProviderTektonProviderDefaults_v1, isRequired: true }
   - { name: namespace, type: Namespace_v1, isRequired: true }
   - { name: retention, type: PipelinesProviderRetention_v1 }
   - { name: taskTemplates, type: PipelinesProviderTektonObjectTemplate_v1, isList: true }

--- a/schemas/app-sre/pipelines-provider-1.yml
+++ b/schemas/app-sre/pipelines-provider-1.yml
@@ -96,8 +96,7 @@ oneOf:
       "$ref": "/openshift/deploy-resources-1.yml"
   required:
   - namespace
-  # This will need to be addded in a subsequent step
-  #- defaults
+  - defaults
 required:
 - $schema
 - labels


### PR DESCRIPTION
We will make sure that all pipelines providers always have what they need
to work properly and will fail at a schema level without the need of any
ad-hoc checks in the the code.

This is a breaking change.

part of APPSRE-4165

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>