### PR TITLE
deprecate owned_saas_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ the data with a json validator (Draft-06).
 
 #### Multiple allowed schemas for a crossref
 
-What if we want to define a crossref with multiple allowed types? (owned_saas_files case in role-1)
+What if we want to define a crossref with multiple allowed types? (datafiles case in role-1#self_service)
 
 ```json
-  owned_saas_files:
+  datafiles:
     type: array
     items:
       "$ref": "/common-1.json#/definitions/crossref"
@@ -79,12 +79,13 @@ What if we want to define a crossref with multiple allowed types? (owned_saas_fi
             type: string
             enum:
               - "/app-sre/saas-file-2.yml"
+              - "/openshift/namespace-1.yml"
 ```
 
 ```yaml
-owned_saas_files:
+datafiles:
 - $ref: /services/test-saas-deployment-pipelines/cicd/deploy.yml
-- $ref: /services/test-saas-deployment-pipelines/cicd/post-deploy.yml
+- $ref: /services/test-saas-deployment-pipelines/namespaces/stage.yml
 ```
 
 With this definition, `qontract-validator` will validate that the `$schema` attribute of every entry in the list is defined within the enum.

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1960,12 +1960,6 @@ confs:
   - { name: use_channel_in_image_tag, type: boolean }
   - { name: configurableResources, type: boolean }
   - { name: deployResources, type: DeployResources_v1 }
-  - name: roles
-    type: Role_v1
-    isList: true
-    synthetic:
-      schema: /access/role-1.yml
-      subAttr: owned_saas_files
   - name: selfServiceRoles
     type: Role_v1
     isList: true
@@ -2413,7 +2407,6 @@ confs:
   - { name: sentry_teams, type: SentryTeam_v1, isList: true }
   - { name: sentry_roles, type: SentryRole_v1, isList: true }
   - { name: sendgrid_accounts, type: SendGridAccount_v1, isList: true }
-  - { name: owned_saas_files, type: SaasFile_v2, isList: true }
   - { name: self_service, type: SelfServiceConfig_v1, isList: true }
   - name: users
     type: User_v1

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -103,20 +103,6 @@ properties:
     items:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/dependencies/sendgrid-account-1.yml"
-  owned_saas_files:
-    type: array
-    description: |
-      Role owned saas files. All saas files must have an owner.
-      This list must accept all supported saas file versions by AppInterface.
-    items:
-      "$ref": "/common-1.json#/definitions/crossref"
-      "$schemaRef":
-        type: object
-        properties:
-          '$schema':
-            type: string
-            enum:
-            - "/app-sre/saas-file-2.yml"
   self_service:
     type: array
     items:


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-reconcile/pull/2805

once the reconcile PR was promoted, the removal of `owned_saas_files` from the schemas may be promoted as well (this PR).