### PR TITLE
APPSRE-3409 add auth section for ES defaults

### DIFF
--- a/schemas/aws/elasticsearch-defaults-1.yml
+++ b/schemas/aws/elasticsearch-defaults-1.yml
@@ -102,7 +102,7 @@ properties:
         type: string
       indices.query.bool.max_clause_count:
         type: string
-# TODO: @kfischer remove this section after migration finished
+# TODO: @fishi0x01 remove this section after migration finished APPSRE-3409
 ##### START: TO REMOVE ####
   advanced_security_options:
     type: object
@@ -185,5 +185,5 @@ properties:
       - admin_user_credentials
 required:
 - "$schema"
-# TODO: @kfischer enforce auth required once migration finished
+# TODO: @fishi0x01 enforce auth required once migration finished APPSRE-3409
 #- auth

--- a/schemas/aws/elasticsearch-defaults-1.yml
+++ b/schemas/aws/elasticsearch-defaults-1.yml
@@ -102,6 +102,8 @@ properties:
         type: string
       indices.query.bool.max_clause_count:
         type: string
+# TODO: @kfischer remove this section after migration finished
+##### START: TO REMOVE ####
   advanced_security_options:
     type: object
     additionalProperties: false
@@ -132,5 +134,56 @@ properties:
         - master_user_secret
     required:
     - enabled
+##### END: TO REMOVE ####
+  auth:
+    type: object
+    additionalProperties: false
+    properties:
+      admin_user_arn:
+        description: |
+          The ARN for the admin user.
+          This option is mutually exclusive with admin_user_credentials.
+        type: string
+      admin_user_credentials:
+        description: |
+          Secret containing the user/password authentication data. It must only
+          contain the "master_user_name" and "master_user_password" keys.
+          The admin user password must be at least 8 chars long, contain at least one
+          uppercase letter, one lowercase letter, one number, and one special character.
+          This option is mutually exclusive with admin_user_arn.
+        type: object
+        additionalProperties: false
+        properties:
+          path:
+            type: string
+          version:
+            type: integer
+        required:
+        - path
+        - version
+    oneOf:
+    - additionalProperties: false
+      properties:
+        admin_user_arn:
+          type: string
+      required:
+      - admin_user_arn
+    - additionalProperties: false
+      properties:
+        admin_user_credentials:
+          type: object
+          additionalProperties: false
+          properties:
+            path:
+              type: string
+            version:
+              type: integer
+          required:
+          - path
+          - version
+      required:
+      - admin_user_credentials
 required:
 - "$schema"
+# TODO: @kfischer enforce auth required once migration finished
+#- auth


### PR DESCRIPTION
Add an `auth` section for TF managed ES domains.

This is the beginning of transitioning all existing ES domains towards an auth scheme. Thus, this change is fully backwards compatible with existing ES domains.
Once migration with existing ES domains is done, we will:

- make `auth` section a requirement.
- remove `advanced_security_options` block. For compliance reasons this is not a free customer choice any longer.