### PR TITLE
app endpoint names uniqueness

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1803,7 +1803,7 @@ confs:
 
 - name: AppEndPoints_v1
   fields:
-  - { name: name, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string, isRequired: true }
   - { name: url, type: string, isRequired: true }
   - { name: monitoring, type: AppEndPointMonitoring_v1, isList: true }


### PR DESCRIPTION
the app-endpoint names are used as labels in catchpoint prometheus labels and making them unique simplifies writing alerts.

referenced documentation about catchpoint based alerts - https://service.pages.redhat.com/dev-guidelines/docs/appsre/advanced/service-endpoint-monitoring/#service-endpoint-monitoring-with-catchpoint

i tested that this change will work with a-i commercial since all endpoint names are unique there already.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>