### PR TITLE
APPSRE-4339 AWS uid must not be unique

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -688,7 +688,7 @@
   - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
   - { name: description, type: string }
   - { name: consoleUrl, type: string, isRequired: true }
-  - { name: uid, type: string, isRequired: true, isUnique: true, isSearchable: true }
+  - { name: uid, type: string, isRequired: true, isSearchable: true }
   - { name: resourcesDefaultRegion, type: string, isRequired: true }
   - { name: supportedDeploymentRegions, type: string, isList: true }
   - { name: providerVersion, type: string, isRequired: true }


### PR DESCRIPTION
**Motivation**

We want to simulate multiple accounts in test runs. For that reason, we must be able to allow multiple account aliases to point to the same AWS `uid`.

Decision for this change: https://issues.redhat.com/browse/APPSRE-4399

**Changes**

Remove uniqueness constraint from `uid`

**Test**

Successfully bundled with schema multiple accounts in app-interface locally.