### PR TITLE
Change prometheus rule test schema for floats

### DIFF
--- a/schemas/app-interface/prometheus-rule-test-1.yml
+++ b/schemas/app-interface/prometheus-rule-test-1.yml
@@ -101,7 +101,7 @@ properties:
                     labels:
                       type: string
                     value:
-                      type: integer
+                      type: number
                   required:
                   - labels
                   - value


### PR DESCRIPTION
This PR changes the Prometheus rule test schema `exp_samples` under `promql_expr_test` to accommodate floating points instead of just integers, as a series sample can be a float.