### PR TITLE
[terraform-resources] ASG add support for upstream job

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -938,6 +938,7 @@
   - { name: tag_name, type: string, isRequired: true }
   - { name: url, type: string, isRequired: true }
   - { name: ref, type: string, isRequired: true }
+  - { name: upstream, type: SaasResourceTemplateTargetUpstream_v1 }
 
 - name: NamespaceTerraformResourceSecretsManager_v1
   interface: NamespaceTerraformResource_v1

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -139,6 +139,13 @@ properties:
       type: string
   image:
     type: object
+    properties:
+      upstream:
+        type: object
+        properties:
+          instance:
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef": "/dependencies/jenkins-instance-1.yml"
 oneOf:
 - "$ref": "/aws/s3-1.yml"
 - additionalProperties: false
@@ -797,6 +804,20 @@ oneOf:
           description: commit or branch name
           type: string
           pattern: '^([0-9a-f]{40}|master|main)$'
+        upstream:
+          description: jenkins instance and job to wait for
+          type: object
+          additionalProperties: false
+          properties:
+            instance:
+              "$ref": "/common-1.json#/definitions/crossref"
+              "$schemaRef": "/dependencies/jenkins-instance-1.yml"
+            name:
+              description: name of jenkins job to wait for
+              type: string
+          required:
+          - instance
+          - name
       required:
       - tag_name
       - url


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3925

now that we have support for continuous deployment of AMIs, we want to avoid failing under healthy conditions.
for example, once a new commit is pushed, the integration tries to use a corresponding AMI. initially, that AMI is being built, which means it doesn't exist yet.

to be able to not fail in this condition, and to improve visibility from the ASG definition, this PR adds support for an `upstream` job to wait for (like saas files).