### PR TITLE
[change-type] allowed to assume

### DIFF
--- a/schemas/app-interface/change-type-1.yml
+++ b/schemas/app-interface/change-type-1.yml
@@ -24,6 +24,9 @@ properties:
     - high
     - medium
     - low
+  allowedToAssume:
+    type: boolean
+    description: assuming this change type does not require approval
   contextType:
     type: string
   contextSchema:


### PR DESCRIPTION
a change type with `allowedToAssume: true` will not require approval to assume, and the permissions within this change type are granted within a MR.

for example, a change type granting permissions to manage one's own user file can be assumed and self-approved within an MR.