### PR TITLE
upgradePolicyTemplate in OCM upgradePolicyDefaults

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -859,11 +859,18 @@ confs:
   - { name: name, type: string, isRequired: true, isContextUnique: true }
   - { name: dependencies, type: OpenShiftClusterManagerSectorDependencies_v1, isList: true }
 
+- name: OpenShiftClusterManagerUpgradePolicyTemplate_v1
+  fields:
+  - { name: path, type: string, isRequired: true, isResource: true, resolveResource: true }
+  - { name: type, type: string }
+  - { name: variables, type: json }
+
 - name: OpenShiftClusterManagerUpgradePolicyDefault_v1
   fields:
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: matchLabels, type: json, isRequired: true }
-  - { name: upgradePolicy, type: ClusterUpgradePolicy_v1, isRequired: true }
+  - { name: upgradePolicy, type: ClusterUpgradePolicy_v1 }
+  - { name: upgradePolicyTemplate, type: OpenShiftClusterManagerUpgradePolicyTemplate_v1 }
 
 - name: OpenShiftClusterManagerUpgradePolicyCluster_v1
   fields:

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -109,10 +109,29 @@ properties:
             type: string
         upgradePolicy:
           "$ref": "/openshift/cluster-upgrade-policy-1.yml"
-      required:
-      - name
-      - matchLabels
-      - upgradePolicy
+        upgradePolicyTemplate:
+          type: object
+          properties:
+            path:
+              "$ref": "/common-1.json#/definitions/resourceref"
+            type:
+              type: string
+              enum:
+              - jinja2
+              - extracurlyjinja2
+            variables:
+              type: object
+          required:
+          - path
+      oneOf:
+      - required:
+        - name
+        - matchLabels
+        - upgradePolicy
+      - required:
+        - name
+        - matchLabels
+        - upgradePolicyTemplate
   upgradePolicyClusters:
     description: List of clusters to define upgrade policies for (no cluster management in such OCM orgs)
     type: array

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -96,39 +96,44 @@ properties:
     description: List of default upgrade policies to apply to clusters by external configuration labels
     type: array
     items:
-      type: object
-      additionalProperties: false
-      properties:
-        name:
-          description: upgrade policy name
-          type: string
-        matchLabels:
-          description: external configuration labels to select default upgrade policy by
-          type: object
-          additionalProperties:
-            type: string
-        upgradePolicy:
-          "$ref": "/openshift/cluster-upgrade-policy-1.yml"
-        upgradePolicyTemplate:
-          type: object
-          properties:
-            path:
-              "$ref": "/common-1.json#/definitions/resourceref"
-            type:
-              type: string
-              enum:
-              - jinja2
-              - extracurlyjinja2
-            variables:
-              type: object
-          required:
-          - path
       oneOf:
-      - required:
+      - additionalProperties: false
+        properties:
+          name:
+            type: string
+          matchLabels:
+            type: object
+            additionalProperties:
+              type: string
+          upgradePolicy:
+            "$ref": "/openshift/cluster-upgrade-policy-1.yml"
+        required:
         - name
         - matchLabels
         - upgradePolicy
-      - required:
+      - additionalProperties: false
+        properties:
+          name:
+            type: string
+          matchLabels:
+            type: object
+            additionalProperties:
+              type: string
+          upgradePolicyTemplate:
+            type: object
+            properties:
+              path:
+                "$ref": "/common-1.json#/definitions/resourceref"
+              type:
+                type: string
+                enum:
+                - jinja2
+                - extracurlyjinja2
+              variables:
+                type: object
+            required:
+            - path
+        required:
         - name
         - matchLabels
         - upgradePolicyTemplate


### PR DESCRIPTION
Allow to reference an upgradepolicy template from OCM `upgradePolicyDefaults`.

This avoids repeating many time the same default for different labels such as `sector` (or region, or cluster-type, ...).

https://issues.redhat.com/browse/APPSRE-6595

Example usage: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/52219/diffs