### PR TITLE
APPSRE-4164 make roles unique and searchable

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1875,7 +1875,7 @@
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
-  - { name: name, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
   - { name: description, type: string }
   - { name: expirationDate, type: string }
   - { name: permissions, type: Permission_v1, isList: true, isInterface: true }


### PR DESCRIPTION
- role names are now unique and searchable

**Test**

local bundle run with latest master from `app-interface`

```
qontract-server$ make bundle 
latest: Pulling from app-sre/qontract-validator
Digest: sha256:32fa05f3aeb43ae55d2b6db2f16eb99effaf1bab37863c42fbfaf0af50dbb552
Status: Image is up to date for quay.io/app-sre/qontract-validator:latest
quay.io/app-sre/qontract-validator:latest
mkdir -p /home/fishi0x01/Workspaces/redhat/app-sre/qontract-server/bundle
WARNING: We can't validate resource with schema /insights-prod/prometheus/prom.prometheusrules.yaml
WARNING: We can't validate resource with schema /insights-stage/prometheus/prom.prometheusrules.yaml
WARNING: We can't validate resource with schema /observability/prometheusrules/hive-stage-capacity.prometheusrules.yaml
WARNING: We can't validate resource with schema /observability/prometheusrules/hive-production-capacity.prometheusrules.yaml
WARNING: We can't validate resource with schema /observability/prometheusrules/qontract-reconcile-time-to-reconcile-slo.prometheusrules.yaml
WARNING: We can't validate resource with schema /observability/prometheusrules/ocm-service-log.prometheusrulestests.yaml
WARNING: We can't validate resource with schema /observability/prometheusrules/uhc-acct-mngr.prometheusrules.yaml
WARNING: We can't validate resource with schema /observability/prometheusrules/ocm-service-log.prometheusrules.yaml
WARNING: We can't validate resource with schema /observability/prometheusrules/cincinnati-slo.prometheusrules.yaml
WARNING: We can't validate resource with schema /observability/prometheusrules/uhc-acct-mngr.prometheusrulestests.yaml
[]
```