### PR TITLE
add required repo url field to settings

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -5,6 +5,7 @@
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
+  - { name: instanceUrl, type: string, isRequired: true }
   - { name: vault, type: boolean, isRequired: true }
   - { name: kubeBinary, type: string, isRequired: true }
   - { name: pullRequestGateway, type: string }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -5,7 +5,7 @@
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
-  - { name: instanceUrl, type: string, isRequired: true }
+  - { name: repoUrl, type: string, isRequired: true }
   - { name: vault, type: boolean, isRequired: true }
   - { name: kubeBinary, type: string, isRequired: true }
   - { name: pullRequestGateway, type: string }

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -15,6 +15,9 @@ properties:
     type: string
   description:
     type: string
+  instanceUrl:
+    type: string
+    format: uri
   vault:
     type: boolean
   kubeBinary:
@@ -135,6 +138,7 @@ required:
 - labels
 - name
 - description
+- instanceUrl
 - vault
 - kubeBinary
 - saasDeployJobTemplate

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -15,8 +15,9 @@ properties:
     type: string
   description:
     type: string
-  instanceUrl:
+  repoUrl:
     type: string
+    description: url of the app-interface git repository
     format: uri
   vault:
     type: boolean
@@ -138,7 +139,7 @@ required:
 - labels
 - name
 - description
-- instanceUrl
+- repoUrl
 - vault
 - kubeBinary
 - saasDeployJobTemplate


### PR DESCRIPTION
this will allow us to provide relative links to files if we wish.

currently planned to be used for:
https://github.com/app-sre/qontract-reconcile/pull/2422/files#diff-0e7b34d72a912959fc73360c9ad81c9ce8d1ca4fff2ef4dac354f976728de183R1389

making this field mandatory, mostly because it is a very simple change.