### PR TITLE
remove credentials name enum

### DIFF
--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -100,9 +100,6 @@ properties:
       properties:
         name:
           type: string
-          enum:
-          - app-interface-production-dev-access
-          - app-interface-production-cicd-access
         secret:
           "$ref": "/common-1.json#/definitions/vaultSecret"
       required:

--- a/schemas/app-interface/credentials-request-1.yml
+++ b/schemas/app-interface/credentials-request-1.yml
@@ -20,9 +20,6 @@ properties:
     "$schemaRef": "/access/user-1.yml"
   credentials:
     type: string
-    enum:
-    - app-interface-production-dev-access
-    - app-interface-production-cicd-access
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
to be able to use credentials-sender as a way to send vault content.