### PR TITLE
add smtp settings to app-interface settings

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -11,11 +11,17 @@
   - { name: mergeRequestGateway, type: string }
   - { name: saasDeployJobTemplate, type: string, isRequired: true }
   - { name: hashLength, type: int, isRequired: true }
+  - { name: smtp, type: SmtpSettings_v1 }
   - { name: dependencies, type: AppInterfaceDependencyMapping_v1, isList: true }
   - { name: credentials, type: CredentialsRequestMap_v1, isList: true }
   - { name: sqlQuery, type: SqlQuerySettings_v1 }
   - { name: pushGatewayCluster, type: Cluster_v1 }
   - { name: alertingServices, type: string, isList: true }
+
+- name: SmtpSettings_v1
+  fields:
+  - { name: mailAdress, type: string, isRequired: true }
+  - { name: credentials, type: VaultSecret_v1, isRequired: true }
 
 - name: AppInterfaceDependencyMapping_v1
   fields:

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -44,7 +44,8 @@ properties:
     type: object
     additionalProperties: false
     properties:
-      mailAdress: string
+      mailAddress:
+        type: string
       credentials:
         "$ref": "/common-1.json#/definitions/vaultSecret"
   dependencies:

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -40,6 +40,13 @@ properties:
     type: integer
     enum:
     - 7
+  smtp:
+    type: object
+    additionalProperties: false
+    properties:
+      mailAdress: string
+      credentials:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
   dependencies:
     type: array
     items:


### PR DESCRIPTION
we currently store the smtp settings in the qontract-reconcile toml file.

this PR adds schema support to specify smtp settings in app-interface settings.

required for https://github.com/app-sre/qontract-reconcile/pull/2157