### PR TITLE
schema for service maintenances

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3857,6 +3857,7 @@ confs:
   - { name: ocm_environments_v1, type: OpenShiftClusterManagerEnvironment_v1, isList: true, isRequired: true, datafileSchema: /openshift/openshift-cluster-manager-environment-1.yml }
   - { name: status_page_v1, type: StatusPage_v1, isList: true, datafileSchema: /dependencies/status-page-1.yml }
   - { name: status_page_component_v1, type: StatusPageComponent_v1, isList: true, datafileSchema: /dependencies/status-page-component-1.yml }
+  - { name: maintenance_v1, type: Maintenance_v1, isList: true, datafileSchema: /app-sre/maintenance-1.yml }
   - { name: endpoint_monitoring_provider_v1, type: EndpointMonitoringProvider_v1, isList: true, isInterface: true, datafileSchema: /dependencies/endpoint-monitoring-provider-1.yml }
   - { name: change_types_v1, type: ChangeType_v1, isList: true, datafileSchema: /app-interface/change-type-1.yml }
   - { name: scorecards_v2, type: Scorecard_v2, isList: true, datafileSchema: /app-sre/scorecard-2.yml }
@@ -4219,6 +4220,41 @@ confs:
   fields:
   - { name: exclude, type: string, isList: true }
 
+- name: Maintenance_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: title, type: string, isRequired: true }
+  - { name: stage, type: string, isRequired: true }
+  - { name: affectedServices, type: App_v1, isList: true, isRequired: true }
+  - { name: scheduledStart, type: string, isRequired: true }
+  - { name: scheduledEnd, type: string }
+  - { name: announcements, type: MaintenanceAnnouncement_v1, isInterface: true, isList: true }
+
+- name: MaintenanceAnnouncement_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      statuspage: MaintenanceStatuspageAnnouncement_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+
+- name: MaintenanceStatuspageAnnouncement_v1
+  fields:
+  - { name: "provider", type: string, isRequired: true }
+  - { name: "announceAt", type: string, isRequired: true }
+  - { name: "message", type: string, isRequired: true }
+  - { name: "remindSubscribers", type: boolean }
+  - { name: "notifySubscribersOnStart", type: boolean }
+  - { name: "notifySubscribersOnCompletion", type: boolean }
+  - name: statuspageComponents
+    type: StatusPageComponent_v1
+    isList: true
+    synthetic:
+      schema: /dependencies/status-page-component-1.yml
+      subAttr: status.maintenance
+
 - name: EndpointMonitoringProvider_v1
   isInterface: true
   interfaceResolve:
@@ -4286,6 +4322,7 @@ confs:
     fieldMap:
       prometheus-alerts: PrometheusAlertsStatusProvider_v1
       manual: ManualStatusProvider_v1
+      maintenance: MaintenanceStatusProvider_v1
   fields:
   - { name: provider, type: string, isRequired: true }
 
@@ -4568,3 +4605,9 @@ confs:
   - { name: default_version, type: string, isRequired: true}
   - { name: reconcile_drift_interval_minutes, type: string, isRequired: true}
   - { name: reconcile_timeout_minutes, type: string, isRequired: true}
+
+- name: MaintenanceStatusProvider_v1
+  interface: StatusProvider_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: maintenance, type: Maintenance_v1, isRequired: true }

--- a/schemas/app-sre/maintenance-1.yml
+++ b/schemas/app-sre/maintenance-1.yml
@@ -1,0 +1,92 @@
+---
+"$schema": /metaschema-1.json
+version: "1.0"
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /app-sre/maintenance-1.yml
+  name:
+    type: string
+    description: the name of the maintenance
+  title:
+    type: string
+    description: the display name of the maintenance, e.g. visible name on status page
+  stage:
+    type: string
+    description: the current stage the maintenance is in
+    enum:
+    - scheduled
+    - in_progress
+    - verifying
+    - completed
+  affectedServices:
+    type: array
+    items:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/app-sre/app-1.yml"
+  scheduledStart:
+    type: string
+    format: date-time
+  scheduledEnd:
+    type: string
+    format: date-time
+  anouncements:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        provider:
+          type: string
+          enum:
+          - statuspage
+        announceAt:
+          type: string
+          format: date-time
+          description: the date and time when the maintenance will be announced
+        message:
+          type: string
+          description: a message describing the maintenance
+        remindSubscribers:
+          type: boolean
+        notifySubscribersOnStart:
+          type: boolean
+        notifySubscribersOnCompletion:
+          type: boolean
+      required:
+      - provider
+      - announceAt
+      - message
+    oneOf:
+    - properties:
+        provider:
+          type: string
+          enum:
+          - statuspage
+        announceAt:
+          type: string
+          format: date-time
+          description: the date and time when the maintenance will be announced
+        message:
+          type: string
+          description: a message describing the maintenance
+        remindSubscribers:
+          type: boolean
+        notifySubscribersOnStart:
+          type: boolean
+        notifySubscribersOnCompletion:
+          type: boolean
+      required:
+      - provider
+      - announceAt
+      - message
+required:
+- name
+- title
+- stage
+- affectedServices
+- scheduledStart

--- a/schemas/dependencies/status-provider-1.yml
+++ b/schemas/dependencies/status-provider-1.yml
@@ -54,6 +54,9 @@ properties:
         format: date-time
     required:
     - componentStatus
+  maintenance:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/openshift/namespace-1.yml"
 oneOf:
 - additionalProperties: false
   properties:
@@ -129,6 +132,18 @@ oneOf:
       - componentStatus
   required:
   - manual
+
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - maintenance
+    maintenance:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/openshift/namespace-1.yml"
+  required:
+  - maintenance
 
 required:
 - provider

--- a/schemas/dependencies/status-provider-1.yml
+++ b/schemas/dependencies/status-provider-1.yml
@@ -141,7 +141,7 @@ oneOf:
       - maintenance
     maintenance:
       "$ref": "/common-1.json#/definitions/crossref"
-      "$schemaRef": "/openshift/namespace-1.yml"
+      "$schemaRef": "/app-sre/maintenance-1.yml"
   required:
   - maintenance
 


### PR DESCRIPTION
the new schema `/app-sre/maintenance-1.yml` tracks details for maintenances, their time windows and announcements.

```yaml
$schema: /app-sre/maintenance-1.yml
name: maintenance name
title: Maintenance for xxx
stage: scheduled | in_progress | verifying | completed
affectedServices:
- $ref: to service
scheduledStart: ISO timestamp
scheduledEnd: ISO timestamp
announcements:
- provider: statuspage
  announceAt: ISO timestamp
  message: a message describing the maintenance on the status page
  statuspage:
    remindSubscribers: true | false
    notifySubscribersOnStart: true | false
    notifySubscribersOnCompletion: true | false
```

`/dependencies/status-page-component-1.yml` can participate in a maintenance by referencing it in their `/dependencies/status-provider-1.yml` section  and have their status managed for the time of the maintenance.

```yaml
$schema: /dependencies/status-page-component-1.yml
...
status:
- provider: maintenance
  maintenance:
    $ref: ref-to-maintenance.yaml
```

part of https://issues.redhat.com/browse/APPSRE-3906
design doc: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/maintenances.md