### PR TITLE
Delete field for SQL Query - APPSRE-3787

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2385,6 +2385,7 @@
   - { name: overrides, type: SqlEmailOverrides_v1 }
   - { name: output, type: string, isRequired: true }
   - { name: schedule, type: string }
+  - { name: delete, type: boolean }
   - { name: query, type: string }
   - { name: queries, type: string, isList: true }
 

--- a/schemas/app-interface/app-interface-sql-query-1.yml
+++ b/schemas/app-interface/app-interface-sql-query-1.yml
@@ -39,6 +39,8 @@ properties:
   schedule:
     type: string
     pattern: '(((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*) ?){5}'
+  delete:
+    type: boolean
   query:
     "$ref": "/common-1.json#/definitions/query"
   queries:


### PR DESCRIPTION
Part of [APPSRE-3787](https://issues.redhat.com/browse/APPSRE-3787), this adds a `delete:` parameter for CronJob SQL queries so that they can be removed after being created in an automated manner. 