### PR TITLE
APPSRE-5597: make auto_minor_version_upgrade parameter as required so we can set it explicitly with false value

### DIFF
--- a/schemas/aws/rds-defaults-1.yml
+++ b/schemas/aws/rds-defaults-1.yml
@@ -90,3 +90,4 @@ required:
 - engine
 - engine_version
 - instance_class
+- auto_minor_version_upgrade


### PR DESCRIPTION
Related: APPSRE-5597

Per https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#auto_minor_version_upgrade
`auto_minor_upgrade_version` defaults to true if not specified explicitly.

This takes care of some RDS instances which refer to such defaults with no `auto_minor_upgrade_version` by having us to define it explicitly but limit it with the change introduced in https://github.com/app-sre/qontract-schemas/pull/264
