### PR TITLE
[change-types] saas-file-target referencable in self-service role

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2234,6 +2234,12 @@ confs:
   - { name: disable, type: boolean }
   - { name: delete, type: boolean }
 
+- name: SaasResourceTemplateTargetReference_v2
+  datafile: /app-sre/saas-file-target-1.yml
+  fields:
+  - { name: path, type: string, isRequired: true }
+  - { name: schema, type: string, isRequired: true }
+
 - name: SaasResourceTemplateTargetUpstream_v1
   fields:
   - { name: instance, type: JenkinsInstance_v1, isRequired: true }


### PR DESCRIPTION
to be able to reference a datafile in a self-service role, it must inherently implement the `Datafile_v1` interface (think python protocol).

`Datafile_v1` requires a mandatory `path` attribute to be present, which usually makes sense for datafiles since they are actual files with a path in the filesystem of the bundle. `/app-sre/saas-file-target-1.yml` is different in the way that it is used as a datafile, but also inline. therefore the `path` field is optional in the case where it is used inline. graphql sees a conflict in this and does not allow the GQL type `SaasResourceTemplateTarget_v2` to be referencable in self service roles.

the trick is to come up with a second GQL type `SaasResourceTemplateTargetReference_v2` which is compatible with `Datafile_v1` and bind the `jsonschema` `/app-sre/saas-file-target-1.yml` to it.

this is not entirely elegant (misunderstand of the year) but will do for now until we can come up with a better solution maybe directly supported in qontract-server.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>