### PR TITLE
add deletionApprovals for Cloudflare accounts

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -913,7 +913,7 @@ confs:
   - { name: automationToken, type: VaultSecret_v1, isRequired: true }
   - { name: garbageCollection, type: boolean }
   - { name: enableDeletion, type: boolean }
-  - { name: deletionApprovals, type: AWSAccountDeletionApproval_v1, isList: true }
+  - { name: deletionApprovals, type: DeletionApproval_v1, isList: true }
   - { name: disable, type: DisableClusterAutomations_v1 }
   - { name: deleteKeys, type: string, isList: true }
   - { name: resetPasswords, type: AWSAccountResetPassword_v1, isList: true }
@@ -948,6 +948,7 @@ confs:
   - { name: enableDeletion, type: boolean }
   - { name: apiCredentials, type: VaultSecret_v1, isRequired: true }
   - { name: terraformStateAccount, type: AWSAccount_v1, isRequired: true }
+  - { name: deletionApprovals, type: DeletionApproval_v1, isList: true }
 
 - name: AWSGroup_v1
   fields:
@@ -965,7 +966,7 @@ confs:
       schema: /access/role-1.yml
       subAttr: aws_groups
 
-- name: AWSAccountDeletionApproval_v1
+- name: DeletionApproval_v1
   fields:
   - { name: type, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }

--- a/schemas/app-interface/deletion-approval-1.yml
+++ b/schemas/app-interface/deletion-approval-1.yml
@@ -1,0 +1,21 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /app-interface/deletion-approval-1.yml
+  expiration:
+    type: string
+  type:
+    type: string
+  name:
+    type: string
+required:
+- expiration
+- name
+- type

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -52,19 +52,7 @@ properties:
   deletionApprovals:
     type: array
     items:
-      type: object
-      additionalProperties: false
-      properties:
-        type:
-          type: string
-        name:
-          type: string
-        expiration:
-          type: string
-      required:
-      - type
-      - name
-      - expiration
+      "$ref": "/app-interface/deletion-approval-1.yml"
   disable:
     type: object
     additionalProperties: false

--- a/schemas/cloudflare/account-1.yml
+++ b/schemas/cloudflare/account-1.yml
@@ -37,19 +37,7 @@ properties:
   deletionApprovals:
     type: array
     items:
-      type: object
-      additionalProperties: false
-      properties:
-        type:
-          type: string
-        name:
-          type: string
-        expiration:
-          type: string
-      required:
-      - type
-      - name
-      - expiration
+      "$ref": "/app-interface/deletion-approval-1.yml"
 required:
 - "$schema"
 - name

--- a/schemas/cloudflare/account-1.yml
+++ b/schemas/cloudflare/account-1.yml
@@ -34,6 +34,22 @@ properties:
     description: AWS Account to use for state in S3
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/aws/account-1.yml"
+  deletionApprovals:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+        name:
+          type: string
+        expiration:
+          type: string
+      required:
+      - type
+      - name
+      - expiration
 required:
 - "$schema"
 - name


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6478

This renames the `AWSAccountDeletionApproval_v1` schema to a more generic name `DeletionApproval_v1` and adds it to the `CloudflareAccount_v1` schema

The object definition for a `deletionApproval` is also extracted out of AWS and Cloudflare accounts schemas into a common definition

This is required by https://github.com/app-sre/qontract-reconcile/pull/2896