### PR TITLE
Added AWS ES advanced security options support

### DIFF
--- a/schemas/aws/elasticsearch-defaults-1.yml
+++ b/schemas/aws/elasticsearch-defaults-1.yml
@@ -102,5 +102,32 @@ properties:
         type: string
       indices.query.bool.max_clause_count:
         type: string
+  advanced_security_options:
+    type: object
+    additionalProperties: false
+    properties:
+      enabled:
+        type: boolean
+      internal_user_database_enabled:
+        type: boolean
+      master_user_options:
+        type: object
+        additionalProperties: false
+        properties:
+          master_user_secret:
+            type: object
+            additionalProperties: false
+            properties:
+              path:
+                type: string
+              version:
+                type: integer
+            required:
+            - path
+            - version
+        required:
+        - master_user_secret
+    required:
+    - enabled
 required:
 - "$schema"


### PR DESCRIPTION
part of [APPSRE-4219](https://issues.redhat.com/browse/APPSRE-4219)

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#advanced_security_options

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>