### PR TITLE
add secret engine attribute for vault instance auth

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1892,11 +1892,13 @@
       token: VaultInstanceAuthToken_v1
   fields:
   - { name: provider, type: string, isRequired: true }
+  - { name: secretEngine, type: string, isRequired: true }
 
 - name: VaultInstanceAuthApprole_v1
   interface: VaultInstanceAuth_v1
   fields:
   - { name: provider, type: string, isRequired: true }
+  - { name: secretEngine, type: string, isRequired: true }
   - { name: roleID, type: VaultSecret_v1, isRequired: true }
   - { name: secretID, type: VaultSecret_v1, isRequired: true }
 
@@ -1904,6 +1906,7 @@
   interface: VaultInstanceAuth_v1
   fields:
   - { name: provider, type: string, isRequired: true }
+  - { name: secretEngine, type: string, isRequired: true }
   - { name: token, type: VaultSecret_v1, isRequired: true }
 
 - name: OidcPermission_v1

--- a/schemas/vault-config/instance-auth-1.yml
+++ b/schemas/vault-config/instance-auth-1.yml
@@ -11,6 +11,11 @@ properties:
     - /vault-config/instance-auth-1.yml
   provider:
     type: string
+  secretEngine:
+    type: string
+    enum:
+    - kv_v1
+    - kv_v2
   roleID:
     "$ref": "/common-1.json#/definitions/vaultSecret"
   secretID:
@@ -41,3 +46,4 @@ oneOf:
   - token
 required:
 - provider
+- secretEngine


### PR DESCRIPTION
ticket: https://issues.redhat.com/browse/APPSRE-4506

Vault api returns slightly different payloads when reading secrets from kv v1 vs v2. This needs to be handled within vault-manager logic, and therefore requires defining which secret engine version the particular secret is within.