### PR TITLE
explicit resource reference metadata in qontract-schema data files

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -368,7 +368,7 @@
   - { name: instance, type: JenkinsInstance_v1, isRequired: true }
   - { name: type, type: string, isRequired: true }
   - { name: config, type: json }
-  - { name: config_path, type: string }
+  - { name: config_path, type: string, isResourceRef: true }
 
 - name: JiraServer_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -262,6 +262,14 @@
   - { name: content, type: string, isRequired: true }
   - { name: sha256sum, type: string, isRequired: true }
   - { name: schema, type: string }
+  - { name: backrefs, type: ResourceBackref_v1, isList: true }
+
+- name: ResourceBackref_v1
+  fields:
+  - { name: path, type: string, isRequired: true }
+  - { name: datafileSchema, type: string, isRequired: true }
+  - { name: type, type: string, isRequired: true }
+  - { name: jsonpath, type: string, isRequired: true }
 
 - name: VaultSecret_v1
   fields:
@@ -998,6 +1006,7 @@
   - { name: alternate_names, type: string, isList: true }
 
 - name: NamespaceOpenshiftResource_v1
+  datafile: /openshift/openshift-resource-1.yml
   isInterface: true
   interfaceResolve:
     strategy: fieldMap
@@ -1014,7 +1023,7 @@
   interface: NamespaceOpenshiftResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: path, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true, isResourceRef: true }
   - { name: validate_json, type: boolean }
   - { name: validate_alertmanager_config, type: boolean }
   - { name: alertmanager_config_key, type: string }
@@ -1023,7 +1032,7 @@
   interface: NamespaceOpenshiftResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: path, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true, isResourceRef: true }
   - { name: type, type: string }
   - { name: variables, type: json }
   - { name: validate_alertmanager_config, type: boolean }
@@ -1046,7 +1055,7 @@
   interface: NamespaceOpenshiftResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: path, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true, isResourceRef: true }
   - { name: vault_tls_secret_path, type: string }
   - { name: vault_tls_secret_version, type: int }
 
@@ -1077,6 +1086,7 @@
   - { name: resources, type: NamespaceTerraformResourceGCP_v1, isRequired: true, isList: true, isInterface: true }
 
 - name: NamespaceTerraformResourceGCP_v1
+  datafile: /gcp/terraform-resource-1.yml
   isInterface: true
   interfaceResolve:
     strategy: fieldMap
@@ -1099,6 +1109,7 @@
   - { name: annotations, type: json }
 
 - name: NamespaceTerraformResourceAWS_v1
+  datafile: /aws/terraform-resources-1.yml
   isInterface: true
   interfaceResolve:
     strategy: fieldMap
@@ -1154,7 +1165,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
-  - { name: defaults, type: string, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResourceRef: true }
   - { name: cloudinit_configs, type: CloudinitConfig_v1, isList: true }
   - { name: variables, type: json }
   - { name: image, type: ASGImage_v1, isRequired: true }
@@ -1215,7 +1226,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
-  - { name: defaults, type: string, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResourceRef: true }
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
@@ -1227,7 +1238,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
-  - { name: defaults, type: string, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResourceRef: true }
   - { name: availability_zone, type: string }
   - { name: parameter_group, type: string }
   - { name: overrides, type: json }
@@ -1246,7 +1257,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
-  - { name: defaults, type: string, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResourceRef: true }
   - { name: overrides, type: json }
   - { name: event_notifications, type: AWSS3EventNotification_v1, isList: true }
   - { name: sqs_identifier, type: string }
@@ -1308,7 +1319,7 @@
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
-  - { name: defaults, type: string, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResourceRef: true }
   - { name: parameter_group, type: string }
   - { name: region, type: string }
   - { name: overrides, type: json }
@@ -1318,7 +1329,7 @@
 
 - name: SQSQueuesSpecs_v1
   fields:
-  - { name: defaults, type: string, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResourceRef: true }
   - { name: queues, type: KeyValue_v1, isRequired: true, isList: true }
 
 - name: NamespaceTerraformResourceSQS_v1
@@ -1334,7 +1345,7 @@
 
 - name: DynamoDBTableSpecs_v1
   fields:
-  - { name: defaults, type: string, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResourceRef: true }
   - { name: tables, type: KeyValue_v1, isRequired: true, isList: true }
 
 - name: NamespaceTerraformResourceDynamoDB_v1
@@ -1367,7 +1378,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
-  - { name: defaults, type: string, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResourceRef: true }
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: storage_class, type: string }
@@ -1380,7 +1391,7 @@
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
   - { name: kms_encryption, type: boolean }
-  - { name: defaults, type: string, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResourceRef: true }
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: storage_class, type: string }
@@ -1392,7 +1403,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
-  - { name: defaults, type: string, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResourceRef: true }
   - { name: es_identifier, type: string }
   - { name: filter_pattern, type: string }
   - { name: output_resource_name, type: string }
@@ -1405,7 +1416,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
-  - { name: defaults, type: string, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResourceRef: true }
   - { name: overrides, type: json }
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
@@ -1417,7 +1428,7 @@
   - { name: provider, type: string, isRequired: true }
   - { name: region, type: string }
   - { name: identifier, type: string, isRequired: true }
-  - { name: defaults, type: string, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResourceRef: true }
   - { name: overrides, type: json }
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
@@ -2379,7 +2390,7 @@
 
 - name: QontractQuery_v1
   fields:
-  - { name: path, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true, isResourceRef: true }
 
 - name: QueryValidation_v1
   fields:

--- a/schemas/app-interface/query-validation-1.yml
+++ b/schemas/app-interface/query-validation-1.yml
@@ -28,7 +28,7 @@ properties:
       additionalProperties: false
       properties:
         path:
-          type: string
+          "$ref": "/common-1.json#/definitions/resourceref"
           description: path to resource query to be tested
       required:
       - path

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -152,7 +152,7 @@ oneOf:
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     defaults:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     overrides:
       type: object
       properties:
@@ -351,7 +351,7 @@ oneOf:
     availability_zone:
       type: string
     defaults:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     parameter_group:
       type: string
     overrides:
@@ -456,7 +456,7 @@ oneOf:
     identifier:
       type: string
     defaults:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     parameter_group:
       type: string
     region:
@@ -513,7 +513,7 @@ oneOf:
         type: object
         properties:
           defaults:
-            type: string
+            "$ref": "/common-1.json#/definitions/resourceref"
           queues:
             type: array
             items:
@@ -551,7 +551,7 @@ oneOf:
         type: object
         properties:
           defaults:
-            type: string
+            "$ref": "/common-1.json#/definitions/resourceref"
           tables:
             type: array
             items:
@@ -606,7 +606,7 @@ oneOf:
     output_format:
       "$ref": "/openshift/terraform-output-format-1.yml"
     defaults:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
   required:
@@ -623,7 +623,7 @@ oneOf:
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
     defaults:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     overrides:
       type: object
       properties:
@@ -662,7 +662,7 @@ oneOf:
     output_format:
       "$ref": "/openshift/terraform-output-format-1.yml"
     defaults:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
     publish_log_types:
@@ -723,7 +723,7 @@ oneOf:
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
     defaults:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     output_format:
@@ -887,7 +887,7 @@ oneOf:
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     defaults:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     cloudinit_configs:
       type: array
       items:

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -32,6 +32,10 @@
       "type": "string",
       "pattern": "^[A-Za-z0-9][A-Za-z0-9-_]{0,30}[A-Za-z0-9]$"
     },
+    "resourceref": {
+      "type": "string",
+      "pattern": "^\/(?:[^\/]+\/)*[^\/]+$"
+    },
     "extendedIdentifier": {
       "type": "string",
       "pattern": "^[A-Za-z0-9][A-Za-z0-9-_\\.]{0,30}[A-Za-z0-9]$"

--- a/schemas/dependencies/jenkins-config-1.yml
+++ b/schemas/dependencies/jenkins-config-1.yml
@@ -33,7 +33,7 @@ properties:
     - job-templates
     - jobs
   config_path:
-    type: string
+    "$ref": "/common-1.json#/definitions/resourceref"
   config:
     type: array
     items:

--- a/schemas/openshift/openshift-resource-1.yml
+++ b/schemas/openshift/openshift-resource-1.yml
@@ -44,7 +44,7 @@ oneOf:
       enum:
       - resource
     path:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     validate_json:
       type: boolean
     validate_alertmanager_config:
@@ -60,7 +60,7 @@ oneOf:
       enum:
       - resource-template
     path:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     type:
       type: string
       enum:
@@ -81,7 +81,7 @@ oneOf:
       enum:
       - route
     path:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     vault_tls_secret_path:
       type: string
     vault_tls_secret_version:


### PR DESCRIPTION
Introduce a common type declaration `/common-1.json#/definitions/resourceref` that is compatible with `string` but represents a path to a resource.

```yaml
---
"$schema": /metaschema-1.json
version: '1.0'
type: object
...
properties:
  ...
  path:
    "$ref": "/common-1.json#/definitions/resourceref"
```

This information is used in `qontract-validator` to verify resource references and enables fast fail for PR checks during bundle creation. At the same time it is compatible with current data.

Additionally add a property `isResourceRef = true` to the respective field in the graphql schema. This can leveraged during schema introspection.

During bundle creation, `resources.backrefs` will be filled with a list of data files that reference a resource.

References:
* design doc https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/qontract-schema-resource-references.md
* https://issues.redhat.com/browse/APPSRE-5629

Enables https://github.com/app-sre/qontract-validator/pull/37

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>