### PR TITLE
Remove unmanaged_record_names field from DNS zone schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3005,7 +3005,6 @@ confs:
   - { name: account, type: AWSAccount_v1, isRequired: true }
   - { name: vpc, type: AWSVPC_v1 }
   - { name: origin, type: string, isRequired: true }
-  - { name: unmanaged_record_names, type: string, isList: true }
   - { name: records, type: DnsRecord_v1, isList: true }
 
 - name: SLODocumentSLOSLOParameters_v1

--- a/schemas/dependencies/dns-zone-1.yml
+++ b/schemas/dependencies/dns-zone-1.yml
@@ -23,10 +23,6 @@ properties:
   vpc:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/aws/vpc-1.yml"
-  unmanaged_record_names:
-    type: array
-    items:
-      type: string
   records:
     type: array
     items:


### PR DESCRIPTION
[APPSRE-6393](https://issues.redhat.com/browse/APPSRE-6393)

`unmanaged_record_names` in the `dns-zone-1.yml` schema is no longer needed as Terraform won't overwrite existing DNS records and only modifies records explicitly outlined in dns zone files. This MR removes that attribute from the schema and GQL.