### PR TITLE
[integration] early exit feature for pr-check dry runs

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2380,6 +2380,7 @@ confs:
   - { name: always_run, type: boolean }
   - { name: no_validate_schemas, type: boolean }
   - { name: run_for_valid_saas_file_changes, type: boolean }
+  - { name: early_exit, type: boolean }
 
 - name: IntegrationSpecExtraEnv_v1
   fields:

--- a/schemas/app-sre/integration-1.yml
+++ b/schemas/app-sre/integration-1.yml
@@ -53,6 +53,8 @@ properties:
         type: boolean
       run_for_valid_saas_file_changes:
         type: boolean
+      early_exit:
+        type: boolean
     required:
     - cmd
 


### PR DESCRIPTION
the flag `/app-sre/integration-1.yml#pr_check.early_exit` controls if an integration will exit early from the potentially long running PR check dry-run if it can detect that there has been no change in desired state. the integration needs to support early exit, otherwise the flag has no effect.

q-r change: https://github.com/app-sre/qontract-reconcile/pull/2672
part of: https://issues.redhat.com/browse/APPSRE-6098

```yaml
$schema: /app-sre/integration-1.yml

name: terraform-vpc-peerings

pr_check:
  cmd: terraform-vpc-peerings
  early_exit: true
```

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>