### PR TITLE
introduce saas file deprecation

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1947,6 +1947,7 @@ confs:
   - { name: resourceTemplates, type: SaasResourceTemplate_v2, isRequired: true, isList: true }
   - { name: imagePatterns, type: string, isRequired: true, isList: true }
   - { name: takeover, type: boolean }
+  - { name: deprecated, type: boolean }
   - { name: compare, type: boolean }
   - { name: publishJobLogs, type: boolean }
   - { name: clusterAdmin, type: boolean }

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -111,6 +111,9 @@ properties:
       - targets
   takeover:
     type: boolean
+  deprecated:
+    type: boolean
+    description: prevent updates to a saas file
   compare:
     type: boolean
   publishJobLogs:


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-6021

saas file deprecation indicates a saas file is being deprecated. with qontract-reconcile implementation, this field being true may mean that a saas file can no longer receive updates, and users will be forced to migrate resources out of it. at the very least, we can output a deprecation message.