### PR TITLE
change-type inherritence

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3212,6 +3212,7 @@ confs:
   - { name: contextType, type: string, isRequired: true } # datafile or resource
   - { name: contextSchema, type: string } # schema of a datafile or resource
   - { name: disabled, type: boolean }
+  - { name: inherrit, type: ChangeType_v1, isList: true }
   - { name: changes, type: ChangeTypeChangeDetector_v1, isInterface: true, isRequired: true, isList: true }
 
 - name: ChangeTypeChangeDetector_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3212,7 +3212,7 @@ confs:
   - { name: contextType, type: string, isRequired: true } # datafile or resource
   - { name: contextSchema, type: string } # schema of a datafile or resource
   - { name: disabled, type: boolean }
-  - { name: inherrit, type: ChangeType_v1, isList: true }
+  - { name: inherit, type: ChangeType_v1, isList: true }
   - { name: changes, type: ChangeTypeChangeDetector_v1, isInterface: true, isRequired: true, isList: true }
 
 - name: ChangeTypeChangeDetector_v1

--- a/schemas/app-interface/change-type-1.yml
+++ b/schemas/app-interface/change-type-1.yml
@@ -22,9 +22,9 @@ properties:
   disabled:
     type: boolean
     description: a disabled change-type does not have any effect but will still log into the PR check logs
-  inherrit:
+  inherit:
     type: array
-    description: inherrit the permissions of additional change types
+    description: inherit the permissions of additional change types
     items:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/app-interface/change-type-1.yml"

--- a/schemas/app-interface/change-type-1.yml
+++ b/schemas/app-interface/change-type-1.yml
@@ -22,6 +22,12 @@ properties:
   disabled:
     type: boolean
     description: a disabled change-type does not have any effect but will still log into the PR check logs
+  inherrit:
+    type: array
+    description: inherrit the permissions of additional change types
+    items:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/app-interface/change-type-1.yml"
   changes:
     type: array
     minItems: 1

--- a/schemas/app-interface/change-type-1.yml
+++ b/schemas/app-interface/change-type-1.yml
@@ -24,7 +24,7 @@ properties:
     description: a disabled change-type does not have any effect but will still log into the PR check logs
   inherit:
     type: array
-    description: inherit the permissions of additional change types
+    description: inherit the changes of additional change types
     items:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/app-interface/change-type-1.yml"


### PR DESCRIPTION
this is a proposal to implement change-type inheritance, where one change-type can reference other change-types and get their permissions as well.

this may help us prevent duplication between change-types where we want to include the same permissions and will provide reusability of change-types.

part of: https://issues.redhat.com/browse/APPSRE-6473