### PR TITLE
allow disabling terraform-resources per cluster

### DIFF
--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -468,6 +468,8 @@ properties:
           - openshift-resourcequotas
           - openshift-limitranges
           - openshift-serviceaccount-tokens
+          - terraform-resources
+          - terraform-resources-wrapper
       e2eTests:
         type: array
         items:


### PR DESCRIPTION
the expected result is that terraform resources will be reconciled regularly and output resources will not be applied to disabled clusters.