### PR TITLE
enable support for gitlab-housekeeping to only accept labels from users in specific roles

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1778,6 +1778,11 @@ confs:
   - { name: limit, type: int }
   - { name: enable_closing, type: boolean }
   - { name: pipeline_timeout, type: int }
+  - { name: labels_allowed, type: CodeComponentGitlabHousekeepingLabelsAllowed_v1, isList: true }
+
+- name: CodeComponentGitlabHousekeepingLabelsAllowed_v1
+  fields:
+  - { name: role, type: Role_v1, isRequired: true }
 
 - name: AppCodeComponents_v1
   fields:

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -315,6 +315,17 @@ properties:
               type: boolean
             pipeline_timeout:
               type: integer
+            labels_allowed:
+              type: array
+              items:
+                type: object
+                additionalProperties: false
+                properties:
+                  role:
+                    "$ref": "/common-1.json#/definitions/crossref"
+                    "$schemaRef": "/access/role-1.yml"
+                required:
+                - role
           required:
           - enabled
           - rebase


### PR DESCRIPTION
with this change, we enable the definition of roles per repos. users who have these roles will not be prohibited from adding labels.

this is to handle users with Developer access adding labels to MRs.