### PR TITLE
cna assume-role resource

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -945,7 +945,8 @@ confs:
   - { name: partition, type: string }
   - { name: sharing, type: AWSAccountSharingOption_v1, isList: true, isInterface: true }
   - { name: terraformState, type: TerraformStateAWS_v1, isRequired: false }
-  - { name: rosa, type: RosaAWSSpec_v1, isRequired: false}
+  - { name: rosa, type: RosaAWSSpec_v1, isRequired: false }
+  - { name: cna, type: CNAAWSSpec_v1, isRequired: false }
 
   - name: ecrs
     type: AWSECR_v1
@@ -959,6 +960,16 @@ confs:
     synthetic:
       schema: /aws/policy-1.yml
       subAttr: account
+
+- name: CNAAWSSpec_v1
+  fields:
+  - { name: defaultRoleARN, type: string }
+  - { name: moduleRoleARNS, type: CNAModuleAWSARN_v1, isList: true }
+
+- name: CNAModuleAWSARN_v1
+  fields:
+  - { name: module, type: string, isRequired: true }
+  - { name: arn, type: string, isRequired: true }
 
 - name: CNAExperimentalProvisioner_v1
   interface: ExternalResourcesProvisioner_v1
@@ -983,9 +994,23 @@ confs:
     strategy: fieldMap
     field: provider
     fieldMap:
+      aws-assume-role: CNAAssumeRoleAsset_v1
       null-asset: CNANullAsset_v1
   fields:
   - { name: provider, type: string, isRequired: true }
+  - { name: identifier, type: string, isRequired: true, isUnique: true }
+
+- name: CNAAssumeRoleAsset_v1
+  interface: CNAsset_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: identifier, type: string, isRequired: true, isUnique: true }
+  - { name: aws_assume_role, type: CNAAssumeRoleAssetConfig_v1, isRequired: true }
+
+- name: CNAAssumeRoleAssetConfig_v1
+  fields:
+  - { name: slug, type: string, isRequired: true }
+  - { name: account, type: AWSAccount_v1, isRequired: true }
 
 - name: CNANullAsset_v1
   interface: CNAsset_v1

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -105,6 +105,26 @@ properties:
     description: "Rosa related attributes in the aws account."
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/dependencies/rosa-aws-1.yml"
+  cna:
+    type: object
+    additionalProperties: false
+    properties:
+      defaultRoleARN:
+        type: string
+      moduleRoleARNS:
+        type: array
+        items:
+          additionalProperties: false
+          properties:
+            module:
+              type: string
+            arn:
+              type: string
+          required:
+          - module
+          - arn
+    required:
+    - defaultRoleARN
 required:
 - "$schema"
 - labels

--- a/schemas/cna/asset-1.yml
+++ b/schemas/cna/asset-1.yml
@@ -17,6 +17,15 @@ properties:
     "$ref": "/common-1.json#/definitions/longIdentifier"
   addr_block:
     type: string
+  aws_assume_role:
+    type: object
+    additionalProperties: false
+    properties:
+      account:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "/aws/account-1.yml"
+      slug:
+        type: string
 oneOf:
 - additionalProperties: false
   properties:
@@ -32,3 +41,23 @@ oneOf:
       type: string
   required:
   - identifier
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - aws-assume-role
+    identifier:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    aws_assume_role:
+      type: object
+      additionalProperties: false
+      properties:
+        account:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/aws/account-1.yml"
+        slug:
+          type: string
+  required:
+  - identifier
+  - aws_assume_role


### PR DESCRIPTION
temporarily add support for the `example-aws-assumerole` CNA type.

```
  - provider: aws-assume-role
    identifier: test
    aws_assume_role:
      slug: test
      account:
        $ref: /aws/some-acc/account.yml
```

the role ARNs this and other kinds require, are stored in the `/aws/account-1.yml` schema. a default role ARN can be defined but module specific ones are supported as well. while we iterate we might drop support for the defaultRoleARN or revamp the way of providing module/context specific default parameters

```
---
$schema: /aws/account-1.yml

cna:
  defaultRoleARN: arn:aws:iam::xxx:role/RH-CNA
  moduleRoleARNS:
  - module: aws-rds
     arn: arn:aws:iam::xxx:role/RH-CNA-RDS
```

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>