### PR TITLE
fix s3 schemas for external resources

### DIFF
--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -147,8 +147,6 @@ oneOf:
       - s3
       - s3-cloudfront
       - s3-sqs
-    account:
-      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
     identifier:
@@ -239,10 +237,8 @@ oneOf:
     kms_encryption:
       type: boolean
   required:
-  - account
   - identifier
   - defaults
-
 - additionalProperties: false
   properties:
     provider:

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -135,7 +135,114 @@ properties:
   secrets_prefix:
     type: string
 oneOf:
-- "$ref": "/aws/s3-1.yml"
+- additionalProperties: false
+  properties:
+    "$schema":
+      type: string
+      enum:
+      - /aws/s3-1.yml
+    provider:
+      type: string
+      enum:
+      - s3
+      - s3-cloudfront
+      - s3-sqs
+    account:
+      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
+    region:
+      "$ref": "/aws/regions-1.yml#/properties/region"
+    identifier:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    defaults:
+      type: string
+    overrides:
+      type: object
+      properties:
+        acl:
+          type: string
+          enum:
+          - private
+          - public-read
+    event_notifications:
+      type: array
+      items:
+        type: object
+        properties:
+          event_type:
+            type: array
+            items:
+              type: string
+          destination:
+            type: string
+          destination_type:
+            type: string
+            enum:
+            - sns
+            - sqs
+          filter_prefix:
+            type: string
+          filter_suffix:
+            type: string
+    sqs_identifier:
+      type: string
+    s3_events:
+      type: array
+      items:
+        type: string
+    versioning:
+      type: boolean
+    storage_class:
+      type: string
+      enum:
+      - standard
+      - reduced_redundancy
+      - standard_ia
+      - onezone_ia
+      - intelligent_tiering
+      - glacier
+      - deep_archive
+    replication_configurations:
+      type: array
+      items:
+        type: object
+        properties:
+          rule_name:
+            type: string
+          destination_bucket_identifier:
+            type: string
+          status:
+            type: string
+            enum:
+            - enabled
+            - disabled
+          storage_class:
+            type: string
+            enum:
+            - standard
+            - reduced_redundancy
+            - standard_ia
+            - onezone_ia
+            - intelligent_tiering
+            - glacier
+            - deep_archive
+        required:
+          - rule_name
+          - destination_bucket_identifier
+    bucket_policy:
+      type: object
+    output_resource_name:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
+    allow_object_tagging:
+      type: boolean
+    kms_encryption:
+      type: boolean
+  required:
+  - account
+  - identifier
+  - defaults
+
 - additionalProperties: false
   properties:
     provider:

--- a/schemas/openshift/external-resource-1.yml
+++ b/schemas/openshift/external-resource-1.yml
@@ -22,26 +22,9 @@ properties:
     type: array
     description: resources to provision
     items:
-      type: object
-      properties:
-        aws_infrastructure_access:
-          type: object
-          properties:
-            cluster:
-              "$ref": "/common-1.json#/definitions/crossref"
-              "$schemaRef": "/openshift/cluster-1.yml"
-        vpc:
-          "$ref": "/common-1.json#/definitions/crossref"
-          "$schemaRef": "/aws/vpc-1.yml"
-        image:
-          type: object
-          properties:
-            upstream:
-              type: object
-              properties:
-                instance:
-                  "$ref": "/common-1.json#/definitions/crossref"
-                  "$schemaRef": "/dependencies/jenkins-instance-1.yml"
+      oneOf:
+      - "$ref": "/aws/terraform-resource-2.yml"
+      - "$ref": "/gcp/terraform-resource-1.yml"
 oneOf:
 - additionalProperties: false
   properties:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5726

depends on https://github.com/app-sre/qontract-validator/pull/38

following the validator PR, we can define `oneOf` for `refs`.

we also move the s3 definition into terraform-resource-2 because it can not be reused (terraform-resources-2 does not require an `account`).