### PR TITLE
override and default schema represented by same schema objects

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1007,10 +1007,10 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: aws_account, type: AWSAccount_v1, isRequired: true }
-  - { name: overrides, type: CNAAssumeRoleAssetOverrides_v1 }
-  - { name: defaults, type: string, isRequired: true, isResource: true, resolveResource: true }
+  - { name: defaults, type: CNAAssumeRoleAssetConfig_v1 }
+  - { name: overrides, type: CNAAssumeRoleAssetConfig_v1 }
 
-- name: CNAAssumeRoleAssetOverrides_v1
+- name: CNAAssumeRoleAssetConfig_v1
   fields:
   - { name: slug, type: string }
 
@@ -1020,9 +1020,10 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string }
-  - { name: overrides, type: CNANullAssetOverrides_v1 }
+  - { name: defaults, type: CNANullAssetConfig_v1 }
+  - { name: overrides, type: CNANullAssetConfig_v1 }
 
-- name: CNANullAssetOverrides_v1
+- name: CNANullAssetConfig_v1
   fields:
   - { name: addr_block, type: string }
 
@@ -1031,21 +1032,28 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
-  - { name: vpc, type: AWSVPC_v1, isRequired: true }
-  - { name: defaults, type: string, isRequired: true, isResource: true, resolveResource: true }
-  - { name: overrides, type: CNARDSInstanceOverrides_v1 }
-
-- name: CNARDSInstanceOverrides_v1
-  fields:
   - { name: name, type: string }
-  - { name: engine, type: string }
-  - { name: engine_version, type: string }
-  - { name: username, type: string }
+  - { name: defaults, type: CNARDSInstanceConfig_v1 }
+  - { name: overrides, type: CNARDSInstanceConfig_v1 }
+
+- name: CNARDSInstanceConfig_v1
+  fields:
+  - { name: vpc, type: AWSVPC_v1 }
+  - { name: db_subnet_group_name, type: string }
   - { name: instance_class, type: string }
   - { name: allocated_storage, type: int }
   - { name: max_allocated_storage, type: int }
+  - { name: engine, type: string }
+  - { name: engine_version, type: string }
+  - { name: major_engine_version, type: string}
+  - { name: username, type: string }
+  - { name: maintenance_window, type: string }
   - { name: backup_retention_period, type: int }
-  - { name: db_subnet_group_name, type: string }
+  - { name: backup_window, type: string }
+  - { name: multi_az, type: boolean }
+  - { name: deletion_protection, type: boolean }
+  - { name: apply_immediately, type: boolean }
+
 
 - name: CloudflareAccount_v1
   interface: ExternalResourcesProvisioner_v1

--- a/schemas/cna/asset-1.yml
+++ b/schemas/cna/asset-1.yml
@@ -15,18 +15,18 @@ properties:
     "$ref": "/common-1.json#/definitions/annotations"
   identifier:
     "$ref": "/common-1.json#/definitions/longIdentifier"
-  addr_block:
+  name:
     type: string
   aws_account:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/aws/account-1.yml"
-  vpc:
-    "$ref": "/common-1.json#/definitions/crossref"
-    "$schemaRef": "/aws/vpc-1.yml"
   defaults:
-    type: string
+    "$ref": "/common-1.json#/definitions/crossref"
   overrides:
-    type: object
+    oneOf:
+      - "$ref": "/cna/null-asset-config-1.yml"
+      - "$ref": "/cna/aws-assume-role-config-1.yml"
+      - "$ref": "/cna/aws-rds-config-1.yml"
 oneOf:
 - additionalProperties: false
   properties:
@@ -38,12 +38,11 @@ oneOf:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     description:
       type: string
+    defaults:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/cna/null-asset-config-1.yml"
     overrides:
-      type: object
-      additionalProperties: false
-      properties:
-        addr_block:
-          type: string
+      "$ref": "/cna/null-asset-config-1.yml"
   required:
   - identifier
 - additionalProperties: false
@@ -57,16 +56,11 @@ oneOf:
     aws_account:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/aws/account-1.yml"
-    overrides:
-      type: object
-      additionalProperties: false
-      properties:
-        slug:
-          type: string
-      required:
-      - slug
     defaults:
-      "$ref": "/common-1.json#/definitions/resourceref"
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/cna/aws-assume-role-config-1.yml"
+    overrides:
+      "$ref": "/cna/aws-assume-role-config-1.yml"
   required:
   - identifier
   - aws_account
@@ -78,73 +72,17 @@ oneOf:
       - aws-rds
     identifier:
       type: string
-    vpc:
-      "$ref": "/common-1.json#/definitions/crossref"
-      "$schemaRef": "/aws/vpc-1.yml"
+      description: The name for the CNA
+    name:
+      type: string
+      description: |
+        The identifier for the RDS instance.
+        Defaults to the `identifier` field
     defaults:
-      "$ref": "/common-1.json#/definitions/resourceref"
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/cna/aws-rds-config-1.yml"
     overrides:
-      type: object
-      properties:
-        name:
-          type: string
-        engine:
-          type: string
-          enum:
-          - postgres
-        engine_version:
-          type: string
-        username:
-          type: string
-        instance_class:
-          type: string
-          enum:
-          - db.t2.micro
-          - db.t2.small
-          - db.t3.small
-          - db.m3.medium
-          - db.t3.medium
-          - db.m4.large
-          - db.m4.xlarge
-          - db.m4.2xlarge
-          - db.m5.large
-          - db.m5.xlarge
-          - db.m5.2xlarge
-          - db.m5.4xlarge
-          - db.m5.8xlarge
-          - db.m5.12xlarge
-          - db.m5.16xlarge
-          - db.m5.24xlarge
-          - db.m6g.large
-          - db.m6g.xlarge
-          - db.m6g.2xlarge
-          - db.m6g.4xlarge
-          - db.m6g.8xlarge
-          - db.m6g.12xlarge
-          - db.m6g.16xlarge
-          - db.r4.large
-          - db.r4.xlarge
-          - db.r4.2xlarge
-          - db.r4.4xlarge
-          - db.r4.8xlarge
-          - db.r4.16xlarge
-          - db.r5.large
-          - db.r5.xlarge
-          - db.r5.2xlarge
-          - db.r5.4xlarge
-          - db.r5.8xlarge
-          - db.r5.12xlarge
-          - db.r5.16xlarge
-          - db.r5.24xlarge
-        allocated_storage:
-          type: integer
-        max_allocated_storage:
-          type: integer
-        backup_retention_period:
-          type: integer
-        db_subnet_group_name:
-          type: string
+      "$ref": "/cna/aws-rds-config-1.yml"
   required:
   - identifier
-  - vpc
   - defaults

--- a/schemas/cna/aws-assume-role-config-1.yml
+++ b/schemas/cna/aws-assume-role-config-1.yml
@@ -10,5 +10,3 @@ properties:
     - /cna/aws-assume-role-config-1.yml
   slug:
     type: string
-required:
-- "$schema"

--- a/schemas/cna/aws-assume-role-config-1.yml
+++ b/schemas/cna/aws-assume-role-config-1.yml
@@ -1,0 +1,14 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /cna/aws-assume-role-config-1.yml
+  slug:
+    type: string
+required:
+- "$schema"

--- a/schemas/cna/aws-rds-config-1.yml
+++ b/schemas/cna/aws-rds-config-1.yml
@@ -107,5 +107,4 @@ properties:
     type: boolean
     description: |
       Indicates whether to apply changes immediately, or wait until the next maintenance window
-required:
-- "$schema"
+

--- a/schemas/cna/aws-rds-config-1.yml
+++ b/schemas/cna/aws-rds-config-1.yml
@@ -1,0 +1,111 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /cna/aws-rds-config-1.yml
+  vpc:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/aws/vpc-1.yml"
+    description: The VPC the RDS instance is created in.
+  db_subnet_group_name:
+    type: string
+    description: |
+      Name of DB subnet group. DB instance will be created in the VPC
+      associated with the DB subnet group.
+      Must exist in the referenced VPC.
+      Mandatory: must be set here or provided via a default.
+  instance_class:
+    type: string
+    enum:
+    - db.t2.micro
+    - db.t2.small
+    - db.t3.small
+    - db.m3.medium
+    - db.t3.medium
+    - db.m4.large
+    - db.m4.xlarge
+    - db.m4.2xlarge
+    - db.m5.large
+    - db.m5.xlarge
+    - db.m5.2xlarge
+    - db.m5.4xlarge
+    - db.m5.8xlarge
+    - db.m5.12xlarge
+    - db.m5.16xlarge
+    - db.m5.24xlarge
+    - db.m6.large
+    - db.m6g.large
+    - db.m6g.xlarge
+    - db.m6g.2xlarge
+    - db.m6g.4xlarge
+    - db.m6g.8xlarge
+    - db.m6g.12xlarge
+    - db.m6g.16xlarge
+    - db.r4.large
+    - db.r4.xlarge
+    - db.r4.2xlarge
+    - db.r4.4xlarge
+    - db.r4.8xlarge
+    - db.r4.16xlarge
+    - db.r5.large
+    - db.r5.xlarge
+    - db.r5.2xlarge
+    - db.r5.4xlarge
+    - db.r5.8xlarge
+    - db.r5.12xlarge
+    - db.r5.16xlarge
+    - db.r5.24xlarge
+    description: |
+      Provided via a default or overwritten here.
+  allocated_storage:
+    type: integer
+    description: allocated storage in Gi
+  max_allocated_storage:
+    type: integer
+    description: max allocated storage in Gi
+  engine:
+    type: string
+    enum:
+    - postgres
+  engine_version:
+    type: string
+    description: The engine version to use
+  major_engine_version:
+    type: string
+    description: Specifies the major version of the engine that this option group should be associated with
+  username:
+    type: string
+  maintenance_window:
+    type: string
+    description: |
+      The window to perform maintenance in.
+      Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00'
+  backup_retention_period:
+    type: integer
+    description: The days to retain backups for
+  backup_window:
+    type: string
+    description: |
+      The daily time range (in UTC) during which automated backups are created if they are enabled.
+      Example: '09:46-10:16'
+      Must not overlap with maintenance_window
+  multi_az:
+    type: boolean
+    description: |
+      Whether to use a multi-az configuration that includes a standby instance to improve
+      availability when a failover is required (certain upgrades, instance hardware issues, etc.)
+  deletion_protection:
+    type: boolean
+    description:
+      Protect against deletion. Defaults to true.
+  apply_immediately:
+    type: boolean
+    description: |
+      Indicates whether to apply changes immediately, or wait until the next maintenance window
+required:
+- "$schema"

--- a/schemas/cna/null-asset-config-1.yml
+++ b/schemas/cna/null-asset-config-1.yml
@@ -1,0 +1,12 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /cna/null-asset-config-1.yml
+  addr_block:
+    type: string


### PR DESCRIPTION
all CNA assets must have a `defaults` and an `overrides` section, as a lot of the terraform-resources do. the difference is, that each CNA type declares a special `XXXConfig_v1` type that is used for both fields.

```yaml
  name: CNARDSInstance_v1
  interface: CNAsset_v1
  fields:
  - { name: provider, type: string, isRequired: true }
  - { name: identifier, type: string, isRequired: true, isUnique: true }
  - { name: name, type: string }
  - { name: defaults, type: CNARDSInstanceConfig_v1 } <--
  - { name: overrides, type: CNARDSInstanceConfig_v1 } <--
```

having defaults following a strict schema and overrides being able to override all of the defaults, makes writing testable and verifiable code a lot easier.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>