### PR TITLE
Add attributes for gitlab sync support

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2002,11 +2002,23 @@ confs:
   fields:
   - { name: role, type: Role_v1, isRequired: true }
 
+- name: CodeComponentGitlabSync_v1
+  fields:
+  - { name: sourceProject, type: CodeComponentGitlabSyncProject_v1, isRequired: true }
+  - { name: destinationProject, type: CodeComponentGitlabSyncProject_v1, isRequired: true }
+
+- name: CodeComponentGitlabSyncProject_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: group, type: string, isRequired: true }
+  - { name: branch, type: string, isRequired: true }
+
 - name: AppCodeComponents_v1
   fields:
   - { name: name, type: string, isRequired: true }
   - { name: resource, type: string, isRequired: true }
   - { name: url, type: string, isRequired: true }
+  - { name: gitlabSync, type: CodeComponentGitlabSync_v1 }
   - { name: showInReviewQueue, type: boolean}
   - { name: gitlabRepoOwners, type: CodeComponentGitlabOwners_v1 }
   - { name: gitlabHousekeeping, type: CodeComponentGitlabHousekeeping_v1 }

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -314,6 +314,9 @@ properties:
                   type: string
                 branch: 
                   type: string
+          required:
+          - sourceProject
+          - destinationProject
         gitlabRepoOwners:
           type: object
           properties:

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -293,6 +293,27 @@ properties:
           description: Include MRs from this repo in the AppSRE Review Queue
         url:
           type: string
+        gitlabSync:
+          type: object
+          properties:
+            sourceProject:
+              type: object
+              properties:
+                name: 
+                  type: string
+                group: 
+                  type: string
+                branch: 
+                  type: string
+            destinationProject:
+              type: object
+              properties:
+                name: 
+                  type: string
+                group: 
+                  type: string
+                branch: 
+                  type: string
         gitlabRepoOwners:
           type: object
           properties:


### PR DESCRIPTION
Adds support for specifying partitioned gitlab instance to copy repositories to. https://github.com/app-sre/git-partition-sync-producer performs the graphql query to obtain the sync configuration.

ticket: https://issues.redhat.com/browse/APPSRE-6544