### PR TITLE
APPSRE-4404 schema for githubRepoInvites

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -28,7 +28,6 @@
 
 - name: GithubRepoInvites_v1
   fields:
-  - { name: description, type: string, isRequired: true }
   - { name: credentials, type: VaultSecret_v1, isRequired: true }
 
 - name: LdapSettings_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -12,6 +12,7 @@
   - { name: saasDeployJobTemplate, type: string, isRequired: true }
   - { name: hashLength, type: int, isRequired: true }
   - { name: smtp, type: SmtpSettings_v1 }
+  - { name: githubRepoInvites, type: GithubRepoInvites_v1 }
   - { name: dependencies, type: AppInterfaceDependencyMapping_v1, isList: true }
   - { name: credentials, type: CredentialsRequestMap_v1, isList: true }
   - { name: sqlQuery, type: SqlQuerySettings_v1 }
@@ -23,6 +24,10 @@
 - name: SmtpSettings_v1
   fields:
   - { name: mailAddress, type: string, isRequired: true }
+  - { name: credentials, type: VaultSecret_v1, isRequired: true }
+
+- name: GithubRepoInvites_v1
+  fields:
   - { name: credentials, type: VaultSecret_v1, isRequired: true }
 
 - name: LdapSettings_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -28,6 +28,7 @@
 
 - name: GithubRepoInvites_v1
   fields:
+  - { name: description, type: string, isRequired: true }
   - { name: credentials, type: VaultSecret_v1, isRequired: true }
 
 - name: LdapSettings_v1

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -52,12 +52,14 @@ properties:
     type: object
     additionalProperties: false
     properties:
-      description:
-        type: string
       credentials:
         "$ref": "/common-1.json#/definitions/vaultSecret"
+    description: |
+      Configuration for github-repo-invites integration.
+      Currently contains information for fetching the
+      token of the github app-sre bot for accepting
+      invitations to repositories.
     required:
-    - description
     - credentials
   ldap:
     type: object

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -48,6 +48,12 @@ properties:
         type: string
       credentials:
         "$ref": "/common-1.json#/definitions/vaultSecret"
+  githubRepoInvites:
+    type: object
+    additionalProperties: false
+    properties:
+      credentials:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
   ldap:
     type: object
     additionalProperties: false

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -52,8 +52,13 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      description:
+        type: string
       credentials:
         "$ref": "/common-1.json#/definitions/vaultSecret"
+    required:
+    - description
+    - credentials
   ldap:
     type: object
     additionalProperties: false


### PR DESCRIPTION
**Motivation**

We currently store configuration for the `github-repo-invites` integration in our `config.toml`. This PR adds a schema to move the `[github-repo-invites]` toml section to our `app-interface` repo.

**Test**

Successfully ran:

```
make bundle
```

Further, tested with `--dry-run` in corresponding [q-r PR](https://github.com/app-sre/qontract-reconcile/pull/2239) in qontract-reconcile