### PR TITLE
add signalfx as endpoint monitoring provider

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2420,6 +2420,7 @@
     field: provider
     fieldMap:
       blackbox-exporter: EndpointMonitoringProviderBlackboxExporter_v1
+      signalfx: EndpointMonitoringProviderSignalFx_v1
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
@@ -2450,3 +2451,23 @@
   - { name: module, type: string, isRequired: true }
   - { name: namespace, type: Namespace_v1, isRequired: true }
   - { name: exporterUrl, type: string, isRequired: true }
+
+- name: EndpointMonitoringProviderSignalFx_v1
+  interface: EndpointMonitoringProvider_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: labels, type: json }
+  - { name: name, type: string, isRequired: true, isUnique: true }
+  - { name: description, type: string, isRequired: true }
+  - { name: provider, type: string, isRequired: true }
+  - { name: metricLabels, type: json }
+  - { name: timeout, type: string }
+  - { name: checkInterval, type: string }
+  - { name: signalFx, type: EndpointMonitoringProviderSignalFxSettings_v1, isRequired: true }
+
+- name: EndpointMonitoringProviderSignalFxSettings_v1
+  fields:
+  - { name: namespace, type: Namespace_v1, isRequired: true }
+  - { name: exporterUrl, type: string, isRequired: true }
+  - { name: targetFilterLabel, type: string, isRequired: true }

--- a/schemas/dependencies/endpoint-monitoring-provider-1.yml
+++ b/schemas/dependencies/endpoint-monitoring-provider-1.yml
@@ -40,6 +40,7 @@ properties:
       properties:
         module:
           type: string
+          format: uri
           description: the blackbox exporter module to use for the endpoint check, e.g. http_2xx
         namespace:
           "$ref": "/common-1.json#/definitions/crossref"
@@ -47,6 +48,7 @@ properties:
           description: the namespace where the prometheus Probe CR will be created
         exporterUrl:
           type: string
+          format: uri
           description: the blackbox-exporter URL to use, must be a full scrape URL
       required:
       - module

--- a/schemas/dependencies/endpoint-monitoring-provider-1.yml
+++ b/schemas/dependencies/endpoint-monitoring-provider-1.yml
@@ -47,7 +47,7 @@ properties:
           description: the namespace where the prometheus Probe CR will be created
         exporterUrl:
           type: string
-          description: the blackbox-exporter URL to use, must be a full URL including potential URL paths
+          description: the blackbox-exporter URL to use, must be a full scrape URL
       required:
       - module
       - namespace
@@ -63,7 +63,7 @@ properties:
         description: the namespace where the prometheus Probe CR will be created
       exporterUrl:
         type: string
-        description: the signalfx-prometheus-exporter URL to use, must be a full URL including potential URL paths
+        description: the signalfx-prometheus-exporter URL to use, must be a full scrape URL
       targetFilterLabel:
         type: string
         description: the signalfx label that holds the target value to be filtered on

--- a/schemas/dependencies/endpoint-monitoring-provider-1.yml
+++ b/schemas/dependencies/endpoint-monitoring-provider-1.yml
@@ -20,6 +20,7 @@ properties:
     type: string
     enum:
     - blackbox-exporter
+    - signalfx
     description: The provider defines which monitoring implementation will be used for endpoints
   timeout:
     type: string
@@ -51,6 +52,25 @@ properties:
       - module
       - namespace
       - exporterUrl
+  signalFx:
+    type: object
+    description: signalfx exporter specific configuration options
+    additionalProperties: false
+    properties:
+      namespace:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "/openshift/namespace-1.yml"
+        description: the namespace where the prometheus Probe CR will be created
+      exporterUrl:
+        type: string
+        description: the signalfx-prometheus-exporter URL to use, must be a full URL including potential URL paths
+      targetFilterLabel:
+        type: string
+        description: the signalfx label that holds the target value to be filtered on
+    required:
+    - namespace
+    - exporterUrl
+    - targetFilterLabel
 oneOf:
 - properties:
     provider:
@@ -71,8 +91,31 @@ oneOf:
       required:
       - module
       - namespace
+      - exporterUrl
   required:
   - blackboxExporter
+- properties:
+    provider:
+      type: string
+      enum:
+      - signalfx
+    signalFx:
+      type: object
+      additionalProperties: false
+      properties:
+        namespace:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/openshift/namespace-1.yml"
+        exporterUrl:
+          type: string
+        targetFilterLabel:
+          type: string
+      required:
+      - namespace
+      - exporterUrl
+      - targetFilterLabel
+  required:
+  - signalFx
 required:
 - "$schema"
 - labels

--- a/schemas/dependencies/endpoint-monitoring-provider-1.yml
+++ b/schemas/dependencies/endpoint-monitoring-provider-1.yml
@@ -40,7 +40,6 @@ properties:
       properties:
         module:
           type: string
-          format: uri
           description: the blackbox exporter module to use for the endpoint check, e.g. http_2xx
         namespace:
           "$ref": "/common-1.json#/definitions/crossref"
@@ -65,6 +64,7 @@ properties:
         description: the namespace where the prometheus Probe CR will be created
       exporterUrl:
         type: string
+        format: uri
         description: the signalfx-prometheus-exporter URL to use, must be a full scrape URL
       targetFilterLabel:
         type: string


### PR DESCRIPTION
following the provider pattern for endpoint monitoring established in the [endpoint monitoring design doc](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/service-endpoint-monitoring.md), this schema change adds signalfx metric scraping capabilities using https://github.com/geoberle/signalfx-prometheus-exporter

since signalfx can be a metric store for arbitrary metric producing systems like catchpoint, the integration following this schema change will open a way to get ahold of those metric sources in a generic way.

similar to the blackbox exporter provider, this implementation acquires metrics by scraping
an endpoint that returns target specific metrics. while the target for blackbox-exporter is usually
a URL, for signalfx it is a label/value combination for metrics exposed by signalfx cloud.
this is due to the fact that signalfx is not just about URLs but more genericly about metrics with labels,
similar to promtheus itself.

### Example
first lets define the provider. the `exporterUrl` references the scrape URL of a https://github.com/geoberle/signalfx-prometheus-exporter. the provider itself is a representation of a scrape Job and the provided `namespace` will be the place where the `Probe` will be stored.

```yaml
  ---
  $schema: /dependencies/endpoint-monitoring-provider-1.yml
  ...
  provider: signalfx
  signalFx:
    namespace:
      $ref: my-monioring-namespace.yml
    exporterUrl: http://signalfx-prometheus-exporter:9091/metrics
    targetFilterLabel: probe
```

scraping for an endpoint is defined in the `/app-sre/app-1.yml` schema by referencing the provider.

```yaml
  ---
  $schema: /app-sre/app-1.yml
  ...
  endpoints:
  - name: my-probe-name
    description: Status
    url: https://my-service.com
    monitoring:
    - provider:
        $ref: my-signalfx-provider.yml
```

this will result in the setup of a `Probe` that will scrape for metrics with `probe=my-probe-name` labels,
where `probe` is defined as `signalFx.targetFilterLabel` and `probe-name` is provided by `endpoints.name`.

the resulting metrics will have the following target labels:
* job = provider name
* instance = the `url` of the endpoint

the filter label will also present as well, e.g. in the the case of catchpoint based signalfx metrics, this will be the probe name as defined in catchpoint.

part of https://issues.redhat.com/browse/APPSRE-4700

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>