### PR TITLE
Add schema support for creating SNS topics and RDS event notification

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -995,6 +995,12 @@ confs:
   - { name: filter_prefix, type: string}
   - { name: filter_suffix, type: string}
 
+- name: AWSRDSEventNotification_v1
+  fields:
+  - { name: destination, type: string, isRequired: true}
+  - { name: source_type, type: string}
+  - { name: event_categories, type: string, isList: true}
+
 - name: TerraformState_v1
   isInterface: true
   interfaceResolve:
@@ -1140,6 +1146,7 @@ confs:
       secrets-manager-service-account: NamespaceTerraformResourceSecretsManagerServiceAccount_v1
       aws-iam-role: NamespaceTerraformResourceRole_v1
       sqs: NamespaceTerraformResourceSQS_v1
+      sns: NamespaceTerraformResourceSNSTopic_v1
       dynamodb: NamespaceTerraformResourceDynamoDB_v1
       ecr: NamespaceTerraformResourceECR_v1
       s3-cloudfront: NamespaceTerraformResourceS3CloudFront_v1
@@ -1270,6 +1277,7 @@ confs:
   - { name: replica_source, type: string }
   - { name: ca_cert, type: VaultSecret_v1 }
   - { name: annotations, type: json }
+  - { name: event_notifications, type: AWSRDSEventNotification_v1, isList: true}
 
 - name: NamespaceTerraformResourceS3_v1
   interface: NamespaceTerraformResourceAWS_v1
@@ -1362,6 +1370,25 @@ confs:
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: specs, type: SQSQueuesSpecs_v1, isRequired: true, isList: true }
   - { name: annotations, type: json }
+
+- name: NamespaceTerraformResourceSNSSubscription_v1
+  fields:
+  - { name: protocol, type: string, isRequired: true }
+  - { name: endpoint, type: string, isRequired: true}
+
+- name: NamespaceTerraformResourceSNSTopic_v1
+  interface: NamespaceTerraformResourceAWS_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: defaults, type: string, isResource: true, isRequired: true }
+  - { name: region, type: string }
+  - { name: identifier, type: string, isRequired: true }
+  - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
+  - { name: fifo_topic, type: boolean }
+  - { name: inline_policy, type: json }
+  - { name: annotations, type: json }
+  - { name: subscriptions, type: NamespaceTerraformResourceSNSSubscription_v1, isList: true}
 
 - name: DynamoDBTableSpecs_v1
   fields:

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -160,6 +160,17 @@ properties:
     type: string
   pre_signup_lambda_github_release_url:
     type: string
+  subscriptions:
+    type: array
+    items:
+      type: object
+      properties:
+        protocol:
+          type: string
+          enum:
+          - email
+        endpoint:
+          type: string 
 oneOf:
 - additionalProperties: false
   properties:
@@ -470,6 +481,26 @@ oneOf:
       "$ref": "/common-1.json#/definitions/vaultSecret"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
+    event_notifications:
+      type: array
+      items:
+        type: object
+        properties:
+          destination:
+            type: string
+          source_type:
+            type: string
+            enum:
+            - db-instance
+            - db-security-group
+            - db-parameter-group
+            - db-snapshot
+            - db-cluster
+            - db-cluster-snapshot
+          event_categories:
+            type: array
+            items:
+              type: string
   required:
   - identifier
   - defaults
@@ -555,6 +586,42 @@ oneOf:
   required:
   - identifier
   - specs
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - sns
+    defaults:
+      "$ref": "/common-1.json#/definitions/resourceref"
+    region:
+      "$ref": "/aws/regions-1.yml#/properties/region"
+    identifier:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_resource_name:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
+    fifo_topic:
+       type: boolean
+    inline_policy:
+       type: object
+    annotations:
+      "$ref": "/common-1.json#/definitions/annotations"
+    subscriptions:
+      type: array
+      items:
+        type: object
+        properties:
+          protocol:
+            type: string
+            enum:
+            - email
+          endpoint:
+            type: string
+  required:
+  - identifier
+  - defaults
 - additionalProperties: false
   properties:
     provider:


### PR DESCRIPTION
#### What:
* Add schema support for creating SNS topics
* Add schema support for creating  RDS event subscription to SNS topics

#### Why:
<!--- Please include the context and background for your change. 
For example, why are you requesting this permission, any 
justification or approval you can provide is helpful. -->
We want to provide tenants the ability to be able subscribe to email notifications about their RDS instances's activity. 
Design doc [here](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/rds-upgrades-and-maintenance.md#database-maintenance-notifications).

#### Validation:
* Running terraform-resources integration through dry-run mode and check the output consistent with the yml defined in open source App Interface.
* Running the integration without dry-run mode against ter-int-dev AWS account and was able to see SNS topics and RDS event subscriptions created( and deleted) as intended.
yml that was used:
```
externalResources:
  - provider: aws
    provisioner:
      $ref: /aws/app-int-example/account.yml
    resources:
    - provider: rds
      identifier: app-int-example-01
      defaults: /terraform/rds/free-tier-1.yml
      output_resource_name: db-creds
      overrides:
        publicly_accessible: true
      event_notifications:
        - destination: test-sns-1
          source_type: db-instance
          event_categories: 
            - creation 
            - deletion
    - provider: sns
      identifier: test-sns-1
      defaults: /terraform/sns/sns-1.yml
      subscriptions:
        - protocol: email
          endpoint: foo@redhat.com
```