### PR TITLE
blackbox-exporter module allow list in app-interface-settings

### DIFF
--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -105,6 +105,13 @@ properties:
     type: array
     items:
       type: string
+  endpointMonitoringBlackboxExporterModules:
+    type: array
+    description: |
+      the blackbox exporter modules that can be used for /dependencies/endpoint-monitoring-provider-1.yml#blackboxExporter.module
+      if none are listed, no restrictions apply
+    items:
+      type: string
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
Add a section "endpointMonitoringBlackboxExporterModules" to /app-interface/app-interface-settings-1.yml that enumerates the allowed blackbox-exporter modules for an app-interface instance. This will help to give meaningful feedback during PR checks when unsupported modules are referenced in an /dependencies/endpoint-monitoring-provider-1.yml object

Part of https://issues.redhat.com/browse/APPSRE-4523

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>