### PR TITLE
generic-secret output_format for terraform based output secrets

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -996,7 +996,24 @@
   - { name: account, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
+
+- name: NamespaceTerraformResourceOutputFormat_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      generic-secret: NamespaceTerraformResourceGenericSecretOutputFormat_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+
+- name: NamespaceTerraformResourceGenericSecretOutputFormat_v1
+  interface: NamespaceTerraformResourceOutputFormat_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: data, type: json }
 
 - name: NamespaceTerraformResourceASG_v1
   interface: NamespaceTerraformResource_v1
@@ -1010,6 +1027,7 @@
   - { name: variables, type: json }
   - { name: image, type: ASGImage_v1, isRequired: true }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
 
 - name: CloudinitConfig_v1
@@ -1034,6 +1052,7 @@
   - { name: identifier, type: string, isRequired: true }
   - { name: secret, type: VaultSecret_v1 }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceS3CloudFrontPublicKey_v1
@@ -1045,6 +1064,7 @@
   - { name: identifier, type: string, isRequired: true }
   - { name: secret, type: VaultSecret_v1 }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceACM_v1
@@ -1057,6 +1077,7 @@
   - { name: secret, type: VaultSecret_v1 }
   - { name: domain, type: ACMDomain_v1 }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceElasticSearch_v1
@@ -1068,6 +1089,7 @@
   - { name: identifier, type: string, isRequired: true }
   - { name: defaults, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
   - { name: publish_log_types, type: string, isList: true }
 
@@ -1082,6 +1104,7 @@
   - { name: parameter_group, type: string }
   - { name: overrides, type: json }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: output_resource_db_name, type: string }
   - { name: reset_password, type: string }
   - { name: enhanced_monitoring, type: boolean }
@@ -1103,6 +1126,7 @@
   - { name: s3_events, type: string, isList: true }
   - { name: bucket_policy, type: json }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: storage_class, type: string }
   - { name: annotations, type: json }
 
@@ -1122,6 +1146,7 @@
   - { name: policies, type: string, isList: true }
   - { name: user_policy, type: json }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: aws_infrastructure_access, type: NamespaceTerraformResourceServiceAccountAWSInfrastructureAccess_v1 }
   - { name: annotations, type: json }
 
@@ -1140,6 +1165,7 @@
   - { name: assume_condition, type: json }
   - { name: inline_policy, type: json }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceElastiCache_v1
@@ -1153,6 +1179,7 @@
   - { name: region, type: string }
   - { name: overrides, type: json }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
 
 - name: SQSQueuesSpecs_v1
@@ -1168,6 +1195,7 @@
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: specs, type: SQSQueuesSpecs_v1, isRequired: true, isList: true }
   - { name: annotations, type: json }
 
@@ -1184,6 +1212,7 @@
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: specs, type: DynamoDBTableSpecs_v1, isRequired: true, isList: true }
   - { name: annotations, type: json }
 
@@ -1195,6 +1224,7 @@
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: mirror, type: ContainerImageMirror_v1, isRequired: false }
   - { name: public, type: boolean }
   - { name: annotations, type: json }
@@ -1209,6 +1239,7 @@
   - { name: identifier, type: string, isRequired: true }
   - { name: defaults, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: storage_class, type: string }
   - { name: annotations, type: json }
 
@@ -1222,6 +1253,7 @@
   - { name: kms_encryption, type: boolean }
   - { name: defaults, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: storage_class, type: string }
   - { name: annotations, type: json }
 
@@ -1236,6 +1268,7 @@
   - { name: es_identifier, type: string }
   - { name: filter_pattern, type: string }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceKMS_v1
@@ -1248,6 +1281,7 @@
   - { name: defaults, type: string, isRequired: true }
   - { name: overrides, type: json }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceKinesis_v1
@@ -1260,6 +1294,7 @@
   - { name: defaults, type: string, isRequired: true }
   - { name: overrides, type: json }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceALB_v1
@@ -1276,6 +1311,7 @@
   - { name: rules, type: NamespaceTerraformResourceALBRules_v1, isRequired: true, isList: true }
   - { name: vpc, type: AWSVPC_v1, isRequired: true }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceRoute53Zone_v1
@@ -1287,6 +1323,7 @@
   - { name: identifier, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
   - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceALBTargets_v1

--- a/schemas/aws/s3-1.yml
+++ b/schemas/aws/s3-1.yml
@@ -100,6 +100,8 @@ properties:
     type: object
   output_resource_name:
     "$ref": "/common-1.json#/definitions/longIdentifier"
+  output_format:
+    "$ref": "/openshift/terraform-output-format-1.yml"
   allow_object_tagging:
     type: boolean
   kms_encryption:

--- a/schemas/openshift/terraform-output-format-1.yml
+++ b/schemas/openshift/terraform-output-format-1.yml
@@ -1,0 +1,43 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /openshift/terraform-output-format-1.yml
+  provider:
+    type: string
+    enum:
+    - generic-secret
+  data:
+    type: object
+    additionalProperties: false
+    patternProperties: {
+      "^[a-zA-Z0-9_]{0,253}$": {
+        "type": "string"
+      }
+    }
+oneOf:
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - generic-secret
+    data:
+      type: object
+      additionalProperties: false
+      patternProperties: {
+        "^[a-zA-Z0-9_]{0,253}$": {
+          "type": "string"
+        }
+      }
+      description: |
+        the data to use for the secret. the field values can use the
+        terraform output variables as jinja2 placeholders
+  required:
+  - provider

--- a/schemas/openshift/terraform-output-format-1.yml
+++ b/schemas/openshift/terraform-output-format-1.yml
@@ -11,8 +11,10 @@ properties:
     - /openshift/terraform-output-format-1.yml
   provider:
     type: string
-    enum:
-    - generic-secret
+    description: |
+      the provider defines the method of formatting the terraform output
+      into a secret. a provider can declare additional configuration data to
+      get the job done or define the format directly
   data:
     type: object
     additionalProperties: false

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -39,6 +39,8 @@ properties:
     type: object
   output_resource_name:
     "$ref": "/common-1.json#/definitions/longIdentifier"
+  output_format:
+    "$ref": "/openshift/terraform-output-format-1.yml"
   defaults:
     type: string
   parameter_group:
@@ -170,6 +172,8 @@ oneOf:
       type: object
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     aws_infrastructure_access:
       type: object
       additionalProperties: false
@@ -226,6 +230,8 @@ oneOf:
       type: object
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
@@ -308,6 +314,8 @@ oneOf:
               type: string
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     output_resource_db_name:
       type: string
     reset_password:
@@ -363,6 +371,8 @@ oneOf:
           type: integer
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
@@ -383,6 +393,8 @@ oneOf:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
     specs:
@@ -422,6 +434,8 @@ oneOf:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
     specs:
@@ -461,6 +475,8 @@ oneOf:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     mirror:
       "$schemaRef": "/dependencies/container-image-mirror-1.yml"
     public:
@@ -486,6 +502,8 @@ oneOf:
       type: string
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     defaults:
       type: string
     annotations:
@@ -524,6 +542,8 @@ oneOf:
           type: boolean
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
@@ -544,6 +564,8 @@ oneOf:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     defaults:
       type: string
     annotations:
@@ -587,6 +609,8 @@ oneOf:
         - domain_name
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
@@ -613,6 +637,8 @@ oneOf:
       type: string
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
@@ -635,6 +661,8 @@ oneOf:
       "$ref": "/common-1.json#/definitions/vaultSecret"
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
@@ -653,6 +681,8 @@ oneOf:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
     vpc:
@@ -759,6 +789,8 @@ oneOf:
       "$ref": "/common-1.json#/definitions/vaultSecret"
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
@@ -829,6 +861,8 @@ oneOf:
       - ref
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
@@ -853,6 +887,8 @@ oneOf:
       "$ref": "/aws/regions-1.yml#/properties/region"
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:


### PR DESCRIPTION
### What changes?
Provide an output_format section to /openshift/terraform-resource-1.yml. This section will hold configuration data to drive the formatting process for terraform output data. output_format configuration is provider based, allowing different implementations to format the terraform outputs into consumable kubernetes secrets.

The first supported provider is the generic-secret provider, which formats the terraform output data as a kubernetes secret in the exact same way as it was handled before this change. to influence the output format, the secret data section can be specified inline, while providing jinja2 templating functionality.

### Example
The generic-secret provider will be the implicit default one when none is specified, making the following three declarations equivalent:

```yaml
  terraformResources:
  - provider: aws-iam-service-account
    ...
```

```yaml
  terraformResources:
  - provider: aws-iam-service-account
    output_format:
      provider: generic-secret
    ...
```

```yaml
  terraformResources:
  - provider: aws-iam-service-account
    output_format:
      provider: generic-secret
      data:
        aws_access_key_id: {{ aws_access_key_id }}
        aws_secret_access_key: {{ aws_secret_access_key }}
    ...
```

Another example shows how AWS access credentials can be formatted in the credentials file format

```yaml
  terraformResources:
  - provider: aws-iam-service-account
    output_format:
      provider: generic-secret
      data:
        credentials: |
          [default]
          aws_access_key_id = {{ aws_access_key_id }}
          aws_secret_access_key = {{ aws_secret_access_key }}

    ...
```

### References
Part of https://issues.redhat.com/browse/APPSRE-4766

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>