### PR TITLE
Add googleChat to IntegrationSpecLogs_v1

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2659,6 +2659,7 @@ confs:
 - name: IntegrationSpecLogs_v1
   fields:
   - { name: slack, type: boolean }
+  - { name: googleChat, type: boolean }
 
 - name: AWSShardSpecOverride_v1
   interface: IntegrationSpecShardSpecOverride_v1


### PR DESCRIPTION
Following up on !272 this adds googleChat as a logging parameter for FedRamp.

[APPSRE-6564](https://issues.redhat.com/browse/APPSRE-6564)