### PR TITLE
APPSRE-4119 add publish_log_types list for ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ make bundle-and-validate-schema
 ```
 
 However, usually you want to validate a schema change against real existing data in app-interface.
+During the development process it is encouraged to rely on test data in [app-sre/app-interface](https://github.com/app-sre/app-interface) instead.
 See [qcontract-server](https://github.com/app-sre/qontract-server) on how to bundle schema and app-interface data.

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -942,6 +942,7 @@
   - { name: defaults, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
   - { name: annotations, type: json }
+  - { name: publish_log_types, type: string, isList: true }
 
 - name: NamespaceTerraformResourceRDS_v1
   interface: NamespaceTerraformResource_v1

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -540,7 +540,6 @@ oneOf:
         - INDEX_SLOW_LOGS
         - SEARCH_SLOW_LOGS
         - ES_APPLICATION_LOGS
-        - AUDIT_LOGS
   required:
   - account
   - identifier

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -540,6 +540,7 @@ oneOf:
         - INDEX_SLOW_LOGS
         - SEARCH_SLOW_LOGS
         - ES_APPLICATION_LOGS
+        - AUDIT_LOGS
   required:
   - account
   - identifier

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -135,11 +135,6 @@ properties:
     type: array
     items:
       type: string
-      enum:
-      - INDEX_SLOW_LOGS
-      - SEARCH_SLOW_LOGS
-      - ES_APPLICATION_LOGS
-      - AUDIT_LOGS
 oneOf:
 - "$ref": "/aws/s3-1.yml"
 - additionalProperties: false

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -131,6 +131,15 @@ properties:
     type: array
     items:
       type: object
+  publish_log_types:
+    type: array
+    items:
+      type: string
+      enum:
+      - INDEX_SLOW_LOGS
+      - SEARCH_SLOW_LOGS
+      - ES_APPLICATION_LOGS
+      - AUDIT_LOGS
 oneOf:
 - "$ref": "/aws/s3-1.yml"
 - additionalProperties: false
@@ -528,6 +537,15 @@ oneOf:
       type: string
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
+    publish_log_types:
+      type: array
+      items:
+        type: string
+        enum:
+        - INDEX_SLOW_LOGS
+        - SEARCH_SLOW_LOGS
+        - ES_APPLICATION_LOGS
+        - AUDIT_LOGS
   required:
   - account
   - identifier


### PR DESCRIPTION
This adds `publish_log_types` to the schema. The types will be consumed in a next step by our terraform integration to forward logs to cloudwatch loggroups accordingly.

Usage example:
```
terraformResources:
- provider: elasticsearch
  account: xxx
  identifier: kibana-elasticsearch
  output_resource_name: kibana-elasticsearch
  publish_log_types:
  - ES_APPLICATION_LOGS
  - SEARCH_SLOW_LOGS
```

Tested locally by adding following to one of our existing services in app-interface:
```
- provider: elasticsearch
  ...
  publish_log_types:
  - ES_APPLICATION_LOGS
  - SEARCH_SLOW_LOGS
```

Then run:
```
app-sre/qontract-server$ make dev 
...
WARNING: We can't validate resource with schema ...
[]
yarn run v1.22.17
$ node ./dist/main-bundle.js
2022-01-25T17:17:57.599Z INFO: Running at http://localhost:4000/graphql
```

Further, checked in http://localhost:4000/graphql that the terrascript query returns `publish_log_types` properly.