### PR TITLE
add shardingStrategy for integrations

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2291,6 +2291,7 @@
   - { name: logs, type: IntegrationSpecLogs_v1 }
   - { name: resources, type: DeployResources_v1, isRequired: true }
   - { name: shards, type: int }
+  - { name: shardingStrategy, type: string }
   - { name: sleepDurationSecs, type: int }
   - { name: state, type: boolean }
   - { name: storage, type: string }

--- a/schemas/app-sre/integration-spec-1.yml
+++ b/schemas/app-sre/integration-spec-1.yml
@@ -82,6 +82,12 @@ properties:
   shards:
     type: integer
     description: number of shards to run integration with
+  shardingStrategy:
+    type: string
+    description: the strategy to use for sharding
+    enum:
+    - per-aws-account
+    - static
   sleepDurationSecs:
     type: integer
     description: time to sleep in seconds between integration executions


### PR DESCRIPTION
the `shardingStrategy` will be used by the integrations-manager to statically or dynamically deploy shards for integrations.

the `static sharding` strategy is the backwards compatible default strategy that deploys shards based on `spec.shards`

the `per-aws-account` deploys shards based on the aws accounts in app-interface

design doc: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/qontract-operator-sharding.md
part of: https://issues.redhat.com/browse/APPSRE-2963

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>