### PR TITLE
resolvable resource references for openshift-resources

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1058,7 +1058,7 @@ confs:
   interface: NamespaceOpenshiftResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: path, type: string, isRequired: true, isResource: true }
+  - { name: path, type: string, isRequired: true, isResource: true, resolveResource: true }
   - { name: validate_json, type: boolean }
   - { name: validate_alertmanager_config, type: boolean }
   - { name: alertmanager_config_key, type: string }
@@ -1068,7 +1068,7 @@ confs:
   interface: NamespaceOpenshiftResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: path, type: string, isRequired: true, isResource: true }
+  - { name: path, type: string, isRequired: true, isResource: true, resolveResource: true }
   - { name: type, type: string }
   - { name: variables, type: json }
   - { name: validate_alertmanager_config, type: boolean }
@@ -1092,7 +1092,7 @@ confs:
   interface: NamespaceOpenshiftResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: path, type: string, isRequired: true, isResource: true }
+  - { name: path, type: string, isRequired: true, isResource: true, resolveResource: true }
   - { name: vault_tls_secret_path, type: string }
   - { name: vault_tls_secret_version, type: int }
 


### PR DESCRIPTION
in order to improve performance for openshift-resources related integrations and their early-exit mode, their resources will be fetched inline along with the rest of the data instead of sequential reads.

it is crucial to align the rollout of this schema change with the qontract-reconcile integration using those fields (openshift-resources, openshift-routes, prometheus-rules-tester).

relates to https://issues.redhat.com/browse/APPSRE-6098

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>