### PR TITLE
Add cognito and api_gateway support

### DIFF
--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -774,5 +774,61 @@ oneOf:
   - account
   - identifier
   - defaults
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - cognito
+    account:
+      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
+    identifier:
+      type: string
+    domain:
+      type: string
+    sms_role_ext_id:
+      type: string
+    defaults:
+      type: string
+    region:
+      "$ref": "/aws/regions-1.yml#/properties/region"
+    output_resource_name:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    annotations:
+      "$ref": "/common-1.json#/definitions/annotations"
+  required:
+  - account
+  - identifier
+  - domain
+  - sms_role_ext_id
+  - defaults
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - api-gateway
+    account:
+      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
+    identifier:
+      type: string
+    api_proxy_uri:
+      type: string
+    lb_subnet_id:
+      type: string
+    defaults:
+      type: string
+    region:
+      "$ref": "/aws/regions-1.yml#/properties/region"
+    output_resource_name:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    annotations:
+      "$ref": "/common-1.json#/definitions/annotations"
+  required:
+  - account
+  - identifier
+  - api_proxy_uri
+  - lb_subnet_id
+  - defaults
 required:
 - provider


### PR DESCRIPTION
# Add Cognito and API Gateway schemas to support ROSA-FedRAMP effory

This MR adds support for AWS Cogntio and API Gateway resource creation via Terrascript -> Terraform, adding schemas for these provider types.

This MR depends on MR #38690 in Gitlab [merged], the design document documenting the use case and technical decisions that go into this change.

In addition, this MR will depend on updates to qontract-reconcile (https://github.com/app-sre/qontract-reconcile/pull/2409)

App-interface representation of new resources:

```
terraformResources:

- provider: cognito
  account: appsrefrp01ugw1
  identifier: rosa-cognito
  domain: cognito.fedramp.devshift.net
  sms_role_ext_id: foobar
  defaults: /terraform/cognito-1.yml

- provider: api-gateway
  account: appsrefrp01ugw1
  identifier: rosa-cognito
  api_proxy_uri: api-gateway.fedramp.devshift.net
  lb_subnet_id: subnet-abcdef123456
  defaults: /terraform/api-gateway-1.yml
```
