### PR TITLE
APPSRE-6295 mark CNA provisioner as experimental

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -960,7 +960,7 @@ confs:
       schema: /aws/policy-1.yml
       subAttr: account
 
-- name: CNAProvisioner_v1
+- name: CNAExperimentalProvisioner_v1
   interface: ExternalResourcesProvisioner_v1
   fields:
   - { name: schema, type: string, isRequired: true }
@@ -973,7 +973,7 @@ confs:
   interface: NamespaceExternalResource_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: provisioner, type: CNAProvisioner_v1, isRequired: true }
+  - { name: provisioner, type: CNAExperimentalProvisioner_v1, isRequired: true }
   - { name: resources, type: CNAsset_v1, isRequired: true, isList: true, isInterface: true }
 
 - name: CNAsset_v1
@@ -1200,7 +1200,7 @@ confs:
       aws: NamespaceTerraformProviderResourceAWS_v1
       cloudflare: NamespaceTerraformProviderResourceCloudflare_v1
       gcp-project: NamespaceTerraformProviderResourceGCPProject_v1
-      cna: NamespaceCNAsset_v1
+      cna-experimental: NamespaceCNAsset_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: provisioner, type: ExternalResourcesProvisioner_v1, isRequired: true, isInterface: true }
@@ -2836,7 +2836,7 @@ confs:
   - { name: awsgroups_v1, type: AWSGroup_v1, isList: true, datafileSchema: /aws/group-1.yml }
   - { name: awsaccounts_v1, type: AWSAccount_v1, isList: true, datafileSchema: /aws/account-1.yml }
   - { name: cloudflare_accounts_v1, type: CloudflareAccount_v1, isList: true, datafileSchema: /cloudflare/account-1.yml }
-  - { name: cna_provisioners_v1, type: CNAProvisioner_v1, isList: true, datafileSchema: /cna/provisioner-1.yml }
+  - { name: cna_experimental_provisioners_v1, type: CNAExperimentalProvisioner_v1, isList: true, datafileSchema: /cna/experimental-provisioner-1.yml }
   - { name: clusters_v1, type: Cluster_v1, isList: true, datafileSchema: /openshift/cluster-1.yml }
   - { name: jumphosts_v1, type: ClusterJumpHost_v1, isList: true, datafileSchema: /openshift/jump-host-1.yml }
   - { name: kafka_clusters_v1, type: KafkaCluster_v1, isList: true, datafileSchema: /kafka/cluster-1.yml }

--- a/schemas/cna/experimental-provisioner-1.yml
+++ b/schemas/cna/experimental-provisioner-1.yml
@@ -8,7 +8,7 @@ properties:
   "$schema":
     type: string
     enum:
-    - /cna/provisioner-1.yml
+    - /cna/experimental-provisioner-1.yml
   name:
     type: string
   description:

--- a/schemas/openshift/external-resource-1.yml
+++ b/schemas/openshift/external-resource-1.yml
@@ -16,7 +16,7 @@ properties:
     - aws
     - cloudflare
     - gcp-project
-    - cna
+    - cna-experimental
   provisioner:
     "$ref": "/common-1.json#/definitions/crossref"
     description: the provisioning entity
@@ -74,10 +74,10 @@ oneOf:
     provider:
       type: string
       enum:
-      - cna
+      - cna-experimental
     provisioner:
       "$ref": "/common-1.json#/definitions/crossref"
-      "$schemaRef": "/cna/provisioner-1.yml"
+      "$schemaRef": "/cna/experimental-provisioner-1.yml"
     resources:
       type: array
       items:


### PR DESCRIPTION
CNA is being spiked. Renaming provisioner to `experimental` to highlight this must not be used in production.