### PR TITLE
remove throughout for ebs_options

### DIFF
--- a/schemas/aws/elasticsearch-defaults-1.yml
+++ b/schemas/aws/elasticsearch-defaults-1.yml
@@ -18,15 +18,14 @@ properties:
         type: boolean
       iops:
         type: integer
-      throughput:
-        type: integer
       volume_size:
         type: integer
       volume_type:
         type: string
         enum:
+        - standard
         - gp2
-        - gp3
+        - io1
     required:
     - ebs_enabled
   encrypt_at_rest:


### PR DESCRIPTION
partly revert https://github.com/app-sre/qontract-schemas/pull/221

gp3 and throughput dose not supported by terraform aws provider 3.75.2

Signed-off-by: Feng Huang <fehuang@redhat.com>