### PR TITLE
add description field to VPC peering connections

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -511,6 +511,7 @@
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
+  - { name: description, type: string }
   - { name: manageRoutes, type: boolean }
   - { name: delete, type: boolean }
 
@@ -520,6 +521,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
   - { name: vpc, type: AWSVPC_v1, isRequired: true }
+  - { name: description, type: string }
   - { name: manageRoutes, type: boolean }
   - { name: delete, type: boolean }
   - { name: assumeRole, type: string }
@@ -530,6 +532,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
   - { name: account, type: AWSAccount_v1, isRequired: true }
+  - { name: description, type: string }
   - { name: tags, type: json }
   - { name: manageRoutes, type: boolean }
   - { name: delete, type: boolean }
@@ -540,6 +543,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
   - { name: account, type: AWSAccount_v1, isRequired: true }
+  - { name: description, type: string }
   - { name: tags, type: json }
   - { name: manageRoutes, type: boolean }
   - { name: manageSecurityGroups, type: boolean }
@@ -553,6 +557,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
   - { name: cluster, type: Cluster_v1, isRequired: true }
+  - { name: description, type: string }
   - { name: manageRoutes, type: boolean }
   - { name: delete, type: boolean }
   - { name: assumeRole, type: string }
@@ -564,6 +569,7 @@
   - { name: name, type: string, isRequired: true }
   - { name: cluster, type: Cluster_v1, isRequired: true }
   - { name: awsInfrastructureManagementAccount, type: AWSAccount_v1 }
+  - { name: description, type: string }
   - { name: manageRoutes, type: boolean }
   - { name: delete, type: boolean }
   - { name: assumeRole, type: string }

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -289,6 +289,8 @@ properties:
               - cluster-vpc-accepter
             name:
               type: string
+            description:
+              type: string
             vpc:
               "$ref": "/common-1.json#/definitions/crossref"
               "$schemaRef": "/aws/vpc-1.yml"
@@ -321,6 +323,8 @@ properties:
                 - account-vpc
               name:
                 type: string
+              description:
+                type: string
               vpc:
                 "$ref": "/common-1.json#/definitions/crossref"
                 "$schemaRef": "/aws/vpc-1.yml"
@@ -341,6 +345,8 @@ properties:
                 - account-vpc-mesh
               name:
                 type: string
+              description:
+                type: string
               account:
                 "$ref": "/common-1.json#/definitions/crossref"
                 "$schemaRef": "/aws/account-1.yml"
@@ -360,6 +366,8 @@ properties:
                 enum:
                 - account-tgw
               name:
+                type: string
+              description:
                 type: string
               account:
                 "$ref": "/common-1.json#/definitions/crossref"
@@ -387,6 +395,8 @@ properties:
                 - cluster-vpc-requester
               name:
                 type: string
+              description:
+                type: string
               cluster:
                 "$ref": "/common-1.json#/definitions/crossref"
                 "$schemaRef": "/openshift/cluster-1.yml"
@@ -406,6 +416,8 @@ properties:
                 enum:
                 - cluster-vpc-accepter
               name:
+                type: string
+              description:
                 type: string
               cluster:
                 "$ref": "/common-1.json#/definitions/crossref"


### PR DESCRIPTION
the purpose for VPC peerings is not always obvious. this change
introduces optional description fields to allow documentation
of VPC peering connections.

Ref: https://issues.redhat.com/browse/APPSRE-4428

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>