### PR TITLE
add enum for upgrade policy allowed workloads

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -842,6 +842,7 @@ confs:
   - { name: accessTokenUrl, type: string, isRequired: true }
   - { name: offlineToken, type: VaultSecret_v1 }
   - { name: blockedVersions, type: string, isList: true }
+  - { name: upgradePolicyAllowedWorkloads, type: string, isList: true }
   - name: clusters
     type: Cluster_v1
     isList: true

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -30,6 +30,11 @@ properties:
     type: array
     items:
       type: string
+  upgradePolicyAllowedWorkloads:
+    description: List of workloads that are allowed to be defined as cluster upgrade policy mutexes
+    type: array
+    items:
+      type: string
 required:
 - "$schema"
 - labels

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -31,7 +31,7 @@ properties:
     items:
       type: string
   upgradePolicyAllowedWorkloads:
-    description: List of workloads that are allowed to be defined as cluster upgrade policy mutexes
+    description: List of workloads that are allowed to be defined as cluster upgrade policy workload
     type: array
     items:
       type: string


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-4709

with this list in place, we can add a validation that cluster upgrade policies are only using a workload name from this list.
this will help us avoid adding a "hard coded" enum to the schemas repo, which is AppSRE specific.