### PR TITLE
make app-interface-sql-query name unique

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2412,7 +2412,7 @@ confs:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
-  - { name: name, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: namespace, type: Namespace_v1, isRequired: true }
   - { name: identifier, type: string, isRequired: true }
   - { name: requestor, type: User_v1 }


### PR DESCRIPTION
PR checks can fail a lot faster if the uniqueness is enforced on the schema and detected during bundling instead of a dry run of the integration

ref: https://issues.redhat.com/browse/APPSRE-5973

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>