### PR TITLE
add access token client secret field to OCM org

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -850,6 +850,7 @@ confs:
   - { name: accessTokenClientId, type: string, isRequired: true }
   - { name: accessTokenUrl, type: string, isRequired: true }
   - { name: offlineToken, type: VaultSecret_v1 }
+  - { name: accessTokenClientSecret, type: VaultSecret_v1 }
   - { name: blockedVersions, type: string, isList: true }
   - { name: upgradePolicyAllowedWorkloads, type: string, isList: true }
   - { name: upgradePolicyAllowedMutexes, type: string, isList: true }

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -23,6 +23,8 @@ properties:
   accessTokenUrl:
     type: string
     format: uri
+  accessTokenClientSecret:
+    "$ref": "/common-1.json#/definitions/vaultSecret"
   offlineToken:
     "$ref": "/common-1.json#/definitions/vaultSecret"
   blockedVersions:
@@ -49,3 +51,4 @@ required:
 - accessTokenClientId
 - accessTokenUrl
 - offlineToken
+- accessTokenClientSecret


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2494

with this change, we can switch OCM auth from a user to a ServiceAccount (implemented in https://github.com/app-sre/qontract-reconcile/pull/2905)