### PR TITLE
APPSRE-3652 make org_username searchable

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1984,7 +1984,7 @@
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
-  - { name: org_username, type: string, isRequired: true, isUnique: true }
+  - { name: org_username, type: string, isSearchable: true, isRequired: true, isUnique: true }
   - { name: github_username, type: string, isRequired: true }
   - { name: quay_username, type: string }
   - { name: slack_username, type: string }


### PR DESCRIPTION
**Motivation**
We want to be able to query users based on their `org_username`. 
This is a requirement for https://github.com/app-sre/qontract-reconcile/pull/2263

**Test**
Tested with corresponding feature branch in q-r https://github.com/app-sre/qontract-reconcile/pull/2263