### PR TITLE
add dns-zone-1 to self-service datafiles enum

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2955,8 +2955,10 @@ confs:
   - { name: _target_namespace_zone, type: DnsNamespaceZone_v1 }
 
 - name: DnsZone_v1
+  datafile: /dependencies/dns-zone-1.yml
   fields:
   - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
   - { name: domain_name, type: string }

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -154,6 +154,7 @@ properties:
                   enum:
                   - /app-sre/saas-file-2.yml
                   - /app-sre/saas-file-target-1.yml
+                  - /dependencies/dns-zone-1.yml
                   - /openshift/namespace-1.yml
                   - /access/role-1.yml
                   - /openshift/cluster-1.yml


### PR DESCRIPTION
This adds the dns-zone-1 schema to the list of allowed datafiles types that can be self services

This is needed for the [corresponding](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/50067) MR which adds the definition