### PR TITLE
aws: Allow 'release' as a ref for the asg image

### DIFF
--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -1026,7 +1026,7 @@ oneOf:
             ref:
               description: commit or branch name
               type: string
-              pattern: '^([0-9a-f]{40}|master|main)$'
+              pattern: '^([0-9a-f]{40}|master|main|release)$'
             upstream:
               description: jenkins instance and job to wait for
               type: object


### PR DESCRIPTION
This upstream ref is resolved and used to find the image with a tag containing the resolved ref.

---

Context:
Our upstream now contains the https://github.com/osbuild/osbuild-composer/tree/release ref, which tracks the commits on main for which CI has passed. Due to the size of our CI having a proper merge queue is impractical, so unrebased PRs break composer's main branch now and then. But with this band-aid in place, stage can track upstream again (mostly anyway, currently the ref is pinned). 