### PR TITLE
add datafile field to graphql saas file target

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2218,13 +2218,50 @@ confs:
   - { name: hash_length, type: int }
   - { name: parameters, type: json }
   - { name: secretParameters, type: SaasSecretParameters_v1, isList: true }
-  - { name: targets, type: SaasResourceTemplateTarget_v2, isRequired: true, isList: true }
+  - { name: targets, type: SaasResourceTemplateTarget_v2, isRequired: true, isList: true, isInterface: true }
 
 - name: SaasResourceTemplateTarget_v2
   datafile: /app-sre/saas-file-target-1.yml
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: schema
+    fieldMap:
+      '/app-sre/saas-file-target-1.yml': SaasResourceTemplateTargetReference_v2
+      null: SaasResourceTemplateTargetInline_v2
+  fields:
+  - { name: name, type: string, isContextUnique: true }
+  - { name: namespace, type: Namespace_v1, isRequired: true, isContextUnique: true }
+  - { name: ref, type: string, isRequired: true }
+  - { name: promotion, type: SaasResourceTemplateTargetPromotion_v1 }
+  - { name: parameters, type: json }
+  - { name: secretParameters, type: SaasSecretParameters_v1, isList: true }
+  - { name: upstream, type: SaasResourceTemplateTargetUpstream_v1 }
+  - { name: image, type: SaasResourceTemplateTargetImage_v1 }
+  - { name: disable, type: boolean }
+  - { name: delete, type: boolean }
+
+- name: SaasResourceTemplateTargetReference_v2
+  interface: SaasResourceTemplateTarget_v2
   fields:
   - { name: path, type: string, isRequired: true }
   - { name: schema, type: string, isRequired: true }
+  - { name: name, type: string, isContextUnique: true }
+  - { name: namespace, type: Namespace_v1, isRequired: true, isContextUnique: true }
+  - { name: ref, type: string, isRequired: true }
+  - { name: promotion, type: SaasResourceTemplateTargetPromotion_v1 }
+  - { name: parameters, type: json }
+  - { name: secretParameters, type: SaasSecretParameters_v1, isList: true }
+  - { name: upstream, type: SaasResourceTemplateTargetUpstream_v1 }
+  - { name: image, type: SaasResourceTemplateTargetImage_v1 }
+  - { name: disable, type: boolean }
+  - { name: delete, type: boolean }
+
+- name: SaasResourceTemplateTargetInline_v2
+  interface: SaasResourceTemplateTarget_v2
+  fields:
+  - { name: path, type: string }
+  - { name: schema, type: string }
   - { name: name, type: string, isContextUnique: true }
   - { name: namespace, type: Namespace_v1, isRequired: true, isContextUnique: true }
   - { name: ref, type: string, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2221,6 +2221,7 @@ confs:
   - { name: targets, type: SaasResourceTemplateTarget_v2, isRequired: true, isList: true }
 
 - name: SaasResourceTemplateTarget_v2
+  datafile: /app-sre/saas-file-target-1.yml
   fields:
   - { name: path, type: string }
   - { name: name, type: string, isContextUnique: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2223,7 +2223,8 @@ confs:
 - name: SaasResourceTemplateTarget_v2
   datafile: /app-sre/saas-file-target-1.yml
   fields:
-  - { name: path, type: string }
+  - { name: path, type: string, isRequired: true }
+  - { name: schema, type: string, isRequired: true }
   - { name: name, type: string, isContextUnique: true }
   - { name: namespace, type: Namespace_v1, isRequired: true, isContextUnique: true }
   - { name: ref, type: string, isRequired: true }


### PR DESCRIPTION
this PR is supposed to fix #261 and allow usage of saas file targets as `datafiles`.
alas, a saas file target can either be inline or referenced, hence the `path` field is not mandatory.
this is causing the following error:
```
Error: Interface field DatafileObject_v1.path expects type String! but SaasResourceTemplateTarget_v2.path is type String.
```