### PR TITLE
enable resource resolution on jenkins-config.config_path

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -385,7 +385,7 @@ confs:
   - { name: instance, type: JenkinsInstance_v1, isRequired: true }
   - { name: type, type: string, isRequired: true }
   - { name: config, type: json }
-  - { name: config_path, type: string, isResource: true }
+  - { name: config_path, type: string, isResource: true, resolveResource: true }
 
 - name: JiraServer_v1
   fields:


### PR DESCRIPTION
this enables writing queries for jenkins-config-1.config_path like

```
{
  jenkins_configs: jenkins_configs_v1 {
    name
    ...
    type
    config
    config_path {
      content
    }
  }
}
```

part of https://issues.redhat.com/browse/APPSRE-6003
follows up on https://issues.redhat.com/browse/APPSRE-5950

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>