### PR TITLE
allow saas file target to be inlined or referenced

### DIFF
--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -94,7 +94,12 @@ properties:
         targets:
           type: array
           items:
-            "$ref": "/app-sre/saas-file-target-1.yml"
+            oneOf:
+            # inline
+            - "$ref": "/app-sre/saas-file-target-1.yml"
+            # referenced
+            - "$ref": "/common-1.json#/definitions/crossref"
+              "$schemaRef": "/app-sre/saas-file-target-1.yml"
       required:
       - name
       - url


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-validator/pull/41

follows up on #199

with this change, saas file targets can either be inlined or referenced.

this change introduces an issue for `saas-file-owners`, such that tenants will not be able to lgtm their own promotions. i'd like to merge this and work on a PoC to make it feasible. before that happens, we will not allow this usage for tenants.