### PR TITLE
Change description of architectureDocument

### DIFF
--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -58,8 +58,12 @@ properties:
     type: string
     format: uri
     description: |
-      Link to the architectureDocument. This can be a git link or a link to a
-      Google Doc.
+      The Architecture Document should be written with SREs as the target audience. Anyone
+      reading the Architecture Document should understand how the service works, even
+      without any prior background. This document will be the primary reference during
+      incidents. To ensure the Architecture Document is always accessible to SREs and its
+      changes properly reviewed and tracked, it must be written in markdown and stored in
+      a place where SREs can control its changes.
 
   parentApp:
     "$ref": "/common-1.json#/definitions/crossref"


### PR DESCRIPTION
Following contract changes, we want this to be a read-only markdown
document. We currently cannot enforce it via a regex
because we still have a lot of TODOs and some docs in google.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>