### PR TITLE
remove offlineToken

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -849,7 +849,6 @@ confs:
   - { name: url, type: string, isRequired: true }
   - { name: accessTokenClientId, type: string, isRequired: true }
   - { name: accessTokenUrl, type: string, isRequired: true }
-  - { name: offlineToken, type: VaultSecret_v1 }
   - { name: accessTokenClientSecret, type: VaultSecret_v1 }
   - { name: blockedVersions, type: string, isList: true }
   - { name: upgradePolicyAllowedWorkloads, type: string, isList: true }

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -25,8 +25,6 @@ properties:
     format: uri
   accessTokenClientSecret:
     "$ref": "/common-1.json#/definitions/vaultSecret"
-  offlineToken:
-    "$ref": "/common-1.json#/definitions/vaultSecret"
   blockedVersions:
     description: "List of versions that will be rejected for upgrades. They can be regular expressions"
     type: array
@@ -50,5 +48,4 @@ required:
 - description
 - accessTokenClientId
 - accessTokenUrl
-- offlineToken
 - accessTokenClientSecret


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2494

deprecating `offlineToken` following up on #292, along with the promotion of https://github.com/app-sre/qontract-reconcile/pull/2905