### PR TITLE
[APPSRE-6355] Add review repos to App Interface settings

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -27,7 +27,7 @@ confs:
   - { name: endpointMonitoringBlackboxExporterModules, type: string, isList: true }
   - { name: ldap, type: LdapSettings_v1, isRequired: false}
   - { name: jiraWatcher, type: JiraWatcherSettings_v1, isRequired: false}
-  - { name: reviewRepos, type: ReviewRepos_v1, isRequired: false }
+  - { name: reviewRepos, type: ReviewRepos_v1, isList: true, isRequired: false }
 
 - name: SmtpSettings_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -27,6 +27,7 @@ confs:
   - { name: endpointMonitoringBlackboxExporterModules, type: string, isList: true }
   - { name: ldap, type: LdapSettings_v1, isRequired: false}
   - { name: jiraWatcher, type: JiraWatcherSettings_v1, isRequired: false}
+  - { name: reviewRepos, type: ReviewRepos_v1, isRequired: false }
 
 - name: SmtpSettings_v1
   fields:
@@ -52,6 +53,11 @@ confs:
   fields:
   - { name: readTimeout, type: int, isRequired: true }
   - { name: connectTimeout, type: int, isRequired: true }
+
+- name: ReviewRepos_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: repoUrl, type: string, isRequired: true}
 
 - name: AppInterfaceDependencyMapping_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -57,7 +57,7 @@ confs:
 - name: ReviewRepos_v1
   fields:
   - { name: name, type: string, isRequired: true }
-  - { name: repoUrl, type: string, isRequired: true}
+  - { name: url, type: string, isRequired: true}
 
 - name: AppInterfaceDependencyMapping_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -27,7 +27,6 @@ confs:
   - { name: endpointMonitoringBlackboxExporterModules, type: string, isList: true }
   - { name: ldap, type: LdapSettings_v1, isRequired: false}
   - { name: jiraWatcher, type: JiraWatcherSettings_v1, isRequired: false}
-  - { name: reviewRepos, type: ReviewRepos_v1, isList: true, isRequired: false }
 
 - name: SmtpSettings_v1
   fields:
@@ -53,11 +52,6 @@ confs:
   fields:
   - { name: readTimeout, type: int, isRequired: true }
   - { name: connectTimeout, type: int, isRequired: true }
-
-- name: ReviewRepos_v1
-  fields:
-  - { name: name, type: string, isRequired: true }
-  - { name: url, type: string, isRequired: true}
 
 - name: AppInterfaceDependencyMapping_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1937,6 +1937,7 @@ confs:
   - { name: name, type: string, isRequired: true }
   - { name: resource, type: string, isRequired: true }
   - { name: url, type: string, isRequired: true }
+  - { name: showInReviewQueue, type: boolean}
   - { name: gitlabRepoOwners, type: CodeComponentGitlabOwners_v1 }
   - { name: gitlabHousekeeping, type: CodeComponentGitlabHousekeeping_v1 }
   - { name: jira, type: JiraServer_v1 }

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -170,11 +170,11 @@ properties:
       additionalProperties: false
       required:
       - name
-      - repoUrl
+      - url
       properties:
         name:
           type: string
-        repoUrl:
+        url:
           type: string
           format: uri
 required:

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -160,23 +160,6 @@ properties:
     required:
     - readTimeout
     - connectTimeout
-  reviewRepos:
-    type: array
-    description: |
-      List of additional repos to watch for MRs in the A-I review
-      queue in addition to A-I MRs.
-    items:
-      type: object
-      additionalProperties: false
-      required:
-      - name
-      - url
-      properties:
-        name:
-          type: string
-        url:
-          type: string
-          format: uri
 required:
 - "$schema"
 - labels

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -160,6 +160,23 @@ properties:
     required:
     - readTimeout
     - connectTimeout
+  reviewRepos:
+    type: array
+    description: |
+      List of additional repos to watch for MRs in the A-I review
+      queue in addition to A-I MRs.
+    items:
+      type: object
+      additionalProperties: false
+      required:
+      - name
+      - repoUrl
+      properties:
+        name:
+          type: string
+        repoUrl:
+          type: string
+          format: uri
 required:
 - "$schema"
 - labels

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -288,6 +288,9 @@ properties:
           - saasrepo
           - bundle
           - other
+        showInReviewQueue:
+          type: boolean
+          description: Include MRs from this repo in the AppSRE Review Queue
         url:
           type: string
         gitlabRepoOwners:


### PR DESCRIPTION
[APPSRE-6355](https://issues.redhat.com/browse/APPSRE-6355)

* To increase visibility of MRs for ICs in AppSRE, this allows us to define additional repos to watch for MRs
* The watched repos must be on GitLab.cee and [managed by the AppSRE Bot](https://gitlab.cee.redhat.com/service/app-interface#enable-gitlab-features-on-an-app-interface-controlled-gitlab-repository) as well as have a PR check job setup
* Corresponding QR change here: https://github.com/app-sre/qontract-reconcile/pull/2852

Example of an updated app file:
```yaml
codeComponents:
- name: infra
  resource: other
  url: https://gitlab.cee.redhat.com/app-sre/infra
  showInReviewQueue: true
  gitlabHousekeeping:
    enabled: true
    rebase: false
  jira:
    $ref: /dependencies/jira/issues-redhat-com.yaml
```