### PR TITLE
slack-usergroup and slack-cluster-usergroup merge

### DIFF
--- a/schemas/dependencies/slack-workspace-1.yml
+++ b/schemas/dependencies/slack-workspace-1.yml
@@ -56,7 +56,7 @@ properties:
           - sentry-helper
           - slack-sender
           - openshift-upgrade-watcher
-          - slack-cluster-usergroups
+          - slack-usergroups
           - qontract-cli
       token:
         "$ref": "/common-1.json#/definitions/vaultSecret"

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -526,6 +526,7 @@ properties:
           - ocm-groups
           - ocm-machine-pools
           - ocm-upgrade-scheduler
+          - slack-usergroup
       e2eTests:
         type: array
         items:


### PR DESCRIPTION
Prepare the `slack-usergroup` and `slack-cluster-usergroup`merge.

* `slack-usergroup` has to use `slack-workspace.integrations` to get channel for cluster user groups
* support `cluster.disable.integration` for `slack-usergroup`

Tickets:
* [APPSRE-6593](https://issues.redhat.com/browse/APPSRE-6593)
