### PR TITLE
make the change-type context.selector when condition optional

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2983,7 +2983,7 @@ confs:
 - name: ChangeTypeChangeDetectorContextSelector_v1
   fields:
   - { name: selector, type: string, isRequired: true }
-  - { name: when, type: "string", isRequired: true}
+  - { name: when, type: "string" }
 
 - name: RosaAWSSpec_v1
   fields:


### PR DESCRIPTION
semantically this will imply that the context will be extracted from a changing file without condition.

in the following example, the missing `changes.context.when` field means that this change-type becomes active whenever
* a namespace file is created on a cluster this change-type is bound to
* a namespace file is deleted from a cluster this change-type is bound to
* a namespace file belgong to a cluster is changed

the changes allowed in the namespace file still depend on the jsonpath expressions listed under `changes.jsonPathSelectors`

```yaml
changes:
- provider: jsonPath
  changeSchema: /openshift/namespace-1.yml
  jsonPathSelectors:
  - $
  context:
    selector: cluster.'$ref'
    when: null
```

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>