### PR TITLE
[statuspage] add schema capabilities to manage a component status

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2483,6 +2483,7 @@
   - { name: instructions, type: string, isRequired: true }
   - { name: page, type: StatusPage_v1, isRequired: true }
   - { name: groupName, type: string }
+  - { name: status, type: StatusProvider_v1, isList: true, isInterface: true }
   - name: apps
     type: App_v1
     isList: true
@@ -2548,3 +2549,47 @@
   - { name: namespace, type: Namespace_v1, isRequired: true }
   - { name: exporterUrl, type: string, isRequired: true }
   - { name: targetFilterLabel, type: string, isRequired: true }
+
+- name: StatusProvider_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      prometheus-alerts: PrometheusAlertsStatusProvider_v1
+      manual: ManualStatusProvider_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+
+- name: PrometheusAlertsStatusProvider_v1
+  interface: StatusProvider_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: prometheusAlerts, type: PrometheusAlertsStatusProviderConfig_v1, isRequired: true }
+
+- name: PrometheusAlertsStatusProviderConfig_v1
+  fields:
+  - { name: namespace, type: Namespace_v1, isList: true }
+  - { name: matchers, type: PrometheusAlertMatcher_v1, isList: true }
+
+- name: PrometheusAlertMatcher_v1
+  fields:
+  - { name: matchExpression, type: PrometheusAlertMatcherExpression_v1, isRequired: true }
+  - { name: componentStatus, type: string, isRequired: true }
+
+- name: PrometheusAlertMatcherExpression_v1
+  fields:
+  - { name: alert, type: string }
+  - { name: labels, type: json }
+
+- name: ManualStatusProvider_v1
+  interface: StatusProvider_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: manual, type: ManualStatusProviderConfig_v1, isRequired: true }
+
+- name: ManualStatusProviderConfig_v1
+  fields:
+  - { name: componentStatus, type: string, isRequired: true }
+  - { name: from, type: string }
+  - { name: until, type: string }

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -148,6 +148,17 @@
       "type": "string",
       "description": "Kubernetes resource (request, limit) quantity",
       "pattern": "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+    },
+    "statusPageStatus": {
+      "type": "string",
+      "description": "a list of supported status page component status",
+      "enum": [
+        "operational",
+        "under_maintenance",
+        "degraded_performance",
+        "partial_outage",
+        "major_outage"
+      ]
     }
   }
 }

--- a/schemas/dependencies/status-page-component-1.yml
+++ b/schemas/dependencies/status-page-component-1.yml
@@ -28,6 +28,9 @@ properties:
     type: array
     items:
       "$ref": "/dependencies/status-provider-1.yml"
+    description: |
+      a list of providers that can influence the status of this
+      status page component
 
 required:
 - "$schema"

--- a/schemas/dependencies/status-page-component-1.yml
+++ b/schemas/dependencies/status-page-component-1.yml
@@ -24,6 +24,10 @@ properties:
   page:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/dependencies/status-page-1.yml"
+  status:
+    type: array
+    items:
+      "$ref": "/dependencies/status-provider-1.yml"
 
 required:
 - "$schema"

--- a/schemas/dependencies/status-provider-1.yml
+++ b/schemas/dependencies/status-provider-1.yml
@@ -33,7 +33,7 @@ properties:
                 labels:
                   "$ref": "/common-1.json#/definitions/labels"
             componentStatus:
-              type: string
+              "$ref": "/common-1.json#/definitions/statusPageStatus"
           required:
           - matchExpression
           - componentStatus
@@ -63,6 +63,7 @@ oneOf:
       - prometheus-alerts
     prometheusAlerts:
       type: object
+      description: config options for the 'prometheus-alerts' status provider
       additionalProperties: false
       properties:
         namespace:
@@ -70,6 +71,10 @@ oneOf:
           "$schemaRef": "/openshift/namespace-1.yml"
         matchers:
           type: array
+          description: |
+            a list of prometheus alert matchers (alertname and labels) and a
+            corresponding status that should be applied to a component if such
+            a metric was found
           items:
             type: object
             additionalProperties: false
@@ -80,10 +85,15 @@ oneOf:
                 properties:
                   alert:
                     type: string
+                    description: the alert name to match on
                   labels:
                     "$ref": "/common-1.json#/definitions/labels"
+                    description: the alert labels to match on
               componentStatus:
                 type: string
+                description: |
+                  the status to apply to the status page component if this a
+                  matching prometheus alert was found
             required:
             - matchExpression
             - componentStatus
@@ -101,16 +111,20 @@ oneOf:
       - manual
     manual:
       type: object
+      description: config options for the 'manual' status provider
       additionalProperties: false
       properties:
         componentStatus:
-          type: string
+          "$ref": "/common-1.json#/definitions/statusPageStatus"
+          description: the status to apply to the status page component
         from:
           type: string
           format: date-time
+          description: an optional start date to activate this provider
         until:
           type: string
           format: date-time
+          description: an optional start date to deactivate this provider
       required:
       - componentStatus
   required:

--- a/schemas/dependencies/status-provider-1.yml
+++ b/schemas/dependencies/status-provider-1.yml
@@ -1,0 +1,120 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /dependencies/status-provider-1.yml
+  provider:
+    type: string
+  prometheusAlerts:
+    type: object
+    additionalProperties: false
+    properties:
+      namespace:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "/openshift/namespace-1.yml"
+      matchers:
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          properties:
+            matchExpression:
+              type: object
+              additionalProperties: false
+              properties:
+                alert:
+                  type: string
+                labels:
+                  "$ref": "/common-1.json#/definitions/labels"
+            componentStatus:
+              type: string
+          required:
+          - matchExpression
+          - componentStatus
+    required:
+    - namespace
+    - matchers
+  manual:
+    type: object
+    additionalProperties: false
+    properties:
+      componentStatus:
+        type: string
+      from:
+        type: string
+        format: date-time
+      until:
+        type: string
+        format: date-time
+    required:
+    - componentStatus
+oneOf:
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - prometheus-alerts
+    prometheusAlerts:
+      type: object
+      additionalProperties: false
+      properties:
+        namespace:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/openshift/namespace-1.yml"
+        matchers:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              matchExpression:
+                type: object
+                additionalProperties: false
+                properties:
+                  alert:
+                    type: string
+                  labels:
+                    "$ref": "/common-1.json#/definitions/labels"
+              componentStatus:
+                type: string
+            required:
+            - matchExpression
+            - componentStatus
+      required:
+      - namespace
+      - matchers
+  required:
+  - prometheusAlerts
+
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - manual
+    manual:
+      type: object
+      additionalProperties: false
+      properties:
+        componentStatus:
+          type: string
+        from:
+          type: string
+          format: date-time
+        until:
+          type: string
+          format: date-time
+      required:
+      - componentStatus
+  required:
+  - manual
+
+required:
+- provider


### PR DESCRIPTION
this schema change is based on the design doc https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/36105
it proposes a provider based status management approach for status page components,
specifically the following two providers will be enabled by this change
* prometheus-alerts - set the status page component status based on prometheus alerts
* manual - set the status page component status statically via app-interface

In the following example, the status of the component is Under Maintenance until the defined timestamp in manual.until has passed. After that, the status is managed based on Prometheus alerts.

```yaml
---
$schema: /dependencies/status-page-component-1.yml
name: yakk-shaving-service
...
status:
- provider: manual
  manual:
    until: timestamp-with-timezone
    componentStatus: under_maintenance
- provider: prometheus-alerts
  prometheusAlerts:
    namespace: /services/yakk-shaving/namespaces/yakk-stable.yml
    matchers:
    - matchExpression:
        alert: YakkIsInBadMood
        labels:
          service: yakk-shaving-service
          severity: high
      componentStatus: degraded_performance

```

design doc ticket: https://issues.redhat.com/browse/APPSRE-4764

required by https://github.com/app-sre/qontract-reconcile/pull/2311

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>