### PR TITLE
add option to validate resources with queries

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2566,6 +2566,7 @@ confs:
   - { name: description, type: string, isRequired: true }
   - { name: escalationPolicy, type: AppEscalationPolicy_v1, isRequired: true }
   - { name: queries, type: QontractQuery_v1, isList: true, isRequired: true }
+  - { name: resources, type: NamespaceOpenshiftResource_v1, isList: true, isInterface: true }
 
 - name: UnleashNotifications_v1
   fields:

--- a/schemas/app-interface/query-validation-1.yml
+++ b/schemas/app-interface/query-validation-1.yml
@@ -33,6 +33,10 @@ properties:
       required:
       - path
     minItems: 1
+  resources:
+    type: array
+    items:
+      "$ref": "/openshift/openshift-resource-1.yml"
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-4709

query-validator currently only validates that queries are executed successfully.

with the addition of `resources`, we can do everything we already can in `openshiftResources` (jinja2 for example). with this addition, we can validate the actual data, and not only the query results.

logic added in https://github.com/app-sre/qontract-reconcile/pull/2807