### PR TITLE
add support to enable query support

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1062,6 +1062,7 @@ confs:
   - { name: validate_json, type: boolean }
   - { name: validate_alertmanager_config, type: boolean }
   - { name: alertmanager_config_key, type: string }
+  - { name: enable_query_support, type: boolean }
 
 - name: NamespaceOpenshiftResourceResourceTemplate_v1
   interface: NamespaceOpenshiftResource_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1073,6 +1073,7 @@ confs:
   - { name: variables, type: json }
   - { name: validate_alertmanager_config, type: boolean }
   - { name: alertmanager_config_key, type: string }
+  - { name: enable_query_support, type: boolean }
 
 - name: NamespaceOpenshiftResourceVaultSecret_v1
   interface: NamespaceOpenshiftResource_v1

--- a/schemas/openshift/openshift-resource-1.yml
+++ b/schemas/openshift/openshift-resource-1.yml
@@ -19,6 +19,9 @@ properties:
     type: boolean
   alertmanager_config_key:
     type: string
+  enable_query_support:
+    type: boolean
+    description: indicates that this resource is using graphql query results
   type:
     type: string
   variables:
@@ -51,6 +54,9 @@ oneOf:
       type: boolean
     alertmanager_config_key:
       type: string
+    enable_query_support:
+      type: boolean
+      description: indicates that this resource is using graphql query results
   required:
   - path
 - additionalProperties: false

--- a/schemas/openshift/openshift-resource-1.yml
+++ b/schemas/openshift/openshift-resource-1.yml
@@ -78,6 +78,9 @@ oneOf:
       type: boolean
     alertmanager_config_key:
       type: string
+    enable_query_support:
+      type: boolean
+      description: indicates that this resource is using graphql query results
   required:
   - path
 - additionalProperties: false


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-6098

to speed up openshift-resources (and prometheus-rules-tester) early-exit, we need to skip as many resources as possible.

resources with dynamic content (generated based on graphql query results) must be checked, but only them.
with this field, we will know exactly the ones to check. we will add a validation that if the query() function is used, this option must be set to true.