### PR TITLE
[APPSRE-6368] Validate GQL Queries on PR Checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,15 +51,12 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
-	@$(CONTAINER_ENGINE) run -d --rm --name $(SERVER_CONTAINER_NAME) \
+	@! timeout 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \
 		-e DATAFILES_FILE=/bundle/$(BUNDLE_FILENAME) \
 		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG)
-	sleep 5
-	@$(CONTAINER_ENGINE) logs $(SERVER_CONTAINER_NAME)
-	@$(CONTAINER_ENGINE) stop $(SERVER_CONTAINER_NAME)
 
 build-test: clean
 	@docker build -t $(IMAGE_TEST) -f dockerfiles/Dockerfile.test .

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,14 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
-	@! timeout 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
+	@timeout 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \
 		-e DATAFILES_FILE=/bundle/$(BUNDLE_FILENAME) \
-		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG)
+		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG); \
+	 if [ $$? -eq 124 ]; then exit 0; else exit $$?; fi
+	
 
 build-test: clean
 	@docker build -t $(IMAGE_TEST) -f dockerfiles/Dockerfile.test .

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
 	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG) && \
-	 timeout 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
+	 timeout --foreground 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,14 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
-	@timeout 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
+	@$(CONTAINER_ENGINE) pull $(SERVER_CONTAINER_NAME):$(SERVER_IMAGE_TAG) && \
+	 timeout 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \
 		-e DATAFILES_FILE=/bundle/$(BUNDLE_FILENAME) \
-		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG)
+		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG); \
+	 if [ $$? -eq 124 ]; then exit 0; else exit $$?; fi
 	
 
 build-test: clean

--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,12 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
-	@timeout 5 $(CONTAINER_ENGINE) run -it --rm --name $(SERVER_CONTAINER_NAME) \
+	@timeout 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \
 		-e DATAFILES_FILE=/bundle/$(BUNDLE_FILENAME) \
-		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG); \
-	 if [ $$? -eq 124 ]; then exit 0; else exit $$?; fi
+		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG)
 	
 
 build-test: clean

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
-	@timeout --foreground 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
+	@timeout 5 $(CONTAINER_ENGINE) run -it --rm --name $(SERVER_CONTAINER_NAME) \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ VALIDATOR_IMAGE := quay.io/app-sre/qontract-validator
 VALIDATOR_IMAGE_TAG := latest
 SERVER_IMAGE := quay.io/app-sre/qontract-server
 SERVER_IMAGE_TAG := latest
-SERVER_CONTAINER_NAME := qontract-server 
 CONTAINER_ENGINE ?= $(shell which podman >/dev/null 2>&1 && echo podman || echo docker)
 OUTPUT_DIR ?= $(shell pwd)
 OUTPUT_DIR := $(shell realpath $(OUTPUT_DIR))
@@ -52,7 +51,7 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
 	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG) && \
-	 timeout 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
+	 timeout 5 $(CONTAINER_ENGINE) run --rm \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,12 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
 	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG) && \
-	 timeout --foreground 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
+	 timeout 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \
 		-e DATAFILES_FILE=/bundle/$(BUNDLE_FILENAME) \
-		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG); \
+		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG) || \
 	 if [ $$? -eq 124 ]; then exit 0; else exit $$?; fi
 	
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
-	@timeout 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
+	@timeout --foreground 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ gql_validate: ## Run qontract-server with the schema bundle and no data to revea
 		-e DATAFILES_FILE=/bundle/$(BUNDLE_FILENAME) \
 		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG)
 	sleep 5
+	@$(CONTAINER_ENGINE) logs $(SERVER_CONTAINER_NAME)
 	@$(CONTAINER_ENGINE) stop $(SERVER_CONTAINER_NAME)
 
 build-test: clean

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
-	@$(CONTAINER_ENGINE) pull $(SERVER_CONTAINER_NAME):$(SERVER_IMAGE_TAG) && \
+	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG) && \
 	 timeout 5 $(CONTAINER_ENGINE) run --rm --name $(SERVER_CONTAINER_NAME) \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make test bundle validate
+make test bundle validate gql_validate


### PR DESCRIPTION
[APPSRE-6368](https://issues.redhat.com/browse/APPSRE-6368)

On PR checks of schema updates, bundle up all the schema information without any A-I data and then run an instance of qontract-server to check whether there are any issues with the GraphQL Schema. 

Output on successful run with valid GQL schema:

```
rm -rf fake_data fake_resources
[]
yarn run v1.22.19
warning Skipping preferred cache folder "/opt/app-root/src/.cache/yarn" because it is not writable.
warning Selected the next writable cache folder in the list, will be "/tmp/.yarn-cache-1001".
$ node ./dist/main-bundle.js
2022-10-05T19:44:47.374Z INFO: loading initial bundle 76cd257364365fbe2fe72feab840654aebcf87ca3afc3fb96ae0997dfe02dd95
2022-10-05T19:44:47.489Z INFO: Running at http://localhost:4000/graphql
(node:16) [DEP0152] DeprecationWarning: Custom PerformanceEntry accessors are deprecated. Please use the detail property.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Output on failed run with invalid GQL schema:

```
Error: Interface field DatafileObject_v1.path expects type String! but SaasResourceTemplateTarget_v2.path is type String.

Interface field DatafileObject_v1.schema expected but SaasResourceTemplateTarget_v2 does not provide it.
    at b (/opt/app-root/dist/main-bundle.js:13:33437)
    at C (/opt/app-root/dist/main-bundle.js:7:10690)
    at T (/opt/app-root/dist/main-bundle.js:7:9735)
    at Module.I (/opt/app-root/dist/main-bundle.js:7:9474)
    at Object.t.generateSchemaHash (/opt/app-root/dist/main-bundle.js:217:62607)
    at h.generateSchemaDerivedData (/opt/app-root/dist/main-bundle.js:217:147)
    at new t.ApolloServerBase (/opt/app-root/dist/main-bundle.js:205:44689)
    at new h (/opt/app-root/dist/main-bundle.js:227:41965)
    at h (/opt/app-root/dist/main-bundle.js:205:8299)
    at /opt/app-root/dist/main-bundle.js:205:9134
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
make: *** [Makefile:54: gql_validate] Error 1
```

Context on why I'm checking for an RC of `124`: https://man7.org/linux/man-pages/man1/timeout.1.html