### PR TITLE
add option to use app label for alerts

### DIFF
--- a/schemas/openshift/prometheus-rule-1.yml
+++ b/schemas/openshift/prometheus-rule-1.yml
@@ -132,6 +132,8 @@ properties:
                         app_team:
                         - service
                         - env
+                        app:
+                        - jiralert
                       required:
                       - service
                     expr:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4750

the `service` label may indicate of the alerting service, but does not always correspond to the name of the `app`.
the alerting service may also not be a part of the app. for example - DVO will alert for other apps, and so will RDS related alerts.

by adding the `app` label, we can use it as part of dynamically generated alerts to correlate between an app in app-interface and a created jira ticket.