### PR TITLE
Make contract version mandatory in checkpoint file

### DIFF
--- a/schemas/app-sre/sre-checkpoint-1.yml
+++ b/schemas/app-sre/sre-checkpoint-1.yml
@@ -36,3 +36,4 @@ required:
 - sre
 - date
 - issue
+- contractVersion


### PR DESCRIPTION
We have added a contract version to every checkpoint file in
app-interface. We can now make it mandatory

Part of APPSRE-4788

Signed-off-by: Rafael Porres Molina <rporres@gmail.com>