### PR TITLE
Add domain_name option for DNS zones

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2741,6 +2741,7 @@ confs:
   - { name: schema, type: string, isRequired: true }
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
+  - { name: domain_name, type: string }
   - { name: description, type: string, isRequired: true }
   - { name: provider, type: string, isRequired: true }
   - { name: account, type: AWSAccount_v1, isRequired: true }

--- a/schemas/dependencies/dns-zone-1.yml
+++ b/schemas/dependencies/dns-zone-1.yml
@@ -13,6 +13,8 @@ properties:
     "$ref": "/common-1.json#/definitions/labels"
   name:
     type: string
+  domain_name:
+    type: string
   description:
     type: string
   account:


### PR DESCRIPTION
[APPSRE-6143](https://issues.redhat.com/browse/APPSRE-6143)

Currently, Route 53 DNS zones have a 1:1 correspondence between the domain name the route they are defined for, and their App Interface representation. This adds an optional `domain_name` field which lets you define a different `name` for the zone so that you can have two Route 53 Zones which refer to the same domain name but have different App Interface and Terraform identifiers. This is in order to support [split-view DNS](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-considerations.html#hosted-zone-private-considerations-split-view-dns).

QR change here: https://github.com/app-sre/qontract-reconcile/pull/2750