### PR TITLE
APPSRE-3652 make cluster name searchable

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -665,7 +665,7 @@
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
-  - { name: name, type: string, isRequired: true }
+  - { name: name, type: string, isUnique: true, isSearchable: true, isRequired: true }
   - { name: description, type: string }
   - { name: auth, type: ClusterAuth_v1, isInterface: true }
   - { name: observabilityNamespace, type: Namespace_v1 }


### PR DESCRIPTION
**Motivation**
I would like to be able to query a cluster by name for https://github.com/app-sre/qontract-reconcile/pull/2263
This PR enforces uniqueness on cluster names.

**Test**
schema bundles, i.e., there are no duplicate cluster names as of now.