### PR TITLE
APPSRE-4229 cluster network type support

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -466,6 +466,7 @@
 
 - name: ClusterNetwork_v1
   fields:
+  - { name: type, type: string }
   - { name: vpc, type: string, isRequired: true }
   - { name: service, type: string, isRequired: true }
   - { name: pod, type: string, isRequired: true }

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -220,6 +220,11 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      type:
+        type: string
+        enum:
+        - OpenShiftSDN
+        - OVNKubernetes
       vpc:
         type: string
       service:


### PR DESCRIPTION
New optional enum field `type` within `ClusterNetwork_v1`.
Default will be `OpenShiftSDN`, handled in qontract-reconcile: https://github.com/app-sre/qontract-reconcile/pull/2099