### PR TITLE
Add tests for SQL query regular expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 data.json
+.tox
+test/__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-.PHONY: build push test
+.PHONY: build push build-test test
 
 IMAGE_NAME := quay.io/app-sre/qontract-schemas
+IMAGE_TEST := $(IMAGE_NAME)-test
 IMAGE_TAG := $(shell git rev-parse --short=7 HEAD)
 VALIDATOR_IMAGE := quay.io/app-sre/qontract-validator
 VALIDATOR_IMAGE_TAG := latest
@@ -42,5 +43,14 @@ validate:
 		-v $(OUTPUT_DIR):/bundle:z \
 		$(VALIDATOR_IMAGE):$(VALIDATOR_IMAGE_TAG) \
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
-test:
-	tox
+
+build-test: clean
+	@docker build -t $(IMAGE_TEST) -f dockerfiles/Dockerfile.test .
+
+test: build-test
+	@docker run --rm $(IMAGE_TEST)
+
+clean:
+	@rm -rf .tox .eggs *.egg-info buid .pytest_cache
+	@find . -name "__pycache__" -type d -print0 | xargs -0 rm -rf
+	@find . -name "*.pyc" -delete

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build push
+.PHONY: build push test
 
 IMAGE_NAME := quay.io/app-sre/qontract-schemas
 IMAGE_TAG := $(shell git rev-parse --short=7 HEAD)
@@ -42,3 +42,5 @@ validate:
 		-v $(OUTPUT_DIR):/bundle:z \
 		$(VALIDATOR_IMAGE):$(VALIDATOR_IMAGE_TAG) \
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
+test:
+	tox

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -1,0 +1,8 @@
+FROM registry.access.redhat.com/ubi8/python-39
+
+RUN python3 -m pip install --no-cache-dir --upgrade pip tox
+
+COPY . /opt/app-root/src
+WORKDIR /opt/app-root/src
+
+CMD ["tox"]

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make bundle validate
+make test bundle validate

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+from utils import load_schemas
+
+@pytest.fixture(scope="session")
+def schemas():
+    return load_schemas()

--- a/test/test_sql_regexp.py
+++ b/test/test_sql_regexp.py
@@ -1,0 +1,53 @@
+import pytest
+import anymarkup
+from typing import Any, Dict
+from jsonschema.exceptions import ValidationError
+
+from utils import get_schema_object_validator
+
+valid_sql_queries = [
+    "select a from table_a;",
+    "SELECT A FROM TABLE_A;",
+    "select a from table order by id;",
+    "select a from table order by id;",
+    "select a from ( select a,b from table_b );",
+    "explain select a from table_a;"
+]
+
+not_valid_sql_queries = [
+    "select * from table_a",
+    "SELECT * FROM TABLE_A",
+    "select a from ( select * from table_b )",
+    "explain analyze select a from table b"
+]
+
+def new_query_spec(query: str) -> Dict[str, Any]:
+    return {
+        "$schema": "/app-interface/app-interface-sql-query-1.yml",
+        "labels": {},
+        "name": "query",
+        "namespace": {
+            "$ref": "namespace.yaml"
+        },
+        "identifier": "query",
+        "output": "stdout",
+        "query": query,
+    }
+
+@pytest.fixture(scope='session')
+def sql_validator():
+    """ Gets the schema validator for the sql-query objects"""
+    validator = get_schema_object_validator(
+        "/app-interface/app-interface-sql-query-1.yml"
+    )
+    return validator
+
+@pytest.mark.parametrize("query", valid_sql_queries)
+def test_valid_sql_queries(sql_validator, query):
+    sql_validator.validate(new_query_spec(query))
+
+
+@pytest.mark.parametrize("query", not_valid_sql_queries)
+def test_not_valid_sql_queries_raise_validation_error(sql_validator, query):
+    with pytest.raises(ValidationError):
+        sql_validator.validate(new_query_spec(query))

--- a/test/test_sql_regexp.py
+++ b/test/test_sql_regexp.py
@@ -9,7 +9,6 @@ valid_sql_queries = [
     "select a from table_a;",
     "SELECT A FROM TABLE_A;",
     "select a from table order by id;",
-    "select a from table order by id;",
     "select a from ( select a,b from table_b );",
     "explain select a from table_a;"
 ]
@@ -34,10 +33,11 @@ def new_query_spec(query: str) -> Dict[str, Any]:
         "query": query,
     }
 
-@pytest.fixture(scope='session')
-def sql_validator():
+@pytest.fixture(scope='module')
+def sql_validator(schemas):
     """ Gets the schema validator for the sql-query objects"""
     validator = get_schema_object_validator(
+        schemas,
         "/app-interface/app-interface-sql-query-1.yml"
     )
     return validator

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,34 @@
+import os
+from typing import Any, Dict
+import anymarkup
+from jsonschema import RefResolver, Draft6Validator
+
+
+def load_schemas(work_dir: str = "schemas") -> Dict[str, Any]:
+    """ Function to load all schema files.
+    It works like qontract-bundler, it stores all the schema files in a dictionary.
+    The keys are the schema uris, and the values the schema specs.
+    The same structure is used as a store paramenter in the jsonschema RefResolver.
+    """
+    schemas = {}
+    for root, dirs, files in os.walk(work_dir, topdown=False):
+        for name in files:
+            file_path = os.path.join(root, name)
+            data = anymarkup.parse_file(file_path)
+            rel_path = file_path[len(work_dir):]
+            schemas[rel_path] = data
+    return schemas
+
+
+def get_schema_object_validator(schema_ref: str) -> Draft6Validator:
+    """ Function to get a Draft6Validator object for an object.
+    It gets the schema definition from the store loaded in load_schemas and it
+    has a resolver with a store pointing to the same structure.
+    """
+    store = load_schemas()
+    resolver = RefResolver('', '', store=store)
+
+    return Draft6Validator(
+        store[schema_ref],
+        resolver=resolver
+    )

--- a/test/utils.py
+++ b/test/utils.py
@@ -20,12 +20,11 @@ def load_schemas(work_dir: str = "schemas") -> Dict[str, Any]:
     return schemas
 
 
-def get_schema_object_validator(schema_ref: str) -> Draft6Validator:
+def get_schema_object_validator(store: Dict[str, Any], schema_ref: str) -> Draft6Validator:
     """ Function to get a Draft6Validator object for an object.
     It gets the schema definition from the store loaded in load_schemas and it
     has a resolver with a store pointing to the same structure.
     """
-    store = load_schemas()
     resolver = RefResolver('', '', store=store)
 
     return Draft6Validator(

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py39
+skipsdist = True
+
+[testenv]
+commands = pytest -v
+deps = pytest
+       jsonschema
+       PyYaml
+       anymarkup


### PR DESCRIPTION
## Overview 
This PR adds test cases to ensure the sql-query regex validates the queries allowed in by the schema. The code also introduces a helper function to get validators for any other object that might need testing.
This is part of APPSRE-3316 to improve the sql queries regexp to allow comments on them. 

## Notes: 
* Running these tests here instead of in app-interface it's faster and it provides a more direct way to test the expressions.
* A possible approach is to generate fake data and use qontract-validator, but it introduces a lot of boilerplate files/data. 


