### PR TITLE
CNA aws-rds provider

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -996,6 +996,7 @@ confs:
     fieldMap:
       aws-assume-role: CNAAssumeRoleAsset_v1
       null-asset: CNANullAsset_v1
+      aws-rds: CNARDSInstance_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
@@ -1019,6 +1020,27 @@ confs:
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string }
   - { name: addr_block, type: string }
+
+- name: CNARDSInstance_v1
+  interface: CNAsset_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: identifier, type: string, isRequired: true, isUnique: true }
+  - { name: vpc, type: AWSVPC_v1, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResource: true }
+  - { name: overrides, type: CNARDSInstanceOverrides_v1 }
+
+- name: CNARDSInstanceOverrides_v1
+  fields:
+  - { name: name, type: string }
+  - { name: engine, type: string }
+  - { name: engine_version, type: string }
+  - { name: username, type: string }
+  - { name: instance_class, type: string }
+  - { name: allocated_storage, type: int }
+  - { name: max_allocated_storage, type: int }
+  - { name: backup_retention_period, type: int }
+  - { name: db_subnet_group_name, type: string }
 
 - name: CloudflareAccount_v1
   interface: ExternalResourcesProvisioner_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1006,12 +1006,12 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
-  - { name: aws_assume_role, type: CNAAssumeRoleAssetConfig_v1, isRequired: true }
+  - { name: account, type: AWSAccount_v1, isRequired: true }
+  - { name: overrides, type: CNAAssumeRoleAssetOverrides_v1 }
 
-- name: CNAAssumeRoleAssetConfig_v1
+- name: CNAAssumeRoleAssetOverrides_v1
   fields:
   - { name: slug, type: string, isRequired: true }
-  - { name: account, type: AWSAccount_v1, isRequired: true }
 
 - name: CNANullAsset_v1
   interface: CNAsset_v1
@@ -1019,6 +1019,10 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string }
+  - { name: overrides, type: CNANullAssetOverrides_v1 }
+
+- name: CNANullAssetOverrides_v1
+  fields:
   - { name: addr_block, type: string }
 
 - name: CNARDSInstance_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1008,10 +1008,11 @@ confs:
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: account, type: AWSAccount_v1, isRequired: true }
   - { name: overrides, type: CNAAssumeRoleAssetOverrides_v1 }
+  - { name: defaults, type: string, isRequired: true, isResource: true, resolveResource: true }
 
 - name: CNAAssumeRoleAssetOverrides_v1
   fields:
-  - { name: slug, type: string, isRequired: true }
+  - { name: slug, type: string }
 
 - name: CNANullAsset_v1
   interface: CNAsset_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1027,7 +1027,7 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: vpc, type: AWSVPC_v1, isRequired: true }
-  - { name: defaults, type: string, isRequired: true, isResource: true }
+  - { name: defaults, type: string, isRequired: true, isResource: true, resolveResource: true }
   - { name: overrides, type: CNARDSInstanceOverrides_v1 }
 
 - name: CNARDSInstanceOverrides_v1

--- a/schemas/cna/asset-1.yml
+++ b/schemas/cna/asset-1.yml
@@ -17,15 +17,9 @@ properties:
     "$ref": "/common-1.json#/definitions/longIdentifier"
   addr_block:
     type: string
-  aws_assume_role:
-    type: object
-    additionalProperties: false
-    properties:
-      account:
-        "$ref": "/common-1.json#/definitions/crossref"
-        "$schemaRef": "/aws/account-1.yml"
-      slug:
-        type: string
+  aws_account:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/aws/account-1.yml"
   vpc:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/aws/vpc-1.yml"
@@ -44,8 +38,12 @@ oneOf:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     description:
       type: string
-    addr_block:
-      type: string
+    overrides:
+      type: object
+      additionalProperties: false
+      properties:
+        addr_block:
+          type: string
   required:
   - identifier
 - additionalProperties: false
@@ -56,18 +54,20 @@ oneOf:
       - aws-assume-role
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
-    aws_assume_role:
+    aws_account:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/aws/account-1.yml"
+    overrides:
       type: object
       additionalProperties: false
       properties:
-        account:
-          "$ref": "/common-1.json#/definitions/crossref"
-          "$schemaRef": "/aws/account-1.yml"
         slug:
           type: string
+      required:
+      - slug
   required:
   - identifier
-  - aws_assume_role
+  - account
 - additionalProperties: false
   properties:
     provider:

--- a/schemas/cna/asset-1.yml
+++ b/schemas/cna/asset-1.yml
@@ -65,6 +65,8 @@ oneOf:
           type: string
       required:
       - slug
+    defaults:
+      "$ref": "/common-1.json#/definitions/resourceref"
   required:
   - identifier
   - account

--- a/schemas/cna/asset-1.yml
+++ b/schemas/cna/asset-1.yml
@@ -26,6 +26,13 @@ properties:
         "$schemaRef": "/aws/account-1.yml"
       slug:
         type: string
+  vpc:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/aws/vpc-1.yml"
+  defaults:
+    type: string
+  overrides:
+    type: object
 oneOf:
 - additionalProperties: false
   properties:
@@ -61,3 +68,81 @@ oneOf:
   required:
   - identifier
   - aws_assume_role
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - aws-rds
+    identifier:
+      type: string
+    vpc:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/aws/vpc-1.yml"
+    defaults:
+      "$ref": "/common-1.json#/definitions/resourceref"
+    overrides:
+      type: object
+      properties:
+        name:
+          type: string
+        engine:
+          type: string
+          enum:
+          - postgres
+        engine_version:
+          type: string
+        username:
+          type: string
+        instance_class:
+          type: string
+          enum:
+          - db.t2.micro
+          - db.t2.small
+          - db.t3.small
+          - db.m3.medium
+          - db.t3.medium
+          - db.m4.large
+          - db.m4.xlarge
+          - db.m4.2xlarge
+          - db.m5.large
+          - db.m5.xlarge
+          - db.m5.2xlarge
+          - db.m5.4xlarge
+          - db.m5.8xlarge
+          - db.m5.12xlarge
+          - db.m5.16xlarge
+          - db.m5.24xlarge
+          - db.m6g.large
+          - db.m6g.xlarge
+          - db.m6g.2xlarge
+          - db.m6g.4xlarge
+          - db.m6g.8xlarge
+          - db.m6g.12xlarge
+          - db.m6g.16xlarge
+          - db.r4.large
+          - db.r4.xlarge
+          - db.r4.2xlarge
+          - db.r4.4xlarge
+          - db.r4.8xlarge
+          - db.r4.16xlarge
+          - db.r5.large
+          - db.r5.xlarge
+          - db.r5.2xlarge
+          - db.r5.4xlarge
+          - db.r5.8xlarge
+          - db.r5.12xlarge
+          - db.r5.16xlarge
+          - db.r5.24xlarge
+        allocated_storage:
+          type: integer
+        max_allocated_storage:
+          type: integer
+        backup_retention_period:
+          type: integer
+        db_subnet_group_name:
+          type: string
+  required:
+  - identifier
+  - vpc
+  - defaults


### PR DESCRIPTION
this is a first draft of the aws-rds CNA provider schema. it naively maps the fields required by the CNA module to a schema without considering concepts like `defaults` or `overwrites` for defaults as the `terraform-resources` flavour does.

```
  - provider: aws-rds
    identifier: cna-test-rds
    vpc:
      $ref: /aws/acc/vpcs/vpc.yml
    defaults: /path/to/defaults.yml
    overrides:
      db_subnet_group_name: default
```

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>