### PR TITLE
[ASG] Add max_instance_lifetime option

### DIFF
--- a/schemas/aws/asg-defaults-1.yml
+++ b/schemas/aws/asg-defaults-1.yml
@@ -24,6 +24,8 @@ properties:
       type: string
   capacity_rebalance:
     type: boolean
+  max_instance_lifetime:
+    type: integer
   instances_distribution:
     type: object
     additionalProperties: false


### PR DESCRIPTION
[APPSRE-6297](https://issues.redhat.com/browse/APPSRE-6297)

Add support for max_instance_lifetime for AWS auto-scaling groups. Such that image builder workers can be ephemeral in nature. 

QR change: https://github.com/app-sre/qontract-reconcile/pull/2839