### PR TITLE
enable support for managing routes in aws for account-vpc

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -737,6 +737,7 @@ confs:
   - { name: vpc, type: AWSVPC_v1, isRequired: true }
   - { name: description, type: string }
   - { name: manageRoutes, type: boolean }
+  - { name: manageAccountRoutes, type: boolean }
   - { name: delete, type: boolean }
   - { name: assumeRole, type: string }
 

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -334,6 +334,8 @@ properties:
               type: object
             manageRoutes:
               type: boolean
+            manageAccountRoutes:
+              type: boolean
             manageSecurityGroups:
               type: boolean
             cidrBlock:
@@ -357,6 +359,13 @@ properties:
                 "$schemaRef": "/aws/vpc-1.yml"
               manageRoutes:
                 type: boolean
+              manageAccountRoutes:
+                type: boolean
+                description: |
+                  historically, account-vpc did not have support for managing routes on the aws side.
+                  instead of re-using manageRoutes, this is a backwards compatible field for managing such routes.
+                  once all account-vpc connections that have manageRoutes also have manageAccountRoutes,
+                  we can consolidate to use managedRoutes only.
               delete:
                 type: boolean
               assumeRole:


### PR DESCRIPTION
historically, account-vpc did not have support for managing routes on the aws side.
instead of re-using manageRoutes, this is a backwards compatible field for managing such routes.
once all account-vpc connections that have manageRoutes also have manageAccountRoutes,
we can consolidate to use managedRoutes only.