### PR TITLE
add backref from saas files to roles via self_service

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1966,6 +1966,12 @@ confs:
     synthetic:
       schema: /access/role-1.yml
       subAttr: owned_saas_files
+  - name: selfServiceRoles
+    type: Role_v1
+    isList: true
+    synthetic:
+      schema: /access/role-1.yml
+      subAttr: self_service.datafiles
 
 - name: DeployResources_v1
   fields:


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-server/pull/165

replaces #244

by adding this backref we are able to find roles referencing saas files in the `self_service` section:
```
{
  saas_files_v2
  {
    name
    selfServiceRoles{
      name
    }
  }
}
```