### PR TITLE
cluster-1.yml#slack attribute

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -796,6 +796,11 @@ confs:
   - { name: url, type: string, isRequired: true }
   - { name: auth, type: VaultSecret_v1, isRequired: true}
 
+- name: ClusterSlack_v1
+  fields:
+  - { name: userGroup, type: string, isRequired: true }
+  - { name: channels, type: string, isList: true, isRequired: true}
+
 - name: Cluster_v1
   datafile: /openshift/cluster-1.yml
   fields:
@@ -806,6 +811,7 @@ confs:
   - { name: description, type: string }
   - { name: auth, type: ClusterAuth_v1, isInterface: true, isList: true, isRequired: true }
   - { name: observabilityNamespace, type: Namespace_v1 }
+  - { name: slack, type: ClusterSlack_v1 }
   - { name: grafanaUrl, type: string }
   - { name: consoleUrl, type: string, isRequired: true }
   - { name: kibanaUrl, type: string, isRequired: true }

--- a/schemas/dependencies/slack-workspace-1.yml
+++ b/schemas/dependencies/slack-workspace-1.yml
@@ -56,7 +56,6 @@ properties:
           - sentry-helper
           - slack-sender
           - openshift-upgrade-watcher
-          - slack-cluster-usergroups
           - qontract-cli
       token:
         "$ref": "/common-1.json#/definitions/vaultSecret"

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -104,6 +104,19 @@ properties:
   observabilityNamespace:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/openshift/namespace-1.yml"
+  slack:
+    type: object
+    additionalProperties: false
+    properties:
+      userGroup:
+        type: string
+      channels:
+        type: array
+        items:
+          type: string
+    required:
+      - userGroup
+      - channels
   grafanaUrl:
     type: string
     format: uri


### PR DESCRIPTION
* Add a dedicated `cluster-1` slack user group attribute to support clusters without GitHub authentication.
* Remove `slack-cluster-usergroups`

Tickets:
* slack-cluster-usergroups OIDC support ([APPSRE-6575](https://issues.redhat.com/browse/APPSRE-6575))
* Merge slack integrations ([APPSRE-6593](https://issues.redhat.com/browse/APPSRE-6593))