### PR TITLE
disabled flag for change-types

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3081,6 +3081,7 @@ confs:
   - { name: description, type: string, isRequired: true }
   - { name: contextType, type: string, isRequired: true } # datafile or resource
   - { name: contextSchema, type: string } # schema of a datafile or resource
+  - { name: disabled, type: boolean }
   - { name: changes, type: ChangeTypeChangeDetector_v1, isInterface: true, isRequired: true, isList: true }
 
 - name: ChangeTypeChangeDetector_v1

--- a/schemas/app-interface/change-type-1.yml
+++ b/schemas/app-interface/change-type-1.yml
@@ -19,6 +19,9 @@ properties:
     type: string
   contextSchema:
     type: string
+  disabled:
+    type: boolean
+    description: a disabled change-type does not have any effect but will still log into the PR check logs
   changes:
     type: array
     minItems: 1


### PR DESCRIPTION
this flags will allow temporary deactivation of a change-type. a disabled change-type will not enable self-service anymore but will still log to the PR check logs.

this can be used to
* disable a buggy change-type
* analyze change-type decisions in production while not affecting production (especially useful while developing a new change-type)

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>