### PR TITLE
Scorecard v2

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2790,6 +2790,21 @@ confs:
   - { name: SECURITY_0003, type: ScorecardAcceptanceCriteria_v1, isRequired: true }
   - { name: SECURITY_0004, type: ScorecardAcceptanceCriteria_v1, isRequired: true }
 
+- name: AcceptanceCriteriaItem_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: status, type: string, isRequired: true }
+  - { name: comment, type: string }
+
+- name: Scorecard_v2
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: labels, type: json, isRequired: true }
+  - { name: app, type: App_v1, isRequired: true }
+  - { name: date, type: string, isRequired: true }
+  - { name: acceptanceCriteria, type: AcceptanceCriteriaItem_v1, isRequired: true, isList: true }
+
 - name: Query
   fields:
   - { name: app_interface_settings_v1, type: AppInterfaceSettings_v1, isList: true, datafileSchema: /app-interface/app-interface-settings-1.yml }
@@ -2860,6 +2875,7 @@ confs:
   - { name: endpoint_monitoring_provider_v1, type: EndpointMonitoringProvider_v1, isList: true, isInterface: true, datafileSchema: /dependencies/endpoint-monitoring-provider-1.yml }
   - { name: change_types_v1, type: ChangeType_v1, isList: true, datafileSchema: /app-interface/change-type-1.yml }
   - { name: scorecards_v1, type: Scorecard_v1, isList: true, datafileSchema: /app-sre/scorecard-1.yml }
+  - { name: scorecards_v2, type: Scorecard_v2, isList: true, datafileSchema: /app-sre/scorecard-2.yml }
 
 - name: GlitchtipInstance_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2797,6 +2797,7 @@ confs:
   - { name: comment, type: string }
 
 - name: Scorecard_v2
+  datafile: /app-sre/scorecard-2.yml
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2792,7 +2792,7 @@ confs:
 
 - name: AcceptanceCriteriaItem_v1
   fields:
-  - { name: name, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: status, type: string, isRequired: true }
   - { name: comment, type: string }
 

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -161,6 +161,7 @@ properties:
                   - /aws/account-1.yml
                   - /app-sre/gabi-instance-1.yml
                   - /app-sre/scorecard-1.yml
+                  - /app-sre/scorecard-2.yml
                   - /openshift/shared-resources-1.yml
                   - /access/user-1.yml
 required:

--- a/schemas/app-sre/scorecard-2.yml
+++ b/schemas/app-sre/scorecard-2.yml
@@ -78,6 +78,8 @@ properties:
       required:
       - name
       - status
+    minItems: 37
+    maxItems: 37
 required:
 - "$schema"
 - labels

--- a/schemas/app-sre/scorecard-2.yml
+++ b/schemas/app-sre/scorecard-2.yml
@@ -1,0 +1,86 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /app-sre/scorecard-2.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  app:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/app-sre/app-1.yml"
+  date:
+    type: string
+    pattern: "^2[0-9]{3}-[01][0-9]-[0123][0-9]$"
+    description: 'YYYY-mm-dd (year, month, day)'
+  acceptanceCriteria:
+    type: array
+    description: acceptance criteria items
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: name of acceptance criteria item
+          enum:
+          - CONTINUITY-0001
+          - CONTINUITY-0002
+          - CONTINUITY-0003
+          - INCIDENT-MGMT-0001
+          - INCIDENT-MGMT-0002
+          - INCIDENT-MGMT-0003
+          - INCIDENT-MGMT-0004
+          - INCIDENT-MGMT-0005
+          - INCIDENT-MGMT-0006
+          - INCIDENT-MGMT-0007
+          - INCIDENT-MGMT-0008
+          - OBSERVABILITY-0001
+          - OBSERVABILITY-0002
+          - OBSERVABILITY-0003
+          - OBSERVABILITY-0004
+          - OBSERVABILITY-0005
+          - OBSERVABILITY-0006
+          - RELEASING-0001
+          - RELEASING-0002
+          - RELEASING-0003
+          - RELEASING-0004
+          - RELEASING-0005
+          - RELIABILITY-0001
+          - RELIABILITY-0002
+          - RELIABILITY-0003
+          - RELIABILITY-0004
+          - RELIABILITY-0005
+          - RELIABILITY-0006
+          - RELIABILITY-0007
+          - RELIABILITY-0008
+          - RELIABILITY-0009
+          - RELIABILITY-0010
+          - RELIABILITY-0011
+          - SECURITY-0001
+          - SECURITY-0002
+          - SECURITY-0003
+          - SECURITY-0004
+        status:
+          type: string
+          enum:
+          - green
+          - yellow
+          - red
+        comment:
+          type: string
+      required:
+      - name
+      - status
+required:
+- "$schema"
+- labels
+- app
+- date
+- acceptanceCriteria


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6506

following up on v1 in #280

this PR introduces v2, which replaces the hard coded AC fields with a list of items with a `name` property.
the name is limited by an enum, a length definition and a uniqueness constraint, to guarantee all ACs are covered in a report.