### PR TITLE
add 2fa enforcement support to cloudflare account schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1015,6 +1015,7 @@ confs:
   - { name: apiCredentials, type: VaultSecret_v1, isRequired: true }
   - { name: terraformStateAccount, type: AWSAccount_v1, isRequired: true }
   - { name: deletionApprovals, type: DeletionApproval_v1, isList: true }
+  - { name: enforceTwofactor, type: boolean }
 
 - name: AWSGroup_v1
   fields:

--- a/schemas/cloudflare/account-1.yml
+++ b/schemas/cloudflare/account-1.yml
@@ -30,6 +30,8 @@ properties:
       - email
   apiCredentials:
     "$ref": "/common-1.json#/definitions/vaultSecret"
+  enforceTwofactor:
+    type: boolean
   terraformStateAccount:
     description: AWS Account to use for state in S3
     "$ref": "/common-1.json#/definitions/crossref"


### PR DESCRIPTION
[APPSRE-6571](https://issues.redhat.com/browse/APPSRE-6571)

This is the schema needed for https://github.com/app-sre/qontract-reconcile/pull/2964 which allows setting 2FA enforcement on Cloudflare accounts via the account definition file
