### PR TITLE
[cna] RDS overrides as json with all optional

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1032,7 +1032,7 @@ confs:
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: aws_account, type: AWSAccount_v1, isRequired: true }
   - { name: defaults, type: CNAAssumeRoleAssetConfig_v1 }
-  - { name: overrides, type: CNAAssumeRoleAssetConfig_v1 }
+  - { name: overrides, type: json }
 
 - name: CNAAssumeRoleAssetConfig_v1
   fields:
@@ -1045,7 +1045,7 @@ confs:
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string }
   - { name: defaults, type: CNANullAssetConfig_v1 }
-  - { name: overrides, type: CNANullAssetConfig_v1 }
+  - { name: overrides, type: json }
 
 - name: CNANullAssetConfig_v1
   fields:
@@ -1057,19 +1057,18 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: name, type: string }
-  - { name: defaults, type: CNARDSInstanceConfig_v1 }
-  - { name: overrides, type: CNARDSInstanceConfig_v1 }
+  - { name: defaults, type: CNARDSInstanceDefaults_v1 }
+  - { name: overrides, type: json }
 
-- name: CNARDSInstanceConfig_v1
+- name: CNARDSInstanceDefaults_v1
   fields:
-  - { name: vpc, type: AWSVPC_v1 }
-  - { name: db_subnet_group_name, type: string }
-  - { name: instance_class, type: string }
-  - { name: allocated_storage, type: int }
-  - { name: max_allocated_storage, type: int }
-  - { name: engine, type: string }
-  - { name: engine_version, type: string }
-  - { name: major_engine_version, type: string}
+  - { name: vpc, type: AWSVPC_v1, isRequired: true }
+  - { name: db_subnet_group_name, type: string, isRequired: true }
+  - { name: instance_class, type: string, isRequired: true }
+  - { name: allocated_storage, type: int, isRequired: true }
+  - { name: max_allocated_storage, type: int, isRequired: true }
+  - { name: engine, type: string, isRequired: true }
+  - { name: engine_version, type: string, isRequired: true }
   - { name: username, type: string }
   - { name: maintenance_window, type: string }
   - { name: backup_retention_period, type: int }

--- a/schemas/cna/asset-1.yml
+++ b/schemas/cna/asset-1.yml
@@ -23,10 +23,7 @@ properties:
   defaults:
     "$ref": "/common-1.json#/definitions/crossref"
   overrides:
-    oneOf:
-      - "$ref": "/cna/null-asset-config-1.yml"
-      - "$ref": "/cna/aws-assume-role-config-1.yml"
-      - "$ref": "/cna/aws-rds-config-1.yml"
+    type: object
 oneOf:
 - additionalProperties: false
   properties:
@@ -71,7 +68,7 @@ oneOf:
       enum:
       - aws-rds
     identifier:
-      type: string
+      "$ref": "/common-1.json#/definitions/longIdentifier"
       description: The name for the CNA
     name:
       type: string
@@ -82,7 +79,49 @@ oneOf:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/cna/aws-rds-config-1.yml"
     overrides:
-      "$ref": "/cna/aws-rds-config-1.yml"
+      type: object
+      additionalProperties: false
+      properties:
+        db_subnet_group_name:
+          type: string
+        instance_class:
+          "$ref": "/common-1.json#/definitions/rdsDbInstanceClass"
+        allocated_storage:
+          type: integer
+          description: allocated storage in Gi
+        max_allocated_storage:
+          type: integer
+          description: max allocated storage in Gi
+        engine_version:
+          type: string
+          description: The engine version to use
+        username:
+          type: string
+        maintenance_window:
+          type: string
+          description: |
+            The window to perform maintenance in.
+            Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00'
+        backup_retention_period:
+          type: integer
+          description: The days to retain backups for
+        backup_window:
+          type: string
+          description: |
+            The daily time range (in UTC) during which automated backups are created if they are enabled.
+            Example: '09:46-10:16'
+            Must not overlap with maintenance_window
+        multi_az:
+          type: boolean
+          description: |
+            Whether to use a multi-az configuration that includes a standby instance to improve
+            availability when a failover is required (certain upgrades, instance hardware issues, etc.)
+        deletion_protection:
+          type: boolean
+          description:
+            Protect against deletion. Defaults to true.
+        apply_immediately:
+          type: boolean
   required:
   - identifier
   - defaults

--- a/schemas/cna/aws-rds-config-1.yml
+++ b/schemas/cna/aws-rds-config-1.yml
@@ -20,48 +20,7 @@ properties:
       Must exist in the referenced VPC.
       Mandatory: must be set here or provided via a default.
   instance_class:
-    type: string
-    enum:
-    - db.t2.micro
-    - db.t2.small
-    - db.t3.small
-    - db.m3.medium
-    - db.t3.medium
-    - db.m4.large
-    - db.m4.xlarge
-    - db.m4.2xlarge
-    - db.m5.large
-    - db.m5.xlarge
-    - db.m5.2xlarge
-    - db.m5.4xlarge
-    - db.m5.8xlarge
-    - db.m5.12xlarge
-    - db.m5.16xlarge
-    - db.m5.24xlarge
-    - db.m6.large
-    - db.m6g.large
-    - db.m6g.xlarge
-    - db.m6g.2xlarge
-    - db.m6g.4xlarge
-    - db.m6g.8xlarge
-    - db.m6g.12xlarge
-    - db.m6g.16xlarge
-    - db.r4.large
-    - db.r4.xlarge
-    - db.r4.2xlarge
-    - db.r4.4xlarge
-    - db.r4.8xlarge
-    - db.r4.16xlarge
-    - db.r5.large
-    - db.r5.xlarge
-    - db.r5.2xlarge
-    - db.r5.4xlarge
-    - db.r5.8xlarge
-    - db.r5.12xlarge
-    - db.r5.16xlarge
-    - db.r5.24xlarge
-    description: |
-      Provided via a default or overwritten here.
+    "$ref": "/common-1.json#/definitions/rdsDbInstanceClass"
   allocated_storage:
     type: integer
     description: allocated storage in Gi
@@ -75,9 +34,6 @@ properties:
   engine_version:
     type: string
     description: The engine version to use
-  major_engine_version:
-    type: string
-    description: Specifies the major version of the engine that this option group should be associated with
   username:
     type: string
   maintenance_window:
@@ -107,4 +63,12 @@ properties:
     type: boolean
     description: |
       Indicates whether to apply changes immediately, or wait until the next maintenance window
-
+required:
+- "$schema"
+- vpc
+- db_subnet_group_name
+- instance_class
+- allocated_storage
+- max_allocated_storage
+- engine
+- engine_version

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -171,6 +171,49 @@
         "partial_outage",
         "major_outage"
       ]
+    },
+    "rdsDbInstanceClass": {
+      "type": "string",
+      "enum": [
+        "db.t2.micro",
+        "db.t2.small",
+        "db.t3.small",
+        "db.m3.medium",
+        "db.t3.medium",
+        "db.m4.large",
+        "db.m4.xlarge",
+        "db.m4.2xlarge",
+        "db.m5.large",
+        "db.m5.xlarge",
+        "db.m5.2xlarge",
+        "db.m5.4xlarge",
+        "db.m5.8xlarge",
+        "db.m5.12xlarge",
+        "db.m5.16xlarge",
+        "db.m5.24xlarge",
+        "db.m6.large",
+        "db.m6g.large",
+        "db.m6g.xlarge",
+        "db.m6g.2xlarge",
+        "db.m6g.4xlarge",
+        "db.m6g.8xlarge",
+        "db.m6g.12xlarge",
+        "db.m6g.16xlarge",
+        "db.r4.large",
+        "db.r4.xlarge",
+        "db.r4.2xlarge",
+        "db.r4.4xlarge",
+        "db.r4.8xlarge",
+        "db.r4.16xlarge",
+        "db.r5.large",
+        "db.r5.xlarge",
+        "db.r5.2xlarge",
+        "db.r5.4xlarge",
+        "db.r5.8xlarge",
+        "db.r5.12xlarge",
+        "db.r5.16xlarge",
+        "db.r5.24xlarge"
+      ]
     }
   }
 }


### PR DESCRIPTION
revert experiment where overrides and defaults are exactly the same schema. the result was that all fields in overrides and defaults needed to be optional so they can be used in both places without making overrides mandatory.

in this PR, overrides are now all optional, follow a schema in jsonschema but none in GQL where they are just JSON

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>