### PR TITLE
dyn-traffic-director: set range for record weight

### DIFF
--- a/schemas/dependencies/dyn-traffic-director-1.yml
+++ b/schemas/dependencies/dyn-traffic-director-1.yml
@@ -26,6 +26,8 @@ properties:
           "$schemaRef": "/openshift/cluster-1.yml"
         weight:
           type: integer
+          minimum: 1
+          maximum: 255
       oneOf:
       - required:
         - hostname


### PR DESCRIPTION
Dyn requires a weight of  `1..255` so this limits the schema such that validation will fail early