### PR TITLE
Grafana Urls as list

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -236,6 +236,11 @@
   - { name: automationToken, type: VaultSecret_v1 }
   - { name: pushCredentials, type: VaultSecret_v1 }
 
+- name: GrafanaDashboardUrls_v1
+  fields:
+  - { name: title, type: string, isRequired: true}
+  - { name: url, type: string, isRequired: true}
+
 - name: QuayOrg_v1
   fields:
   - { name: schema, type: string, isRequired: true }
@@ -1403,7 +1408,8 @@
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
   - { name: onboardingStatus, type: string, isRequired: true }
-  - { name: grafanaUrl, type: string, isRequired: true }
+  - { name: grafanaUrl, type: string }
+  - { name: grafanaUrls, isList: true, type: GrafanaDashboardUrls_v1 }
   - { name: sopsUrl, type: string, isRequired: true }
   - { name: architectureDocument, type: string, isRequired: true }
   - { name: parentApp, type: App_v1 }

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -31,6 +31,25 @@ properties:
     type: string
     format: uri
 
+  grafanaUrls:
+    type: array
+    description: |
+      List of links to Grafana Dashboard/Folders associated with the service. Please provide 
+      a title together with the link.
+    items:
+      type: object
+      additionalProperties: false
+      required:
+      - title
+      - url
+      properties:
+        title:
+          type: string
+        url:
+          type: string
+          format: uri
+      minItems: 1
+
   sopsUrl:
     type: string
     format: uri
@@ -362,6 +381,5 @@ required:
 - escalationPolicy
 - onboardingStatus
 - serviceOwners
-- grafanaUrl
 - sopsUrl
 - architectureDocument


### PR DESCRIPTION
Make it possible to display multiple Grafana Urls for a given service

This implements requirements for configuring multiple dashboards, as described in this ticket: https://issues.redhat.com/browse/APPSRE-3494

Corresponding update in visual qontract: https://github.com/app-sre/visual-qontract/pull/149