### PR TITLE
Revert "APPSRE-3556 deprecate saas-file-1 (#125)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ What if we want to define a crossref with multiple allowed types? (owned_saas_fi
           '$schema':
             type: string
             enum:
+              - "/app-sre/saas-file-1.yml"
               - "/app-sre/saas-file-2.yml"
 ```
 

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1644,6 +1644,12 @@
     synthetic:
       schema: /dependencies/jenkins-config-1.yml
       subAttr: app
+  - name: saasFiles
+    type: SaasFile_v1
+    isList: true
+    synthetic:
+      schema: /app-sre/saas-file-1.yml
+      subAttr: app
   - name: saasFilesV2
     type: SaasFile_v2
     isList: true
@@ -1656,6 +1662,35 @@
     synthetic:
       schema: /app-sre/sre-checkpoint-1.yml
       subAttr: app
+
+- name: SaasFile_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: labels, type: json }
+  - { name: name, type: string, isRequired: true, isSearchable: true, isUnique: true }
+  - { name: description, type: string, isRequired: true }
+  - { name: app, type: App_v1, isRequired: true }
+  - { name: instance, type: JenkinsInstance_v1, isRequired: true }
+  - { name: slack, type: SlackOutput_v1, isRequired: true }
+  - { name: managedResourceTypes, type: string, isRequired: true, isList: true }
+  - { name: authentication, type: SaasFileAuthentication_v1 }
+  - { name: parameters, type: json }
+  - { name: secretParameters, type: SaasSecretParameters_v1, isList: true }
+  - { name: resourceTemplates, type: SaasResourceTemplate_v1, isRequired: true, isList: true }
+  - { name: imagePatterns, type: string, isRequired: true, isList: true }
+  - { name: takeover, type: boolean }
+  - { name: compare, type: boolean }
+  - { name: timeout, type: int }
+  - { name: publishJobLogs, type: boolean }
+  - { name: clusterAdmin, type: boolean }
+  - { name: use_channel_in_image_tag, type: boolean }
+  - name: roles
+    type: Role_v1
+    isList: true
+    synthetic:
+      schema: /access/role-1.yml
+      subAttr: owned_saas_files
 
 - name: SaasFile_v2
   fields:
@@ -2095,7 +2130,7 @@
   - { name: sentry_teams, type: SentryTeam_v1, isList: true }
   - { name: sentry_roles, type: SentryRole_v1, isList: true }
   - { name: sendgrid_accounts, type: SendGridAccount_v1, isList: true }
-  - { name: owned_saas_files, type: SaasFile_v2, isList: true }
+  - { name: owned_saas_files, type: SaasFile_v1, isList: true }
   - name: users
     type: User_v1
     isList: true
@@ -2274,6 +2309,7 @@
   - { name: sentry_teams_v1, type: SentryTeam_v1, isList: true, datafileSchema: /dependencies/sentry-team-1.yml }
   - { name: sentry_instances_v1, type: SentryInstance_v1, isList: true, datafileSchema: /dependencies/sentry-instance-1.yml }
   - { name: app_interface_sql_queries_v1, type: AppInterfaceSqlQuery_v1, isList: true, datafileSchema: /app-interface/app-interface-sql-query-1.yml }
+  - { name: saas_files_v1, type: SaasFile_v1, isList: true, datafileSchema: /app-sre/saas-file-1.yml }
   - { name: saas_files_v2, type: SaasFile_v2, isList: true, datafileSchema: /app-sre/saas-file-2.yml }
   - { name: pipelines_providers_v1, type: PipelinesProvider_v1, isList: true, isInterface: true, datafileSchema: /app-sre/pipelines-provider-1.yml }
   - { name: unleash_instances_v1, type: UnleashInstance_v1, isList: true, datafileSchema: /app-sre/unleash-instance-1.yml }

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -116,6 +116,7 @@ properties:
           '$schema':
             type: string
             enum:
+            - "/app-sre/saas-file-1.yml"
             - "/app-sre/saas-file-2.yml"
 required:
 - $schema

--- a/schemas/app-sre/saas-file-1.yml
+++ b/schemas/app-sre/saas-file-1.yml
@@ -1,0 +1,192 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /app-sre/saas-file-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    type: string
+    maxLength: 40
+  description:
+    type: string
+  app:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/app-sre/app-1.yml"
+  instance:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/dependencies/jenkins-instance-1.yml"
+  slack:
+    type: object
+    properties:
+      output:
+        type: string
+        enum:
+        - events
+        - publish
+      workspace:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "/dependencies/slack-workspace-1.yml"
+      channel:
+        type: string
+      notifications:
+        type: object
+        additionalProperties: false
+        properties:
+          start:
+            type: boolean
+    required:
+    - workspace
+    - channel
+  managedResourceTypes:
+    type: array
+    items:
+      type: string
+  authentication:
+    type: object
+    properties:
+      code:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+      image:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+  parameters:
+    type: object
+  secretParameters:
+    type: array
+    description: saas file level parameters from vault secrets
+    items:
+      "$ref": "/app-sre/vault-secret-parameter-1.yml"
+  resourceTemplates:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        url:
+          type: string
+          format: uri
+        path:
+          type: string
+          pattern: '^\/.*'
+        provider:
+          type: string
+          enum:
+          - openshift-template
+          - directory
+        hash_length:
+          type: integer
+        parameters:
+          type: object
+        secretParameters:
+          type: array
+          description: resource template level parameters from vault secrets
+          items:
+            "$ref": "/app-sre/vault-secret-parameter-1.yml"
+        targets:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              namespace:
+                "$ref": "/common-1.json#/definitions/crossref"
+                "$schemaRef": "/openshift/namespace-1.yml"
+              ref:
+                type: string
+                pattern: '^([0-9a-f]{40}|master|main|quayio|internal)$'
+              promotion:
+                type: object
+                additionalProperties: false
+                properties:
+                  auto:
+                    type: boolean
+                  publish:
+                    type: array
+                    items:
+                      type: string
+                    minItems: 1
+                  subscribe:
+                    type: array
+                    items:
+                      type: string
+                    minItems: 1
+                  promotion_data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        channel:
+                          type: string
+                        data:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                            additionalProperties: true
+                dependencies:
+                  auto:
+                  - subscribe
+              parameters:
+                type: object
+              secretParameters:
+                type: array
+                description: target level parameters from vault secrets
+                items:
+                  "$ref": "/app-sre/vault-secret-parameter-1.yml"
+              upstream:
+                type: string
+              disable:
+                type: boolean
+              delete:
+                type: boolean
+            required:
+            - namespace
+            - ref
+      required:
+      - name
+      - url
+      - path
+      - targets
+  takeover:
+    type: boolean
+  compare:
+    type: boolean
+  timeout:
+    type: integer
+  publishJobLogs:
+    type: boolean
+  clusterAdmin:
+    type: boolean
+  imagePatterns:
+    type: array
+    items:
+      type: string
+      # allowed patterns:
+      # - quay.io
+      # - registry.redhat.io
+      # - ECR
+      pattern: '^(quay\.io|registry\.redhat\.io|[^.]+\.dkr\.ecr\.[^.]+\.amazonaws\.com).*$'
+  use_channel_in_image_tag:
+    type: boolean
+required:
+- "$schema"
+- labels
+- name
+- description
+- app
+- instance
+- slack
+- managedResourceTypes
+- resourceTemplates
+- imagePatterns


### PR DESCRIPTION
This reverts commit a61aafb1efe37bc63324a68d5eebad2354c5993d.

Apparently there are still issues in the `github` integration with saas-file-1

```
gql.transport.exceptions.TransportQueryError: {'message': 'Cannot query field "saasFiles" on type "App_v1". Did you mean "saasFilesV2"?', 'locations': [{'line': 15, 'column': 5}], 'extensions': {'code': 'GRAPHQL_VALIDATION_FAILED'}}
```