### PR TITLE
make issuer as non-required field in cluster.auth.service OIDC

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -575,7 +575,7 @@ confs:
   fields:
   - { name: service, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
-  - { name: issuer, type: string, isRequired: true }
+  - { name: issuer, type: string }
   - { name: claims, type: ClusterAuthOIDCClaims_v1 }
 
 - name: ClusterAuthOIDCClaims_v1

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -100,7 +100,6 @@ properties:
         required:
         - service
         - name
-        - issuer
   observabilityNamespace:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/openshift/namespace-1.yml"


### PR DESCRIPTION
FedRamp manages OIDC via `openshift-resources` instead of OCM and doesn't want to set a dummy issuer url.

[APPSRE-6678](https://issues.redhat.com/browse/APPSRE-6678)