### PR TITLE
add aws sharing options

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -774,6 +774,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: account, type: AWSAccount_v1, isRequired: true }
   - { name: regex, type: string, isRequired: true }
+  - { name: region, type: string }
 
 - name: AWSUserPolicy_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -716,6 +716,7 @@
   - { name: resetPasswords, type: AWSAccountResetPassword_v1, isList: true }
   - { name: premiumSupport, type: boolean, isRequired: true }
   - { name: partition, type: string }
+  - { name: sharing, type: AWSAccountSharingOption_v1, isList: true, isInterface: true }
   - name: ecrs
     type: AWSECR_v1
     isList: true
@@ -755,6 +756,24 @@
   fields:
   - { name: user, type: User_v1, isRequired: true }
   - { name: requestId, type: string, isRequired: true }
+
+- name: AWSAccountSharingOption_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      ami: AWSAccountSharingOptionAMI_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: account, type: AWSAccount_v1, isRequired: true }
+
+- name: AWSAccountSharingOptionAMI_v1
+  interface: AWSAccountSharingOption_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: account, type: AWSAccount_v1, isRequired: true }
+  - { name: regex, type: string, isRequired: true }
 
 - name: AWSUserPolicy_v1
   fields:

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -103,6 +103,10 @@ properties:
     enum:
     - aws
     - aws-us-gov
+  sharing:
+    type: array
+    items:
+      "$ref": "/aws/sharing-option-1.yml"
 required:
 - "$schema"
 - labels

--- a/schemas/aws/sharing-option-1.yml
+++ b/schemas/aws/sharing-option-1.yml
@@ -21,6 +21,8 @@ properties:
   regex:
     type: string
     description: regex expression to filter items by
+  region:
+    "$ref": "/aws/regions-1.yml#/properties/region"
 oneOf:
 - additionalProperties: false
   properties:
@@ -34,6 +36,8 @@ oneOf:
       "$schemaRef": "/aws/account-1.yml"
     regex:
       type: string
+    region:
+      "$ref": "/aws/regions-1.yml#/properties/region"
   required:
   - provider
   - account

--- a/schemas/aws/sharing-option-1.yml
+++ b/schemas/aws/sharing-option-1.yml
@@ -1,0 +1,43 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+description: define sharing options between aws accounts
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /aws/sharing-options-1.yml
+  provider:
+    type: string
+    description: type of sharing to implement
+    enum:
+    - ami
+  account:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/aws/account-1.yml"
+  regex:
+    type: string
+    description: regex expression to filter items by
+oneOf:
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      description: share AMIs and AMI tags
+      enum:
+      - ami
+    account:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/aws/account-1.yml"
+    regex:
+      type: string
+  required:
+  - provider
+  - account
+  - regex
+required:
+- provider
+- account


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4621

design doc: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/34669

this PR adds support to define `sharing` between aws accounts. we use the provider pattern to allow future sharing options between aws accounts.

this `sharing` option is defined on the source account.

example:
```
$schema: /aws/account-1.yml

name: source
...
sharing:
- provider: ami
  account:
    $ref: /aws/destination/account.yml
  regex: '^.*$'
```