### PR TITLE
resource and datafile ownership

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -283,6 +283,14 @@ confs:
   - { name: type, type: string, isRequired: true }
   - { name: jsonpath, type: string, isRequired: true }
 
+- name: DatafileObject_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: schema
+  fields:
+  - { name: path, type: string, isRequired: true }
+  - { name: schema, type: string, isRequired: true }
+
 - name: VaultSecret_v1
   fields:
   - { name: path, type: string, isRequired: true }
@@ -1829,6 +1837,7 @@ confs:
       subAttr: environment
 
 - name: App_v1
+  datafile: /app-sre/app-1.yml
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
@@ -1889,6 +1898,7 @@ confs:
       subAttr: app
 
 - name: SaasFile_v2
+  datafile: /app-sre/saas-file-2.yml
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
@@ -2358,6 +2368,7 @@ confs:
   - { name: sentry_roles, type: SentryRole_v1, isList: true }
   - { name: sendgrid_accounts, type: SendGridAccount_v1, isList: true }
   - { name: owned_saas_files, type: SaasFile_v2, isList: true }
+  - { name: self_service, type: SelfServiceConfig_v1, isList: true }
   - name: users
     type: User_v1
     isList: true
@@ -2370,6 +2381,12 @@ confs:
     synthetic:
       schema: /access/bot-1.yml
       subAttr: roles
+
+- name: SelfServiceConfig_v1
+  fields:
+  - { name: datafiles, type: DatafileObject_v1, isList: true, isInterface: true }
+  - { name: resources, type: string, isList: true, isResource: true }
+  - { name: description, type: string }
 
 - name: IntegrationPrCheck_v1
   fields:

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -117,6 +117,31 @@ properties:
             type: string
             enum:
             - "/app-sre/saas-file-2.yml"
+  self_service:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        description:
+          type: string
+        resources:
+          type: array
+          items:
+            "$ref": "/common-1.json#/definitions/resourceref"
+        datafiles:
+          type: array
+          items:
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef":
+              type: object
+              properties:
+                '$schema':
+                  type: string
+                  enum:
+                  - /app-sre/saas-file-2.yml
+                  - /openshift/namespace-1.yml
+                  - /access/role-1.yml
 required:
 - $schema
 - labels

--- a/schemas/app-interface/graphql-schemas-1.yml
+++ b/schemas/app-interface/graphql-schemas-1.yml
@@ -40,6 +40,7 @@ definitions:
             type: string
             enum:
             - "fieldMap"
+            - "schema"
           field:
             type: string
           fieldMap:


### PR DESCRIPTION
introduce a generic interface `DatafileObject_v1` all datafile types automatically implement (in additional to potential other interfaces they declare). the assignment of the interface to datafile types happens automatically during bundle loading in `qontract-server`. object resolution during query time is achieved by the `interfaceResolve.strategy = schema` strategy based on the `datafile` defined for a type. this type enables mixed-type fields in graphql types where various types can be assigned.

this generic interface can be used to collect all kinds of objects in a list. 

first usecase will be declaring ownership for datafiles.

```yaml
---
$schema: /access/role-1.yml
...
self_service:
- description: AppSRE services
  datafiles:
  - $ref: /services/github-mirror/cicd/deploy.yaml
  - $ref: /services/github-mirror/cicd/test.yaml
  [other things like changetypes will go here]
  resources:
  - /app-sre/app-interface-production/qontract-api.configmap.yaml
  [other things like changetypes will go here]
```

and make them queryable like this

```
{
  roles_v1 {
    self_service {
      description
      datafiles {
        path
      }
      resources
    }
  }
}
```

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>