### PR TITLE
Add missing instance classes for db.m5, db.r5, db.m6g

### DIFF
--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -260,7 +260,18 @@ oneOf:
           - db.m5.large
           - db.m5.xlarge
           - db.m5.2xlarge
+          - db.m5.4xlarge
+          - db.m5.8xlarge
+          - db.m5.12xlarge
+          - db.m5.16xlarge
+          - db.m5.24xlarge
           - db.m6g.large
+          - db.m6g.xlarge
+          - db.m6g.2xlarge
+          - db.m6g.4xlarge
+          - db.m6g.8xlarge
+          - db.m6g.12xlarge
+          - db.m6g.16xlarge
           - db.r4.large
           - db.r4.xlarge
           - db.r4.2xlarge
@@ -270,6 +281,11 @@ oneOf:
           - db.r5.large
           - db.r5.xlarge
           - db.r5.2xlarge
+          - db.r5.4xlarge
+          - db.r5.8xlarge
+          - db.r5.12xlarge
+          - db.r5.16xlarge
+          - db.r5.24xlarge
         allocated_storage:
           type: integer
         backup_retention_period:

--- a/schemas/openshift/terraform-resource-1.yml
+++ b/schemas/openshift/terraform-resource-1.yml
@@ -292,7 +292,18 @@ oneOf:
           - db.m5.large
           - db.m5.xlarge
           - db.m5.2xlarge
+          - db.m5.4xlarge
+          - db.m5.8xlarge
+          - db.m5.12xlarge
+          - db.m5.16xlarge
+          - db.m5.24xlarge
           - db.m6g.large
+          - db.m6g.xlarge
+          - db.m6g.2xlarge
+          - db.m6g.4xlarge
+          - db.m6g.8xlarge
+          - db.m6g.12xlarge
+          - db.m6g.16xlarge
           - db.r4.large
           - db.r4.xlarge
           - db.r4.2xlarge
@@ -302,6 +313,11 @@ oneOf:
           - db.r5.large
           - db.r5.xlarge
           - db.r5.2xlarge
+          - db.r5.4xlarge
+          - db.r5.8xlarge
+          - db.r5.12xlarge
+          - db.r5.16xlarge
+          - db.r5.24xlarge
         allocated_storage:
           type: integer
         backup_retention_period:


### PR DESCRIPTION
We should always add every instance class option for the family.