### PR TITLE
Add query to permitted Prometheus rule labels.

### DIFF
--- a/schemas/openshift/prometheus-rule-1.yml
+++ b/schemas/openshift/prometheus-rule-1.yml
@@ -118,6 +118,8 @@ properties:
                           type: string
                         quantile:
                           type: string
+                        query:
+                          type: string
                         exported_namespace:
                           type: string
                         exported_service:


### PR DESCRIPTION
Currently, we are unable to implement an alert on our query path SLOs as `query` is not a permitted label in the Prometheus rule schema.

Read path latency measurements are identified by the (namespace, query, latency) tuple. See [these](https://prometheus.app-sre-stage-01.devshift.net/graph?g0.expr=(latencytarget%3Aup_custom_query_duration_seconds%3Arate1d%7Blatency%3D%222.0113571874999994%22%2Cnamespace%3D%22observatorium-mst-stage%22%2Cquery%3D%22query-path-sli-1M-samples%22%7D%20%3E%20(3%20*%200.9)%20and%20latencytarget%3Aup_custom_query_duration_seconds%3Arate2h%7Blatency%3D%222.0113571874999994%22%2Cnamespace%3D%22observatorium-mst-stage%22%2Cquery%3D%22query-path-sli-1M-samples%22%7D%20%3E%20(3%20*%200.9))%20or%20(latencytarget%3Aup_custom_query_duration_seconds%3Arate3d%7Blatency%3D%222.0113571874999994%22%2Cnamespace%3D%22observatorium-mst-stage%22%2Cquery%3D%22query-path-sli-1M-samples%22%7D%20%3E%20(0.9)%20and%20latencytarget%3Aup_custom_query_duration_seconds%3Arate6h%7Blatency%3D%222.0113571874999994%22%2Cnamespace%3D%22observatorium-mst-stage%22%2Cquery%3D%22query-path-sli-1M-samples%22%7D%20%3E%20(0.9))&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h&g1.expr=latencytarget%3Aup_custom_query_duration_seconds%3Arate1d&g1.tab=1&g1.stacked=0&g1.show_exemplars=0&g1.range_input=1h&g2.expr=up_custom_query_duration_seconds_count&g2.tab=1&g2.stacked=0&g2.show_exemplars=0&g2.range_input=1h) Prometheus queries for examples.

We _could_ identify them purely by the chosen latency measurement but that would omit valuable information in the alert we eventually receive.

Signed-off-by: Ian Billett <ibillett@redhat.com>