### PR TITLE
OCM org inheritance for cluster versions

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -917,6 +917,8 @@ confs:
   - { name: sectors, type: OpenShiftClusterManagerSector_v1, isList: true }
   - { name: upgradePolicyDefaults, type: OpenShiftClusterManagerUpgradePolicyDefault_v1, isList: true }
   - { name: upgradePolicyClusters, type: OpenShiftClusterManagerUpgradePolicyCluster_v1, isList: true }
+  - { name: inheritVersionData, type: OpenShiftClusterManager_v1, isList: true }
+  - { name: publishVersionData, type: OpenShiftClusterManager_v1, isList: true }
   - name: clusters
     type: Cluster_v1
     isList: true

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -152,6 +152,18 @@ properties:
       required:
       - name
       - upgradePolicy
+  inheritVersionData:
+    description: list of OCM organizations from which we will retrieve cluster version informations (current versions stats, soak days, sectors, ..).
+    type: array
+    items:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": /openshift/openshift-cluster-manager-1.yml
+  publishVersionData:
+    description: list of OCM organizations to which we will publish cluster version informations (current versions stats, soak days, sectors, ..)
+    type: array
+    items:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": /openshift/openshift-cluster-manager-1.yml
 dependencies:
   upgradePolicyDefaults:
   - upgradePolicyClusters


### PR DESCRIPTION
[APPSRE-6549](https://issues.redhat.com/browse/APPSRE-6549)

Implementation PR: https://github.com/app-sre/qontract-reconcile/pull/3007

Allow to inherit cluster version data information from one org to an other. There are 2 fields: one on the publishing org and one on the one inheriting the data. This is to ensure both org owner agree to this data sharing.