### PR TITLE
cluster.auth attribute becomes a list of objects instead of a single object (#317)

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -793,7 +793,7 @@ confs:
   - { name: labels, type: json }
   - { name: name, type: string, isUnique: true, isSearchable: true, isRequired: true }
   - { name: description, type: string }
-  - { name: auth, type: ClusterAuth_v1, isInterface: true }
+  - { name: auth, type: ClusterAuth_v1, isInterface: true, isList: true, isRequired: true }
   - { name: observabilityNamespace, type: Namespace_v1 }
   - { name: grafanaUrl, type: string }
   - { name: consoleUrl, type: string, isRequired: true }

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -32,49 +32,51 @@ properties:
     type: string
     format: uri
   auth:
-    type: object
-    properties:
-      service:
-        type: string
-        enum:
-        - github-org
-        - github-org-team
-        - oidc
-      org:
-        type: string
-      team:
-        type: string
-    oneOf:
-    - properties:
+    type: array
+    items:
+      type: object
+      properties:
         service:
           type: string
           enum:
           - github-org
-        org:
-          type: string
-      required:
-      - service
-      - org
-    - properties:
-        service:
-          type: string
-          enum:
           - github-org-team
+          - oidc
         org:
           type: string
         team:
           type: string
-      required:
-      - service
-      - org
-      - team
-    - properties:
-        service:
-          type: string
-          enum:
-          - oidc
-      required:
-      - service
+      oneOf:
+      - properties:
+          service:
+            type: string
+            enum:
+            - github-org
+          org:
+            type: string
+        required:
+        - service
+        - org
+      - properties:
+          service:
+            type: string
+            enum:
+            - github-org-team
+          org:
+            type: string
+          team:
+            type: string
+        required:
+        - service
+        - org
+        - team
+      - properties:
+          service:
+            type: string
+            enum:
+            - oidc
+        required:
+        - service
   observabilityNamespace:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/openshift/namespace-1.yml"


### PR DESCRIPTION
This is a rework of #317, which was reverted. For the reviewer, nothing has changed compared to #317 

Breaking Change: The `cluster.auth` attribute is now a list and **required**

We want to support [multiple auth backends](https://issues.redhat.com/browse/APPSRE-6374) at the same time.

* [APPSRE-6374](https://issues.redhat.com/browse/APPSRE-6374)
* [APPSRE-6554](https://issues.redhat.com/browse/APPSRE-6554)
