### PR TITLE
[APPSRE-4798] Add old_parameter_group for rds provider

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1312,6 +1312,7 @@ confs:
   - { name: defaults, type: string, isRequired: true, isResource: true }
   - { name: availability_zone, type: string }
   - { name: parameter_group, type: string }
+  - { name: new_parameter_group, type: string }
   - { name: overrides, type: json }
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1312,7 +1312,7 @@ confs:
   - { name: defaults, type: string, isRequired: true, isResource: true }
   - { name: availability_zone, type: string }
   - { name: parameter_group, type: string }
-  - { name: new_parameter_group, type: string }
+  - { name: old_parameter_group, type: string }
   - { name: overrides, type: json }
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -43,7 +43,7 @@ properties:
     type: string
   parameter_group:
     type: string
-  new_parameter_group:
+  old_parameter_group:
     type: string
   region:
     "$ref": "/aws/regions-1.yml#/properties/region"
@@ -395,7 +395,7 @@ oneOf:
       "$ref": "/common-1.json#/definitions/resourceref"
     parameter_group:
       type: string
-    new_parameter_group:
+    old_parameter_group:
       type: string
     overrides:
       type: object
@@ -511,7 +511,7 @@ oneOf:
   - identifier
   - defaults
   dependencies:
-    new_parameter_group:
+    old_parameter_group:
     - parameter_group
 - additionalProperties: false
   properties:

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -510,6 +510,9 @@ oneOf:
   required:
   - identifier
   - defaults
+  dependencies:
+    new_parameter_group:
+    - parameter_group
 - additionalProperties: false
   properties:
     provider:

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -43,6 +43,8 @@ properties:
     type: string
   parameter_group:
     type: string
+  new_parameter_group:
+    type: string
   region:
     "$ref": "/aws/regions-1.yml#/properties/region"
   overrides:
@@ -392,6 +394,8 @@ oneOf:
     defaults:
       "$ref": "/common-1.json#/definitions/resourceref"
     parameter_group:
+      type: string
+    new_parameter_group:
       type: string
     overrides:
       type: object

--- a/schemas/metaschema-1.json
+++ b/schemas/metaschema-1.json
@@ -54,6 +54,9 @@
       "required": [
         "$schema"
       ]
+    },
+    "dependencies": {
+      "type": "object"
     }
   },
   "required": [


### PR DESCRIPTION
Related: APPSRE-4798

This change adds a new field `old_parameter_group` that will be used during RDS upgrades. 

This MR also introduces usage of `dependencies` as defined in json-schema RFC https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-01#section-6.21 