### PR TITLE
[change-types] templated jsonpath selector expressions

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3313,13 +3313,20 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: changeSchema, type: string }
-  - { name: jsonPathSelectors, type: string, isList: true, isRequired: true }
+  - { name: jsonPathSelectors, type: string, isList: true }
+  - { name: jsonPathSelectorTemplates, type: ChangeTypeChangeDetectorJsonPathSelectorTemplate_v1, isList: true }
   - { name: context, type: ChangeTypeChangeDetectorContextSelector_v1 }
+
+- name: ChangeTypeChangeDetectorJsonPathSelectorTemplate_v1
+  fields:
+  - { name: var, type: string, isRequired: true }
+  - { name: items, type: string, isRequired: true }
+  - { name: template, type: string, isRequired: true }
 
 - name: ChangeTypeChangeDetectorContextSelector_v1
   fields:
   - { name: selector, type: string, isRequired: true }
-  - { name: when, type: "string" }
+  - { name: when, type: string }
 
 - name: RosaOcmSpec_v1
   fields:

--- a/schemas/app-interface/change-type-1.yml
+++ b/schemas/app-interface/change-type-1.yml
@@ -39,7 +39,6 @@ properties:
       "$schemaRef": "/app-interface/change-type-1.yml"
   changes:
     type: array
-    minItems: 1
     items:
       oneOf:
       - type: object
@@ -55,6 +54,10 @@ properties:
             type: array
             items:
               type: string
+          jsonPathSelectorTemplates:
+            type: array
+            items:
+              "$ref": "/app-interface/change-type-jsonpath-selector-template-1.yml"
           context:
             type: object
             additionalProperties: false
@@ -66,9 +69,13 @@ properties:
                 enum:
                 - added
                 - removed
-        required:
-        - provider
-        - jsonPathSelectors
+        oneOf:
+        - required:
+          - provider
+          - jsonPathSelectors
+        - required:
+          - provider
+          - jsonPathSelectorTemplates
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
enable a GraphQL data driven approach to generate jsonpath expressions to describe what can be changed with a change-type

```yaml
changes:
- provider: jsonPath
  ...
  changeSchema: /app-sre/saas-file-2.yml
  jsonPathSelectorTemplates:
  - var: ns
    items: gql+jsonpath://clusters_v1[?(@.path=='{{ ctx_file_path }}')].namespaces[*].path
    template: resourceTemplates[*].targets[?(@.namespace.'$ref'=='{{ ns }}')]
```

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>