### PR TITLE
Add method label to prometheus schema

### DIFF
--- a/schemas/openshift/prometheus-rule-1.yml
+++ b/schemas/openshift/prometheus-rule-1.yml
@@ -120,6 +120,8 @@ properties:
                           type: string
                         latency:
                           type: string
+                        method:
+                          type: string
                         quantile:
                           type: string
                         query:


### PR DESCRIPTION
We (RHOBS) team are in the process of introducing SLOs for Rules API and Observatorium Alertmanager. 
We are now in the process to deploy alerts to stage on the related SLOs (see draft MR: [!48083](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/48083#8ad0a2beb2c177328d8b5e82470f38992db62fea_902_1061))

We would like to add a `method` label to the prometheus schema in order to better group some of our alerts (alert example with mentioned label [here](https://github.com/rhobs/configuration/blob/main/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml#L904-L920))

Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>