### PR TITLE
[saas file] secretParameter names can't contain dashes

### DIFF
--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -140,6 +140,8 @@ properties:
                   - subscribe
               parameters:
                 type: object
+                patternProperties:
+                  "^[A-Za-z][A-Za-z0-9_]*$": {}
               secretParameters:
                 type: array
                 description: target level parameters from vault secrets

--- a/schemas/app-sre/vault-secret-parameter-1.yml
+++ b/schemas/app-sre/vault-secret-parameter-1.yml
@@ -11,7 +11,7 @@ properties:
     enum:
     - /app-sre/vault-secret-parameter-1.yml
   name:
-    type: string
+    "$ref": "/common-1.json#/definitions/templateParameterName"
     description: parameter name
   secret:
     "$ref": "/common-1.json#/definitions/vaultSecret"

--- a/schemas/app-sre/vault-secret-parameter-1.yml
+++ b/schemas/app-sre/vault-secret-parameter-1.yml
@@ -11,7 +11,7 @@ properties:
     enum:
     - /app-sre/vault-secret-parameter-1.yml
   name:
-    "$ref": "/common-1.json#/definitions/templateParameterName"
+    pattern: "^[A-Za-z][A-Za-z0-9_]*$"
     description: parameter name
   secret:
     "$ref": "/common-1.json#/definitions/vaultSecret"

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -36,6 +36,10 @@
       "type": "string",
       "pattern": "^[A-Za-z0-9][A-Za-z0-9-_\\.]{0,30}[A-Za-z0-9]$"
     },
+    "templateParameterName": {
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_]*$"
+    },
     "longIdentifier": {
       "type": "string",
       "pattern": "^[a-z0-9][a-z0-9-]{3,63}[a-z0-9]$"

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -36,10 +36,6 @@
       "type": "string",
       "pattern": "^[A-Za-z0-9][A-Za-z0-9-_\\.]{0,30}[A-Za-z0-9]$"
     },
-    "templateParameterName": {
-      "type": "string",
-      "pattern": "^[A-Za-z][A-Za-z0-9_]*$"
-    },
     "longIdentifier": {
       "type": "string",
       "pattern": "^[a-z0-9][a-z0-9-]{3,63}[a-z0-9]$"


### PR DESCRIPTION
`openshift template parameter name` requirements are not well documented but we now that hypens don't work

this change introduces a pattern for secret parameter names that allows only characters (upper,lower), numbers and underscores. also, they need to start with a character

update: also make sure saas parameter names adhere to the pattern

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>