### PR TITLE
[terraform-resources] account refactor

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -854,6 +854,11 @@
   - { name: vault_tls_secret_path, type: string }
   - { name: vault_tls_secret_version, type: int }
 
+- name: NamespaceTerraformResources_v1
+  fields:
+  - { name: account, type: AWSAccount_v1, isRequired: true }
+  - { name: resources, type: NamespaceTerraformResource_v1, isRequired: true, isList: true, isInterface: true }
+
 - name: NamespaceTerraformResource_v1
   isInterface: true
   interfaceResolve:
@@ -882,7 +887,6 @@
       route53-zone: NamespaceTerraformResourceRoute53Zone_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
   - { name: annotations, type: json }
@@ -891,7 +895,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: defaults, type: string, isRequired: true }
@@ -915,7 +918,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: secret, type: VaultSecret_v1 }
@@ -926,7 +928,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: secret, type: VaultSecret_v1 }
@@ -937,7 +938,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: secret, type: VaultSecret_v1 }
@@ -949,7 +949,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: defaults, type: string, isRequired: true }
@@ -961,7 +960,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
   - { name: defaults, type: string, isRequired: true }
   - { name: availability_zone, type: string }
@@ -979,7 +977,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: defaults, type: string, isRequired: true }
@@ -1002,7 +999,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
   - { name: variables, type: json }
   - { name: policies, type: string, isList: true }
@@ -1020,7 +1016,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
   - { name: assume_role, type: AssumeRole_v1, isRequired: true }
   - { name: inline_policy, type: json }
@@ -1031,7 +1026,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
   - { name: defaults, type: string, isRequired: true }
   - { name: parameter_group, type: string }
@@ -1049,7 +1043,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
@@ -1065,7 +1058,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
@@ -1076,7 +1068,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
@@ -1089,7 +1080,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: defaults, type: string, isRequired: true }
@@ -1101,7 +1091,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: kms_encryption, type: boolean }
@@ -1114,7 +1103,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: defaults, type: string, isRequired: true }
@@ -1127,7 +1115,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: defaults, type: string, isRequired: true }
@@ -1139,7 +1126,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: defaults, type: string, isRequired: true }
@@ -1151,7 +1137,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: vpc, type: AWSVPC_v1, isRequired: true }
@@ -1167,7 +1152,6 @@
   interface: NamespaceTerraformResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: account, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
@@ -1288,7 +1272,7 @@
   - { name: sharedResources, type: SharedResources_v1, isList: true }
   - { name: openshiftResources, type: NamespaceOpenshiftResource_v1, isList: true, isInterface: true }
   - { name: managedTerraformResources, type: boolean }
-  - { name: terraformResources, type: NamespaceTerraformResource_v1, isList: true, isInterface: true }
+  - { name: terraformResources, type: NamespaceTerraformResources_v1, isList: true }
   - { name: openshiftServiceAccountTokens, type: ServiceAccountTokenSpec_v1, isList: true }
   - { name: kafkaCluster, type: KafkaCluster_v1 }
 

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -855,11 +855,23 @@
   - { name: vault_tls_secret_version, type: int }
 
 - name: NamespaceTerraformResources_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      aws: NamespaceTerraformResourcesProviderAWS_v1
   fields:
-  - { name: account, type: AWSAccount_v1, isRequired: true }
-  - { name: resources, type: NamespaceTerraformResource_v1, isRequired: true, isList: true, isInterface: true }
+  - { name: provider, type: string, isRequired: true }
 
-- name: NamespaceTerraformResource_v1
+- name: NamespaceTerraformResourcesProviderAWS_v1
+  interface: NamespaceTerraformResources_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: provisioner, type: AWSAccount_v1, isRequired: true }
+  - { name: resources, type: NamespaceTerraformResourceAWS_v1, isRequired: true, isList: true, isInterface: true }
+
+- name: NamespaceTerraformResourceAWS_v1
   isInterface: true
   interfaceResolve:
     strategy: fieldMap
@@ -892,7 +904,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceASG_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -915,7 +927,7 @@
   - { name: id, type: string, isRequired: true }
 
 - name: NamespaceTerraformResourceSecretsManager_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -925,7 +937,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceS3CloudFrontPublicKey_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -935,7 +947,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceACM_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -946,7 +958,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceElasticSearch_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -957,7 +969,7 @@
   - { name: publish_log_types, type: string, isList: true }
 
 - name: NamespaceTerraformResourceRDS_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
@@ -974,7 +986,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceS3_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -996,7 +1008,7 @@
   - { name: assume_role, type: string }
 
 - name: NamespaceTerraformResourceServiceAccount_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
@@ -1013,7 +1025,7 @@
   - { name: Service, type: string, isList: true }
 
 - name: NamespaceTerraformResourceRole_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
@@ -1023,7 +1035,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceElastiCache_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
@@ -1040,7 +1052,7 @@
   - { name: queues, type: KeyValue_v1, isRequired: true, isList: true }
 
 - name: NamespaceTerraformResourceSQS_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -1055,7 +1067,7 @@
   - { name: tables, type: KeyValue_v1, isRequired: true, isList: true }
 
 - name: NamespaceTerraformResourceDynamoDB_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -1065,7 +1077,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceECR_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -1077,7 +1089,7 @@
 
 
 - name: NamespaceTerraformResourceS3CloudFront_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -1088,7 +1100,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceS3SQS_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -1100,7 +1112,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceCloudWatch_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -1112,7 +1124,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceKMS_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -1123,7 +1135,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceKinesis_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -1134,7 +1146,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceALB_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
@@ -1149,7 +1161,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceRoute53Zone_v1
-  interface: NamespaceTerraformResource_v1
+  interface: NamespaceTerraformResourceAWS_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
@@ -1247,7 +1259,7 @@
   - { name: description, type: string, isRequired: true }
   - { name: openshiftResources, type: NamespaceOpenshiftResource_v1, isList: true, isInterface: true, isRequired: true }
   - { name: openshiftServiceAccountTokens, type: ServiceAccountTokenSpec_v1, isList: true }
-  - { name: terraformResources, type: NamespaceTerraformResource_v1, isList: true, isInterface: true }
+  - { name: terraformResources, type: NamespaceTerraformResourceAWS_v1, isList: true, isInterface: true }
 
 - name: Namespace_v1
   fields:
@@ -1272,7 +1284,7 @@
   - { name: sharedResources, type: SharedResources_v1, isList: true }
   - { name: openshiftResources, type: NamespaceOpenshiftResource_v1, isList: true, isInterface: true }
   - { name: managedTerraformResources, type: boolean }
-  - { name: terraformResources, type: NamespaceTerraformResources_v1, isList: true }
+  - { name: terraformResources, type: NamespaceTerraformResources_v1, isList: true, isInterface: true }
   - { name: openshiftServiceAccountTokens, type: ServiceAccountTokenSpec_v1, isList: true }
   - { name: kafkaCluster, type: KafkaCluster_v1 }
 

--- a/schemas/aws/s3-1.yml
+++ b/schemas/aws/s3-1.yml
@@ -15,8 +15,6 @@ properties:
     - s3
     - s3-cloudfront
     - s3-sqs
-  account:
-    "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
   region:
     "$ref": "/aws/regions-1.yml#/properties/region"
   identifier:
@@ -105,6 +103,5 @@ properties:
   kms_encryption:
     type: boolean
 required:
-- account
 - identifier
 - defaults

--- a/schemas/aws/terraform-resource-1.yml
+++ b/schemas/aws/terraform-resource-1.yml
@@ -8,7 +8,7 @@ properties:
   "$schema":
     type: string
     enum:
-    - /openshift/terraform-resource-1.yml
+    - /aws/terraform-resource-1.yml
   provider:
     type: string
   annotations:

--- a/schemas/openshift/namespace-1.yml
+++ b/schemas/openshift/namespace-1.yml
@@ -112,7 +112,7 @@ properties:
         resources:
           type: array
           items:
-            "$ref": "/openshift/terraform-resource-1.yml"
+            "$ref": "/aws/terraform-resource-1.yml"
       required:
       - account
       - resources

--- a/schemas/openshift/namespace-1.yml
+++ b/schemas/openshift/namespace-1.yml
@@ -106,15 +106,33 @@ properties:
       type: object
       additionalProperties: false
       properties:
-        account:
+        provider:
+          type: string
+          enum:
+          - aws
+        provisioner:
           "$ref": "/common-1.json#/definitions/crossref"
-          "$schemaRef": "/aws/account-1.yml"
         resources:
           type: array
           items:
-            "$ref": "/aws/terraform-resource-1.yml"
+            type: object
+      oneOf:
+      - additionalProperties: false
+        properties:
+          provider:
+            type: string
+            enum:
+            - aws
+          provisioner:
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef": "/aws/account-1.yml"
+          resources:
+            type: array
+            items:
+              "$ref": "/aws/terraform-resource-1.yml"
       required:
-      - account
+      - provider
+      - provisioner
       - resources
 
   openshiftServiceAccountTokens:

--- a/schemas/openshift/namespace-1.yml
+++ b/schemas/openshift/namespace-1.yml
@@ -103,7 +103,19 @@ properties:
   terraformResources:
     type: array
     items:
-      "$ref": "/openshift/terraform-resource-1.yml"
+      type: object
+      additionalProperties: false
+      properties:
+        account:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/aws/account-1.yml"
+        resources:
+          type: array
+          items:
+            "$ref": "/openshift/terraform-resource-1.yml"
+      required:
+      - account
+      - resources
 
   openshiftServiceAccountTokens:
     type: array

--- a/schemas/openshift/shared-resources-1.yml
+++ b/schemas/openshift/shared-resources-1.yml
@@ -43,7 +43,7 @@ properties:
   terraformResources:
     type: array
     items:
-      "$ref": "/openshift/terraform-resource-1.yml"
+      "$ref": "/aws/terraform-resource-1.yml"
 
 required:
 - "$schema"

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -13,8 +13,6 @@ properties:
     type: string
   annotations:
     "$ref": "/common-1.json#/definitions/annotations"
-  account:
-    "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
   identifier:
     "$ref": "/common-1.json#/definitions/longIdentifier"
   name:
@@ -153,8 +151,6 @@ oneOf:
       type: string
       enum:
       - aws-iam-service-account
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     variables:
@@ -187,7 +183,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
 - additionalProperties: false
   properties:
@@ -195,8 +190,6 @@ oneOf:
       type: string
       enum:
       - aws-iam-role
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     assume_role:
@@ -223,7 +216,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
   - assume_role
 - additionalProperties: false
@@ -232,8 +224,6 @@ oneOf:
       type: string
       enum:
       - rds
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       type: string
     availability_zone:
@@ -315,7 +305,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
   - defaults
 - additionalProperties: false
@@ -324,8 +313,6 @@ oneOf:
       type: string
       enum:
       - elasticache
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       type: string
     defaults:
@@ -360,7 +347,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
   - defaults
 - additionalProperties: false
@@ -369,8 +355,6 @@ oneOf:
       type: string
       enum:
       - sqs
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
     identifier:
@@ -399,7 +383,6 @@ oneOf:
         - defaults
         - queues
   required:
-  - account
   - identifier
   - specs
 - additionalProperties: false
@@ -408,8 +391,6 @@ oneOf:
       type: string
       enum:
       - dynamodb
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
     identifier:
@@ -438,7 +419,6 @@ oneOf:
         - defaults
         - tables
   required:
-  - account
   - identifier
   - specs
 - additionalProperties: false
@@ -447,8 +427,6 @@ oneOf:
       type: string
       enum:
       - ecr
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
     identifier:
@@ -460,7 +438,6 @@ oneOf:
     public:
       type: boolean
   required:
-  - account
   - identifier
 - additionalProperties: false
   properties:
@@ -468,8 +445,6 @@ oneOf:
       type: string
       enum:
       - cloudwatch
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
     identifier:
@@ -485,7 +460,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
   - defaults
 - additionalProperties: false
@@ -494,8 +468,6 @@ oneOf:
       type: string
       enum:
       - kms
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       type: string
     region:
@@ -521,7 +493,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
   - defaults
 - additionalProperties: false
@@ -532,8 +503,6 @@ oneOf:
       - elasticsearch
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     output_resource_name:
@@ -551,7 +520,6 @@ oneOf:
         - SEARCH_SLOW_LOGS
         - ES_APPLICATION_LOGS
   required:
-  - account
   - identifier
   - defaults
 - additionalProperties: false
@@ -562,8 +530,6 @@ oneOf:
       - acm
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     secret:
@@ -584,7 +550,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
   oneOf:
   - required:
@@ -597,8 +562,6 @@ oneOf:
       type: string
       enum:
       - kinesis
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       type: string
     region:
@@ -610,7 +573,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
   - defaults
 - additionalProperties: false
@@ -621,8 +583,6 @@ oneOf:
       - s3-cloudfront-public-key
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     secret:
@@ -632,7 +592,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
   - secret
 - additionalProperties: false
@@ -641,8 +600,6 @@ oneOf:
       type: string
       enum:
       - alb
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     output_resource_name:
@@ -731,7 +688,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
   - vpc
   - certificate_arn
@@ -745,8 +701,6 @@ oneOf:
       - secrets-manager
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     secret:
@@ -756,7 +710,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
   - secret
 - additionalProperties: false
@@ -767,8 +720,6 @@ oneOf:
       - asg
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     defaults:
@@ -801,7 +752,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
   - defaults
   - image
@@ -811,8 +761,6 @@ oneOf:
       type: string
       enum:
       - route53-zone
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     identifier:
       type: string
     name:
@@ -825,7 +773,6 @@ oneOf:
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
-  - account
   - identifier
   - name
 required:


### PR DESCRIPTION
this PR changes the `terraformResources` schema from:
```
terraformResources:
- provider: rds
  account: app-int-example-01
  identifier: app-int-example-01-rds
  defaults: /terraform/rds/free-tier-1.yml
  output_resource_name: creds
```
to:
```
terraformResources:
- account:
    $ref: /aws/app-int-example-01/account.yml
  resources:
  - provider: rds
    identifier: app-int-example-01-rds
    defaults: /terraform/rds/free-tier-1.yml
    output_resource_name: creds
```