### PR TITLE
add schemas for query-validation

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2273,6 +2273,20 @@
   - { name: query, type: string }
   - { name: queries, type: string, isList: true }
 
+- name: QueryValidationQueryItem_v1
+  fields:
+  - { name: path, type: string, isRequired: true }
+
+- name: QueryValidation_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: labels, type: json }
+  - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
+  - { name: description, type: string, isRequired: true }
+  - { name: escalationPolicy, type: AppEscalationPolicy_v1, isRequired: true }
+  - { name: queries, type: QueryValidationQueryItem_v1, isList: true, isRequired: true }
+
 - name: UnleashNotifications_v1
   fields:
   - { name: slack, type: SlackOutput_v1, isList: true }
@@ -2370,6 +2384,7 @@
   - { name: sentry_teams_v1, type: SentryTeam_v1, isList: true, datafileSchema: /dependencies/sentry-team-1.yml }
   - { name: sentry_instances_v1, type: SentryInstance_v1, isList: true, datafileSchema: /dependencies/sentry-instance-1.yml }
   - { name: app_interface_sql_queries_v1, type: AppInterfaceSqlQuery_v1, isList: true, datafileSchema: /app-interface/app-interface-sql-query-1.yml }
+  - { name: query_validation_v1, type: QueryValidation_v1, isList: true, datafileSchema: /app-interface/query-validation-1.yml }
   - { name: saas_files_v2, type: SaasFile_v2, isList: true, datafileSchema: /app-sre/saas-file-2.yml }
   - { name: pipelines_providers_v1, type: PipelinesProvider_v1, isList: true, isInterface: true, datafileSchema: /app-sre/pipelines-provider-1.yml }
   - { name: unleash_instances_v1, type: UnleashInstance_v1, isList: true, datafileSchema: /app-sre/unleash-instance-1.yml }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2273,7 +2273,7 @@
   - { name: query, type: string }
   - { name: queries, type: string, isList: true }
 
-- name: QueryValidationQueryItem_v1
+- name: QontractQuery_v1
   fields:
   - { name: path, type: string, isRequired: true }
 
@@ -2285,7 +2285,7 @@
   - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
   - { name: description, type: string, isRequired: true }
   - { name: escalationPolicy, type: AppEscalationPolicy_v1, isRequired: true }
-  - { name: queries, type: QueryValidationQueryItem_v1, isList: true, isRequired: true }
+  - { name: queries, type: QontractQuery_v1, isList: true, isRequired: true }
 
 - name: UnleashNotifications_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2384,7 +2384,7 @@
   - { name: sentry_teams_v1, type: SentryTeam_v1, isList: true, datafileSchema: /dependencies/sentry-team-1.yml }
   - { name: sentry_instances_v1, type: SentryInstance_v1, isList: true, datafileSchema: /dependencies/sentry-instance-1.yml }
   - { name: app_interface_sql_queries_v1, type: AppInterfaceSqlQuery_v1, isList: true, datafileSchema: /app-interface/app-interface-sql-query-1.yml }
-  - { name: query_validation_v1, type: QueryValidation_v1, isList: true, datafileSchema: /app-interface/query-validation-1.yml }
+  - { name: query_validations_v1, type: QueryValidation_v1, isList: true, datafileSchema: /app-interface/query-validation-1.yml }
   - { name: saas_files_v2, type: SaasFile_v2, isList: true, datafileSchema: /app-sre/saas-file-2.yml }
   - { name: pipelines_providers_v1, type: PipelinesProvider_v1, isList: true, isInterface: true, datafileSchema: /app-sre/pipelines-provider-1.yml }
   - { name: unleash_instances_v1, type: UnleashInstance_v1, isList: true, datafileSchema: /app-sre/unleash-instance-1.yml }

--- a/schemas/app-interface/query-validation-1.yml
+++ b/schemas/app-interface/query-validation-1.yml
@@ -32,6 +32,7 @@ properties:
           description: path to resource query to be tested
       required:
       - path
+    minItems: 1
 required:
 - "$schema"
 - labels

--- a/schemas/app-interface/query-validation-1.yml
+++ b/schemas/app-interface/query-validation-1.yml
@@ -1,0 +1,41 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /app-interface/query-validation-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    type: string
+    description: unique name for query validation
+  description:
+    type: string
+    description: description of the queries included in the file
+  escalationPolicy:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/app-sre/escalation-policy-1.yml"
+  queries:
+    type: array
+    description: queries to validate
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        path:
+          type: string
+          description: path to resource query to be tested
+      required:
+      - path
+required:
+- "$schema"
+- labels
+- name
+- description
+- escalationPolicy
+- queries


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5561

design doc: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/schema-compatibility.md

To avoid breaking tenants' automations that rely on app-interface, we need to make app-interface aware of the queries tenants are using in their automations. Differently worded, tenants should be able to declare queries they are using and request to be notified for breaking changes.

For that purpose, we will introduce a new schema, `query-validation-1`, which will include the common fields, such as `name` and `description`. In addition, it will include a `queries` field.

This field will be a list of references (paths) to resources (files under the `resources/` directory) which are a file containing a graphql query. Some examples can be found under `resources/queries`. This list will be the queries used in the tenants' automations, and that we need to avoid from breaking. This means that we only need to notify tenants for breaking changes that affect their queries.

In addition to the schema, we will create an integration (`query-validator`). This integration acts on `query-validation-1` files. The integration will be pretty straight forward: For each entry in the `queries` list, execute the query. If it fails - fail the integration.

This integration will only run within app-interface pr-check to gate merges of schema promotions that break the tenants' queries. In case this integration fails, we will contact the responsible team to make adjustments to their source code and to the queries in app-interface.

Once the tenants' source code was changed, together with the query files in app-interface (referenced from a `query-validation-1` file), AppSRE is clear to merge the (no-longer) breaking schema changes.

We should generally avoid breaking schema changes. At the minimum, changes should be backwards compatible to allow some time before introducing the breaking change. With that said, this design document comes as a result of a tenant request. The tenant requested 1-2 working days, so we will use that as the SLA for tenants at first.