### PR TITLE
extract self-service config to its own schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2426,6 +2426,7 @@ confs:
 
 - name: SelfServiceConfig_v1
   fields:
+  - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
   - { name: datafiles, type: DatafileObject_v1, isList: true, isInterface: true }
   - { name: resources, type: string, isList: true, isResource: true }
   - { name: change_type, type: ChangeType_v1, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1966,6 +1966,12 @@ confs:
     synthetic:
       schema: /access/role-1.yml
       subAttr: owned_saas_files
+  - name: selfService
+    type: SelfServiceConfig_v1
+    isList: true
+    synthetic:
+      schema: /app-interface/self-service-config-1.yml
+      subAttr: datafiles
 
 - name: DeployResources_v1
   fields:
@@ -2431,6 +2437,12 @@ confs:
   - { name: resources, type: string, isList: true, isResource: true }
   - { name: change_type, type: ChangeType_v1, isRequired: true }
   - { name: description, type: string }
+  - name: roles
+    type: Role_v1
+    isList: true
+    synthetic:
+      schema: /access/role-1.yml
+      subAttr: self_service
 
 - name: IntegrationPrCheck_v1
   fields:
@@ -2663,6 +2675,7 @@ confs:
   - { name: status_page_component_v1, type: StatusPageComponent_v1, isList: true, datafileSchema: /dependencies/status-page-component-1.yml }
   - { name: endpoint_monitoring_provider_v1, type: EndpointMonitoringProvider_v1, isList: true, isInterface: true, datafileSchema: /dependencies/endpoint-monitoring-provider-1.yml }
   - { name: change_types_v1, type: ChangeType_v1, isList: true, datafileSchema: /app-interface/change-type-1.yml }
+  - { name: self_service_configs_v1, type: SelfServiceConfig_v1, isList: true, datafileSchema: /app-interface/self-service-config-1.yml }
 
 - name: SentryTeam_v1
   fields:

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -120,31 +120,8 @@ properties:
   self_service:
     type: array
     items:
-      type: object
-      additionalProperties: false
-      properties:
-        description:
-          type: string
-        change_type:
-          "$ref": "/common-1.json#/definitions/crossref"
-          "$schemaRef": "/app-interface/change-type-1.yml"
-        resources:
-          type: array
-          items:
-            "$ref": "/common-1.json#/definitions/resourceref"
-        datafiles:
-          type: array
-          items:
-            "$ref": "/common-1.json#/definitions/crossref"
-            "$schemaRef":
-              type: object
-              properties:
-                '$schema':
-                  type: string
-                  enum:
-                  - /app-sre/saas-file-2.yml
-                  - /openshift/namespace-1.yml
-                  - /access/role-1.yml
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/app-interface/self-service-config-1.yml"
 required:
 - $schema
 - labels

--- a/schemas/app-interface/self-service-config-1.yml
+++ b/schemas/app-interface/self-service-config-1.yml
@@ -1,0 +1,35 @@
+---
+"$schema": /metaschema-1.json
+version: "1.0"
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /app-interface/self-service-config-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  description:
+    type: string
+  change_type:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/app-interface/change-type-1.yml"
+  resources:
+    type: array
+    items:
+      "$ref": "/common-1.json#/definitions/resourceref"
+  datafiles:
+    type: array
+    items:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef":
+        type: object
+        properties:
+          '$schema':
+            type: string
+            enum:
+            - /app-sre/saas-file-2.yml
+            - /openshift/namespace-1.yml
+            - /access/role-1.yml

--- a/schemas/app-interface/self-service-config-1.yml
+++ b/schemas/app-interface/self-service-config-1.yml
@@ -11,6 +11,8 @@ properties:
     - /app-interface/self-service-config-1.yml
   labels:
     "$ref": "/common-1.json#/definitions/labels"
+  name:
+    type: string
   description:
     type: string
   change_type:
@@ -33,3 +35,5 @@ properties:
             - /app-sre/saas-file-2.yml
             - /openshift/namespace-1.yml
             - /access/role-1.yml
+required:
+- name


### PR DESCRIPTION
this will allow us to preserve the ability to query the referencing configs from the context of an owned file, like we have today from saas files to roles.

saas file -> self-service config -> role.