### PR TITLE
APPSRE-4706 Add reencrypt PGP schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3373,3 +3373,12 @@ confs:
   - { name: support_role_arn, type: string, isRequired: true}
   - { name: controlplane_role_arn, type: string, isRequired: true}
   - { name: worker_role_arn, type: string, isRequired: true}
+
+
+- name: PgpReencryptSettings_v1
+  fields:
+  - { name: public_gpg_key, type: string, isRequired: true }
+  - { name: private_pgp_key_vault_path, type: string, isRequired: true }
+  - { name: reencrypt_vault_path, type: string, isRequired: true }
+  - { name: aws_account_output_vault_path, type: string, isRequired: true }
+  - { name: skip_aws_accounts, type: AWSAccount_v1, isList: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2966,6 +2966,7 @@ confs:
   - { name: endpoint_monitoring_provider_v1, type: EndpointMonitoringProvider_v1, isList: true, isInterface: true, datafileSchema: /dependencies/endpoint-monitoring-provider-1.yml }
   - { name: change_types_v1, type: ChangeType_v1, isList: true, datafileSchema: /app-interface/change-type-1.yml }
   - { name: scorecards_v2, type: Scorecard_v2, isList: true, datafileSchema: /app-sre/scorecard-2.yml }
+  - { name: pgp_reencrypt_settings_v1, type: PgpReencryptSettings_v1, isList: true, datafileSchema: /app-sre/pgp-reencrypt-settings-1.yml }
 
 - name: GlitchtipInstance_v1
   fields:
@@ -3377,6 +3378,7 @@ confs:
 
 - name: PgpReencryptSettings_v1
   fields:
+  - { name: schema, type: string, isRequired: true }
   - { name: public_gpg_key, type: string, isRequired: true }
   - { name: private_pgp_key_vault_path, type: string, isRequired: true }
   - { name: reencrypt_vault_path, type: string, isRequired: true }

--- a/schemas/app-sre/pgp-reencrypt-settings-1.yml
+++ b/schemas/app-sre/pgp-reencrypt-settings-1.yml
@@ -1,0 +1,48 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /app-sre/pgp-reencrypt-settings-1.yml
+
+  public_gpg_key:
+    description: |
+      This PGP Public key will be used to encrypt the users, instead of the users keys.
+      It is owned by APP-SRE. The field name is not a type as it is consistent with access/user-1.yml schema.
+    type: string
+
+  private_pgp_key_vault_path:
+    description: |
+      This is the vault path to the private key used for reencryption.
+    type: string
+
+  reencrypt_vault_path:
+    description: |
+      Base path to read/write pgp encrypted entries from/to.
+    type: string
+
+  aws_account_output_vault_path:
+    description: |
+      Path to write reencrypted AWS Account passwords to.
+    type: string
+
+  skip_aws_accounts:
+    description: |
+      This is kind of a feature flipper. Access requests for AWS accounts listed here will be sent
+      using the SMTP mail send implementation in terraform-users integration.
+    type: array
+    items:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/aws/account-1.yml"
+
+required:
+- "$schema"
+- public_gpg_key
+- private_pgp_key_vault_path
+- reencrypt_vault_path
+- aws_account_output_vault_path


### PR DESCRIPTION
Required for PGP re-encryption. This adds configuration options used by terraform-users and account-notifier integration. 

`skip_aws_accounts` setting might be removed in the future, once re-encryption was rolled out for all accounts. 

Related issue: https://issues.redhat.com/browse/APPSRE-4706