### PR TITLE
reverse reference between app and statuspage component

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2124,7 +2124,12 @@ confs:
   - { name: endPoints, type: AppEndPoints_v1, isList: true }
   - { name: codeComponents, type: AppCodeComponents_v1, isList: true }
   - { name: sentryProjects, type: AppSentryProjects_v1, isList: true }
-  - { name: statusPageComponents, type: StatusPageComponent_v1, isList: true }
+  - name: statusPageComponents
+    type: StatusPageComponent_v1
+    isList: true
+    synthetic:
+      schema: /dependencies/status-page-component-1.yml
+      subAttr: app
   - name: namespaces
     type: Namespace_v1
     isList: true
@@ -3200,23 +3205,19 @@ confs:
       subAttr: page
 
 - name: StatusPageComponent_v1
+  datafile: /dependencies/status-page-component-1.yml
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true, isUnique: true }
+  - { name: app, type: App_v1, isRequired: true }
   - { name: displayName, type: string, isRequired: true }
   - { name: description, type: string }
   - { name: instructions, type: string, isRequired: true }
   - { name: page, type: StatusPage_v1, isRequired: true }
   - { name: groupName, type: string }
   - { name: status, type: StatusProvider_v1, isList: true, isInterface: true }
-  - name: apps
-    type: App_v1
-    isList: true
-    synthetic:
-      schema: /app-sre/app-1.yml
-      subAttr: statusPageComponents
 
 - name: EndpointMonitoringProvider_v1
   isInterface: true

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -168,6 +168,7 @@ properties:
                   - /openshift/openshift-cluster-manager-1.yml
                   - /dependencies/jira-board-1.yml
                   - /dependencies/glitchtip-project-1.yml
+                  - /dependencies/status-page-component-1.yml
 required:
 - $schema
 - labels

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -115,12 +115,6 @@ properties:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/dependencies/dependency-1.yml"
 
-  statusPageComponents:
-    type: array
-    items:
-      "$ref": "/common-1.json#/definitions/crossref"
-      "$schemaRef": "/dependencies/status-page-component-1.yml"
-
   gcrRepos:
     type: array
     items:

--- a/schemas/dependencies/status-page-component-1.yml
+++ b/schemas/dependencies/status-page-component-1.yml
@@ -13,6 +13,9 @@ properties:
     "$ref": "/common-1.json#/definitions/labels"
   name:
     type: string
+  app:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/app-sre/app-1.yml"
   displayName:
     type: string
   description:
@@ -36,6 +39,7 @@ required:
 - "$schema"
 - labels
 - name
+- app
 - displayName
 - instructions
 - page


### PR DESCRIPTION
similar to #335

instead of referencing status page components from an app file, we will reference the app from the statuspage component file.

this doesn't change much, but makes things consistent with other objects, like slo-document, scorecards, glitchtip projects, and more.