### PR TITLE
add pagerduty reference to gitlab-membership permissions

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2162,6 +2162,13 @@ confs:
   - { name: service, type: string, isRequired: true }
   - { name: group, type: string, isRequired: true}
   - { name: access, type: string, isRequired: true}
+  - { name: pagerduty, type: PagerDutyTarget_v1, isList: true }
+  - name: roles
+    type: Role_v1
+    isList: true
+    synthetic:
+      schema: /access/role-1.yml
+      subAttr: permissions
 
 - name: PermissionSlackUsergroup_v1
   interface: Permission_v1

--- a/schemas/access/permission-1.yml
+++ b/schemas/access/permission-1.yml
@@ -111,6 +111,11 @@ oneOf:
       - "developer"
       - "reporter"
       - "guest"
+    pagerduty:
+      type: array
+      items:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "/dependencies/pagerduty-target-1.yml"
   required:
   - group
   - access


### PR DESCRIPTION
to allow populating gitlab groups based on pagerduty schedules.
think @app-sre-ic, but in an app-interface merge request.