### PR TITLE
allow saas targets to reference repo branches prefixed with release-

### DIFF
--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -103,7 +103,7 @@ properties:
               ref:
                 type: string
                 # pattern: '^([0-9a-f]{40}|master|main|quayio|development-4\.0|internal|mk-release)$'
-                pattern: '^([0-9a-f]{40}|master|main|internal|quayio)$'
+                pattern: '^([0-9a-f]{40}|master|main|internal|quayio|release-.*)$'
               promotion:
                 type: object
                 additionalProperties: false


### PR DESCRIPTION
hypershift maintains release branches and the release- prefix is a well established pattern for projects within the github openshift organization

ref: https://issues.redhat.com/browse/APPSRE-4832

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>