### PR TITLE
creating new schema for tf state

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -807,7 +807,7 @@
   - { name: premiumSupport, type: boolean, isRequired: true }
   - { name: partition, type: string }
   - { name: sharing, type: AWSAccountSharingOption_v1, isList: true, isInterface: true }
-  - { name: terraformState, type: AWSTerraformState_v1, isList: true, isRequired: false, isInterface: true }
+  - { name: terraformState, type: AWSTerraformState_v1, isRequired: false, isInterface: true }
   - name: ecrs
     type: AWSECR_v1
     isList: true
@@ -919,17 +919,22 @@
     strategy: fieldMap
     field: provider
     fieldMap:
-      aws-bucket: AWSBucketInfo_v1
+      s3: AWSS3TerraformState_v1
   fields:
-  - { name: provider, type: string, isRequired: true }
+  - { name: provider, type: string, isRequired: false }
 
-- name: AWSBucketInfo_v1
+- name: AWSS3TerraformState_v1
   interface: AWSTerraformState_v1
   fields:
+  - { name: provider, type: string, isRequired: true}
   - { name: bucket, type: string, isRequired: true }
-  - { name: key, type: string, isRequired: true }
   - { name: region, type: string, isRequired: true }
+  - { name: integrations, type: AWSTerraformStateIntegrations_v1, isList: true, isRequired: true }
+
+- name: AWSTerraformStateIntegrations_v1
+  fields:
   - { name: integration, type: string, isRequired: true }
+  - { name: key, type: string, isRequired: true }
 
 - name: ACMDomain_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -915,13 +915,10 @@
 
 - name: AWSTerraformState_v1
   fields:
-  - { name: terraform_resources, type: AWSTerraformResources_v1, isRequired: true }
-
-- name: AWSTerraformResources_v1
-  fields:
   - { name: bucket, type: string, isRequired: true }
   - { name: key, type: string, isRequired: true }
   - { name: region, type: string, isRequired: true }
+  - { name: integration, type: string, isRequired: true }
 
 - name: ACMDomain_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -807,7 +807,7 @@
   - { name: premiumSupport, type: boolean, isRequired: true }
   - { name: partition, type: string }
   - { name: sharing, type: AWSAccountSharingOption_v1, isList: true, isInterface: true }
-  - { name: terraformState, type: AWSTerraformState_v1, isRequired: false, isInterface: true }
+  - { name: terraformState, type: TerraformState_v1, isRequired: false, isInterface: true }
   - name: ecrs
     type: AWSECR_v1
     isList: true
@@ -913,18 +913,18 @@
   - { name: filter_prefix, type: string}
   - { name: filter_suffix, type: string}
 
-- name: AWSTerraformState_v1
+- name: TerraformState_v1
   isInterface: true
   interfaceResolve:
     strategy: fieldMap
     field: provider
     fieldMap:
-      s3: AWSS3TerraformState_v1
+      s3: TerraformStateAWS_v1
   fields:
   - { name: provider, type: string, isRequired: false }
 
-- name: AWSS3TerraformState_v1
-  interface: AWSTerraformState_v1
+- name: TerraformStateAWS_v1
+  interface: TerraformState_v1
   fields:
   - { name: provider, type: string, isRequired: true}
   - { name: bucket, type: string, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -807,6 +807,7 @@
   - { name: premiumSupport, type: boolean, isRequired: true }
   - { name: partition, type: string }
   - { name: sharing, type: AWSAccountSharingOption_v1, isList: true, isInterface: true }
+  - { name: terraformState, type: AWSTerraformState_v1, isList: true }
   - name: ecrs
     type: AWSECR_v1
     isList: true
@@ -911,6 +912,16 @@
   - { name: destination_type, type: string, isRequired: true}
   - { name: filter_prefix, type: string}
   - { name: filter_suffix, type: string}
+
+- name: AWSTerraformState_v1
+  fields:
+  - { name: terraform_resources, type: AWSTerraformResources_v1, isRequired: true }
+
+- name: AWSTerraformResources_v1
+  fields:
+  - { name: bucket, type: string, isRequired: true }
+  - { name: key, type: string, isRequired: true }
+  - { name: region, type: string, isRequired: true }
 
 - name: ACMDomain_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -807,7 +807,7 @@
   - { name: premiumSupport, type: boolean, isRequired: true }
   - { name: partition, type: string }
   - { name: sharing, type: AWSAccountSharingOption_v1, isList: true, isInterface: true }
-  - { name: terraformState, type: TerraformState_v1, isRequired: false, isInterface: true }
+  - { name: terraformState, type: TerraformStateAWS_v1, isRequired: false }
   - name: ecrs
     type: AWSECR_v1
     isList: true

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -808,6 +808,7 @@
   - { name: partition, type: string }
   - { name: sharing, type: AWSAccountSharingOption_v1, isList: true, isInterface: true }
   - { name: terraformState, type: AWSTerraformState_v1, isList: true }
+  - { name: terraformState, type: AWSTerraformState_v1, isList: true, isRequired: false }
   - name: ecrs
     type: AWSECR_v1
     isList: true

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -807,7 +807,7 @@
   - { name: premiumSupport, type: boolean, isRequired: true }
   - { name: partition, type: string }
   - { name: sharing, type: AWSAccountSharingOption_v1, isList: true, isInterface: true }
-  - { name: terraformState, type: AWSTerraformState_v1, isList: true, isRequired: false }
+  - { name: terraformState, type: AWSTerraformState_v1, isList: true, isRequired: false, isInterface: true }
   - name: ecrs
     type: AWSECR_v1
     isList: true
@@ -914,6 +914,17 @@
   - { name: filter_suffix, type: string}
 
 - name: AWSTerraformState_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      aws-bucket: AWSBucketInfo_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+
+- name: AWSBucketInfo_v1
+  interface: AWSTerraformState_v1
   fields:
   - { name: bucket, type: string, isRequired: true }
   - { name: key, type: string, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -807,7 +807,6 @@
   - { name: premiumSupport, type: boolean, isRequired: true }
   - { name: partition, type: string }
   - { name: sharing, type: AWSAccountSharingOption_v1, isList: true, isInterface: true }
-  - { name: terraformState, type: AWSTerraformState_v1, isList: true }
   - { name: terraformState, type: AWSTerraformState_v1, isList: true, isRequired: false }
   - name: ecrs
     type: AWSECR_v1

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -111,7 +111,7 @@ properties:
   terraformState:
     type: array
     description: key information for a terraform's state location and integration
-    terraform_resources:
+    items:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/aws/terraform-state-1.yml"
 required:

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -108,6 +108,11 @@ properties:
     type: array
     items:
       "$ref": "/aws/sharing-option-1.yml"
+  terraformState:
+    type: array
+    terraform_resources:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/aws/terraformstate-1.yml"
 required:
 - "$schema"
 - labels

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -109,11 +109,9 @@ properties:
     items:
       "$ref": "/aws/sharing-option-1.yml"
   terraformState:
-    type: array
     description: key information for a terraform's state location and integration
-    items:
-      "$ref": "/common-1.json#/definitions/crossref"
-      "$schemaRef": "/aws/terraform-state-1.yml"
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/dependencies/terraform-state-1.yml"
 required:
 - "$schema"
 - labels

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -110,9 +110,10 @@ properties:
       "$ref": "/aws/sharing-option-1.yml"
   terraformState:
     type: array
+    description: key information for a terraform's state location and integration
     terraform_resources:
       "$ref": "/common-1.json#/definitions/crossref"
-      "$schemaRef": "/aws/terraformstate-1.yml"
+      "$schemaRef": "/aws/terraform-state-1.yml"
 required:
 - "$schema"
 - labels

--- a/schemas/aws/terraform-state-1.yml
+++ b/schemas/aws/terraform-state-1.yml
@@ -18,3 +18,4 @@ properties:
     type: string
   integration:
     type: string
+    description: terraform state integration file

--- a/schemas/aws/terraform-state-1.yml
+++ b/schemas/aws/terraform-state-1.yml
@@ -8,7 +8,7 @@ properties:
   "$schema":
     type: string
     enum:
-    - /aws/account-1.yml
+    - /aws/terraform-state-1.yml
   bucket:
     type: string
   key:

--- a/schemas/aws/terraform-state-1.yml
+++ b/schemas/aws/terraform-state-1.yml
@@ -2,6 +2,7 @@
 "$schema": /metaschema-1.json
 version: '1.0'
 type: object
+description: bucket properties for each integration
 
 additionalProperties: false
 properties:
@@ -14,4 +15,6 @@ properties:
   key:
     type: string
   region:
+    type: string
+  integration:
     type: string

--- a/schemas/aws/terraform-state-1.yml
+++ b/schemas/aws/terraform-state-1.yml
@@ -1,0 +1,17 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /aws/account-1.yml
+  bucket:
+    type: string
+  key:
+    type: string
+  region:
+    type: string

--- a/schemas/dependencies/terraform-state-1.yml
+++ b/schemas/dependencies/terraform-state-1.yml
@@ -20,7 +20,7 @@ properties:
     type: string
   integrations:
     type: array
-    description: terraform state integration file
+    description: holds information which bucket key stores the terraform state per integration
     items: 
       type: object
       properties:

--- a/schemas/dependencies/terraform-state-1.yml
+++ b/schemas/dependencies/terraform-state-1.yml
@@ -9,13 +9,23 @@ properties:
   "$schema":
     type: string
     enum:
-    - /aws/terraform-state-1.yml
-  bucket:
+    - /dependencies/terraform-state-1.yml
+  provider:
     type: string
-  key:
+    enum:
+    - s3
+  bucket:
     type: string
   region:
     type: string
-  integration:
-    type: string
+  integrations:
+    type: array
     description: terraform state integration file
+    items: 
+      type: object
+    properties:
+      integration:
+        type: string
+      key:
+        type: string
+    additionalProperties: false

--- a/schemas/dependencies/terraform-state-1.yml
+++ b/schemas/dependencies/terraform-state-1.yml
@@ -23,9 +23,9 @@ properties:
     description: terraform state integration file
     items: 
       type: object
-    properties:
-      integration:
-        type: string
-      key:
-        type: string
-    additionalProperties: false
+      properties:
+        integration:
+          type: string
+        key:
+          type: string
+      additionalProperties: false


### PR DESCRIPTION
Part of [APPSRE-4516](https://issues.redhat.com/browse/APPSRE-4516)

Goal is to have a separate yaml file within app-interface that is then referenced in the account.yml file:
```
---
$schema: /dependencies/terraform-state-1.yml

provider: s3
bucket: someBucket
region: someRegion
integrations:
- integration: terraform-resources
  key:  qontract-reconcile.tfstate
- integration: terraform-tgw-attachements
  key: qontract-reconcile-tgw-attachments.tfstate
```
Within some-cloud-account.yml:
```
...
terraformState:
  $ref: /aws/app-sre-stage/tf-state-test.yml
```

For app-sre, we have specific terraform integrations for route53, resources, tgw, users, and vpc peerings

Signed-off-by: Suzana Nesic <snesic@redhat.com>