### PR TITLE
add issue reopen state

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -431,6 +431,7 @@ confs:
   - { name: severityPriorityMappings, type: JiraSeverityPriorityMappings_v1, isRequired: true }
   - { name: slack, type: SlackOutput_v1 }
   - { name: issueResolveState, type: string }
+  - { name: issueReopenState, type: string }
 
 - name: SendGridAccount_v1
   fields:

--- a/schemas/dependencies/jira-board-1.yml
+++ b/schemas/dependencies/jira-board-1.yml
@@ -33,6 +33,8 @@ properties:
     - workspace
   issueResolveState:
     type: string
+  issueReopenState:
+    type: string
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
Some jira boards don't have default `To Do` state. This change allows us to define reopen state per jira board. 

Setting correct value will result into successful Jira API calls, thereby reducing the no of calls to Jira (because Alertmanager loves to retry on 500 errors)

Related:[ APPSRE-5712](https://issues.redhat.com/browse/APPSRE-5712)