### PR TITLE
alert severity ticket priority mappings

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -366,6 +366,20 @@
   - { name: serverUrl, type: string, isRequired: true }
   - { name: token, type: VaultSecret_v1, isRequired: true }
 
+- name: SeverityPriorityMapping_v1
+  fields:
+  - { name: severity, type: string, isRequired: true }
+  - { name: priority, type: string, isRequired: true }
+
+- name: JiraSeverityPriorityMappings_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: labels, type: json }
+  - { name: name, type: string, isRequired: true }
+  - { name: description, type: string, isRequired: true }
+  - { name: mappings, type: SeverityPriorityMapping_v1, isRequired: true }
+
 - name: JiraBoard_v1
   fields:
   - { name: schema, type: string, isRequired: true }
@@ -374,6 +388,7 @@
   - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
   - { name: description, type: string, isRequired: true }
   - { name: server, type: JiraServer_v1, isRequired: true }
+  - { name: severityPriorityMappings, type: JiraSeverityPriorityMappings_v1, isRequired: true }
   - { name: slack, type: SlackOutput_v1 }
 
 - name: SendGridAccount_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -378,7 +378,7 @@
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
-  - { name: mappings, type: SeverityPriorityMapping_v1, isRequired: true }
+  - { name: mappings, type: SeverityPriorityMapping_v1, isList: true, isRequired: true }
 
 - name: JiraBoard_v1
   fields:

--- a/schemas/dependencies/jira-board-1.yml
+++ b/schemas/dependencies/jira-board-1.yml
@@ -18,6 +18,9 @@ properties:
   server:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/dependencies/jira-server-1.yml"
+  severityPriorityMappings:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/dependencies/jira-severity-priority-mappings-1.yml"
   slack:
     type: object
     properties:
@@ -34,3 +37,4 @@ required:
 - name
 - description
 - server
+- severityPriorityMappings

--- a/schemas/dependencies/jira-severity-priority-mappings-1.yml
+++ b/schemas/dependencies/jira-severity-priority-mappings-1.yml
@@ -1,0 +1,37 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+description: mappings between alert severities and jira ticket priorities
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /dependencies/jira-severity-priority-mappings-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    type: string
+  description:
+    type: string
+  mappings:
+    type: array
+    items:
+      type: object
+      description: a mapping between an alert severity to a ticket priority
+      additionalProperties: false
+      properties:
+        severity:
+          type: string
+          description: alert severity
+        priority:
+          type: string
+          description: ticket priority
+required:
+- "$schema"
+- labels
+- name
+- description
+- mappings

--- a/schemas/dependencies/jira-severity-priority-mappings-1.yml
+++ b/schemas/dependencies/jira-severity-priority-mappings-1.yml
@@ -29,6 +29,9 @@ properties:
         priority:
           type: string
           description: ticket priority
+      required:
+      - severity
+      - priority
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4750

to be able to dynamically generate jiralert configuration that works for every jira board, we need to know which board uses which priorities.