### PR TITLE
MON-2563: Add 'code' to permitted prometheus rule label schema

### DIFF
--- a/schemas/openshift/prometheus-rule-1.yml
+++ b/schemas/openshift/prometheus-rule-1.yml
@@ -94,6 +94,8 @@ properties:
                           type: string
                         team:
                           type: string
+                        code:
+                          type: string
                         component:
                           type: string
                         channel:


### PR DESCRIPTION
In our recent [incident](https://coreos.slack.com/archives/C03GBPGV52B) our API Write Path SLO alerts failed to fire when they should have fired.

This is because we were pruning the `code` [label](https://github.com/rhobs/configuration/blob/14d4991acebe4aea041d05fdf6f900db6e3a5ddc/observability/prometheusrules.jsonnet#L128) in order to pass the App-Interface MR checks. 

This PR adds `code` as a permitted label in the prometheus rule app-interface schema.

Signed-off-by: Ian Billett <ibillett@redhat.com>