### PR TITLE
[ocm-upgrade-scheduler-org] enable support for dynamic cluster discovery

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -849,6 +849,12 @@ confs:
   fields:
   - { name: id, type: string, isRequired: true }
 
+- name: OpenShiftClusterManagerUpgradePolicyDefault_v1
+  fields:
+  - { name: name, type: string, isRequired: true, isUnique: true }
+  - { name: matchLabels, type: json, isRequired: true }
+  - { name: upgradePolicy, type: ClusterUpgradePolicy_v1, isRequired: true }
+
 - name: OpenShiftClusterManagerUpgradePolicyCluster_v1
   fields:
   - { name: name, type: string, isRequired: true, isUnique: true }
@@ -869,6 +875,7 @@ confs:
   - { name: blockedVersions, type: string, isList: true }
   - { name: upgradePolicyAllowedWorkloads, type: string, isList: true }
   - { name: upgradePolicyAllowedMutexes, type: string, isList: true }
+  - { name: upgradePolicyDefaults, type: OpenShiftClusterManagerUpgradePolicyDefault_v1, isList: true }
   - { name: upgradePolicyClusters, type: OpenShiftClusterManagerUpgradePolicyCluster_v1, isList: true }
   - name: clusters
     type: Cluster_v1

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -40,6 +40,27 @@ properties:
     type: array
     items:
       type: string
+  upgradePolicyDefaults:
+    description: List of default upgrade policies to apply to clusters by external configuration labels
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          description: upgrade policy name
+          type: string
+        matchLabels:
+          description: external configuration labels to select default upgrade policy by
+          type: object
+          additionalProperties:
+            type: string
+        upgradePolicy:
+          "$ref": "/openshift/cluster-upgrade-policy-1.yml"
+      required:
+      - name
+      - matchLabels
+      - upgradePolicy
   upgradePolicyClusters:
     description: List of clusters to define upgrade policies for (no cluster management in such OCM orgs)
     type: array
@@ -55,6 +76,9 @@ properties:
       required:
       - name
       - upgradePolicy
+dependencies:
+  upgradePolicyDefaults:
+  - upgradePolicyClusters
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6517

in order to keep `upgradePolicyClusters` up-to-date with clusters being created/deleted, we need to define conditions of clusters (ClusterDeployment labels a.k.a external configuration labels) based on which we select an upgrade policy for a discovered cluster.

the intention is to create a separate integration that will submit MRs to app-interface to update `upgradePolicyClusters`, so we can keep the logic of `ocm-upgrade-scheduler-org` unchanged. the reason is that the current "static" nature of defining clusters is a no-go for management of OSD-FM fleets.

the OSD FM requirements are more complex compared to a regular customer, which usually has a single OCM org in a single OCM environment with a `statically managed set of clusters.