### PR TITLE
Add googleChat as a logging output option for integration specs

### DIFF
--- a/schemas/app-sre/integration-spec-1.yml
+++ b/schemas/app-sre/integration-spec-1.yml
@@ -79,6 +79,9 @@ properties:
       slack:
         type: boolean
         description: ship logs to slack
+      googleChat:
+        type: boolean
+        description: ship logs to google chat
   resources:
     "$ref": "/openshift/deploy-resources-1.yml"
   shards:


### PR DESCRIPTION
This MR adds googleChat as a boolean logging output option, supporting: https://github.com/app-sre/qontract-reconcile/pull/2801,  https://github.com/app-sre/fluentd/pull/4