### PR TITLE
add default field to github org

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -377,6 +377,7 @@
   - { name: description, type: string, isRequired: true }
   - { name: url, type: string, isRequired: true }
   - { name: two_factor_authentication, type: boolean, isRequired: true }
+  - { name: default, type: boolean }
   - { name: token, type: VaultSecret_v1, isRequired: true }
   - { name: managedTeams, type: string, isList: true, isRequired: false }
 

--- a/schemas/dependencies/github-org-1.yml
+++ b/schemas/dependencies/github-org-1.yml
@@ -19,6 +19,8 @@ properties:
     type: string
   two_factor_authentication:
     type: boolean
+  default:
+    type: boolean
   token:
     "$ref": "/common-1.json#/definitions/vaultSecret"
   managedTeams:


### PR DESCRIPTION
in case an integration needs to use a token, with no regards to what account it is from, with this PR we can define a default org to be used.