### PR TITLE
prepare to enable upgrade scheduling for ocm orgs

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -853,6 +853,7 @@ confs:
   - { name: upgradePolicy, type: ClusterUpgradePolicy_v1, isRequired: true }
 
 - name: OpenShiftClusterManager_v1
+  datafile: /openshift/openshift-cluster-manager-1.yml
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -839,6 +839,19 @@ confs:
       schema: /openshift/namespace-1.yml
       subAttr: kafkaCluster
 
+- name: OpenShiftClusterManagerUpgradePolicyClusterSpec_v1
+  fields:
+  - { name: id, type: string, isRequired: true }
+  - { name: product, type: string, isRequired: true }
+  - { name: version, type: string, isRequired: true }
+  - { name: channel, type: string, isRequired: true }
+
+- name: OpenShiftClusterManagerUpgradePolicyCluster_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: spec, type: OpenShiftClusterManagerUpgradePolicyClusterSpec_v1, isRequired: true }
+  - { name: upgradePolicy, type: ClusterUpgradePolicy_v1, isRequired: true }
+
 - name: OpenShiftClusterManager_v1
   fields:
   - { name: schema, type: string, isRequired: true }
@@ -853,6 +866,7 @@ confs:
   - { name: blockedVersions, type: string, isList: true }
   - { name: upgradePolicyAllowedWorkloads, type: string, isList: true }
   - { name: upgradePolicyAllowedMutexes, type: string, isList: true }
+  - { name: upgradePolicyClusters, type: OpenShiftClusterManagerUpgradePolicyCluster_v1, isList: true }
   - name: clusters
     type: Cluster_v1
     isList: true

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -164,6 +164,7 @@ properties:
                   - /openshift/shared-resources-1.yml
                   - /access/user-1.yml
                   - /app-sre/tekton-provider-defaults-1.yml
+                  - /openshift/openshift-cluster-manager-1.yml
 required:
 - $schema
 - labels

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -40,6 +40,50 @@ properties:
     type: array
     items:
       type: string
+  upgradePolicyClusters:
+    description: List of clusters to define upgrade policies for (no cluster management in such OCM orgs)
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          description: cluster name
+          type: string
+        spec:
+          type: object
+          additionalProperties: false
+          properties:
+            product:
+              description: cluster product type (OSD/ROSA)
+              type: string
+              enum:
+              - osd
+              - rosa
+            id:
+              description: cluster id
+              type: string
+            version:
+              description: cluster version
+              type: string
+            channel:
+              description: cluster upgrade channel
+              type: string
+              enum:
+              - stable
+              - fast
+              - candidate
+          required:
+          - id
+          - product
+          - version
+          - channel
+        upgradePolicy:
+          "$ref": "/openshift/cluster-upgrade-policy-1.yml"
+      required:
+      - name
+      - spec
+      - upgradePolicy
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6517

with this change, we can define a very lean list of clusters in an ocm file. this list will suffice to manage cluster upgrade schedules with an integration much like `ocm-upgrade-scheduler`.