### PR TITLE
make slack optional for saas-file-2 files

### DIFF
--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -200,7 +200,6 @@ required:
 - description
 - app
 - pipelinesProvider
-- slack
 - managedResourceTypes
 - resourceTemplates
 - imagePatterns


### PR DESCRIPTION
Relates to: https://issues.redhat.com/browse/APPSRE-4642

I suspect we may still have Q-R problems by doing just this and removing the Slack property from saas-files, but starting with this to see where get in fedramp.