### PR TITLE
route53-zone add name field

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1170,6 +1170,7 @@
   - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
   - { name: annotations, type: json }
 

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -16,6 +16,8 @@ properties:
   account:
     "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
   identifier:
+    "$ref": "/common-1.json#/definitions/longIdentifier"
+  name:
     type: string
   variables:
     type: object
@@ -813,6 +815,8 @@ oneOf:
       "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       type: string
+    name:
+      type: string
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
     output_resource_name:
@@ -822,5 +826,6 @@ oneOf:
   required:
   - account
   - identifier
+  - name
 required:
 - provider

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -816,6 +816,7 @@ oneOf:
     identifier:
       type: string
     name:
+      description: base fqdn of the zone
       type: string
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -817,8 +817,7 @@ oneOf:
       type: string
     name:
       description: base fqdn of the zone
-      type: string
-      format: uri
+      "$ref": "/common-1.json#/definitions/k8sValidContainerName"
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
     output_resource_name:

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -818,6 +818,7 @@ oneOf:
     name:
       description: base fqdn of the zone
       type: string
+      format: uri
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
     output_resource_name:

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -16,7 +16,7 @@ properties:
   account:
     "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
   identifier:
-    "$ref": "/common-1.json#/definitions/longIdentifier"
+    type: string
   variables:
     type: object
   policies:


### PR DESCRIPTION
following https://github.com/app-sre/qontract-reconcile/pull/1962 where we added support for dns zones, we need to be able to provision resources with names that includes dots.