### PR TITLE
add allowed secret parameter paths

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -877,6 +877,7 @@ confs:
   - { name: resourcesDefaultRegion, type: string, isRequired: true }
   - { name: supportedDeploymentRegions, type: string, isList: true }
   - { name: providerVersion, type: string, isRequired: true }
+  - { name: qontractReconcileVersion, type: string }
   - { name: terraformUsername, type: string }
   - { name: accountOwners, type: Owner_v1, isList: true, isRequired: true }
   - { name: automationToken, type: VaultSecret_v1, isRequired: true }
@@ -1894,6 +1895,7 @@ confs:
   - { name: managedResourceTypes, type: string, isRequired: true, isList: true }
   - { name: authentication, type: SaasFileAuthentication_v1 }
   - { name: parameters, type: json }
+  - { name: allowedSecretParameterPaths, type: string, isList: true }
   - { name: secretParameters, type: SaasSecretParameters_v1, isList: true }
   - { name: resourceTemplates, type: SaasResourceTemplate_v2, isRequired: true, isList: true }
   - { name: imagePatterns, type: string, isRequired: true, isList: true }

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -58,6 +58,10 @@ properties:
         "$ref": "/common-1.json#/definitions/vaultSecret"
   parameters:
     type: object
+  allowedSecretParameterPaths:
+    type: array
+    items:
+      type: string
   secretParameters:
     type: array
     description: saas file level parameters from vault secrets


### PR DESCRIPTION
to allow full self-service over saas file secretParameters, we still want to control the paths of the secrets that will be used.

with this schema, we enable defining a list of strings which are paths that are allowed.

as long as secret parameters are added/updated within the allowed path, we enable full self-service.