### PR TITLE
Add rosa-authenticator infrastructure support

### DIFF
--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -968,5 +968,38 @@ oneOf:
   required:
   - identifier
   - name
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+        - rosa-authenticator
+    account:
+      "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
+    identifier:
+      type: string
+    api_proxy_uri:
+      type: string
+    sms_role_ext_id:
+      type: string
+    cognito_callback_bucket_name:
+      type: string
+    defaults:
+      type: string
+    pre_signup_lambda_github_release_url:
+      type: string
+    region:
+      "$ref": "/aws/regions-1.yml#/properties/region"
+    output_resource_name:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    annotations:
+      "$ref": "/common-1.json#/definitions/annotations"
+  required:
+    - account
+    - identifier
+    - api_proxy_uri
+    - sms_role_ext_id
+    - cognito_callback_bucket_name
+    - defaults
 required:
 - provider


### PR DESCRIPTION
This MR adds support for multiple terraform resource creation via Terrascript -> Terraform.

This MR depends on MR #38690 in Gitlab, the design document documenting the use case and technical decisions that go into this change.

In addition, this MR will depend on updates to qontract-schemas (https://github.com/app-sre/qontract-schemas/pull/151), forcing default value requirements for associated yaml files. 

App-interface representation of new resources:

```
terraformResources:

- provider: rosa-authenticator
  account: appsrefrp01ugw1
  identifier: rosa-cognito
  domain: cognito.fedramp.devshift.net
  sms_role_ext_id: foobar
  defaults: /terraform/rosa-authenticator-1.yml
```