### PR TITLE
[terraform-aws-route53] add support for target namespace zone

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2205,6 +2205,11 @@
   - { name: db_user, type: string }
   - { name: db_password, type: string }
 
+- name: DnsNamespaceZone_v1
+  fields:
+  - { name: namespace, type: Namespace_v1, isRequired: true }
+  - { name: name, type: string, isRequired: true }
+
 - name: DnsRecordHealthcheck_v1
   fields:
   - { name: fqdn, type: string }
@@ -2236,6 +2241,7 @@
   - { name: records, type: string, isList: true }
   - { name: _healthcheck, type: DnsRecordHealthcheck_v1 }
   - { name: _target_cluster, type: Cluster_v1 }
+  - { name: _target_namespace_zone, type: DnsNamespaceZone_v1 }
 
 - name: DnsZone_v1
   fields:

--- a/schemas/dependencies/dns-zone-1.yml
+++ b/schemas/dependencies/dns-zone-1.yml
@@ -113,6 +113,9 @@ properties:
               "$schemaRef": "/openshift/namespace-1.yml"
             name:
               "$ref": "/common-1.json#/definitions/k8sValidContainerName"
+          required:
+          - namespace
+          - name
       oneOf:
       - required:
         - records

--- a/schemas/dependencies/dns-zone-1.yml
+++ b/schemas/dependencies/dns-zone-1.yml
@@ -103,11 +103,23 @@ properties:
         _target_cluster:
           "$ref": "/common-1.json#/definitions/crossref"
           "$schemaRef": "/openshift/cluster-1.yml"
+        _target_namespace_zone:
+          type: object
+          description: a namespace and a route53 zone name provisioned within that namespace
+          additionalProperties: false
+          properties:
+            namespace:
+              "$ref": "/common-1.json#/definitions/crossref"
+              "$schemaRef": "/openshift/namespace-1.yml"
+            name:
+              "$ref": "/common-1.json#/definitions/k8sValidContainerName"
       oneOf:
       - required:
         - records
       - required:
         - _target_cluster
+      - required:
+        - _target_namespace_zone
       - required:
         - alias
       required:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4705

similar to using `_target_cluster` to obtain the elb fqdn, we can target a namespace with a `route53-zone` provisioned in it to automatically obtain NS records of that zone (instead of hard coding them).

example: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/35369