### PR TITLE
Revert "make issuer as non-required field in cluster.auth.service OIDC"

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -575,7 +575,7 @@ confs:
   fields:
   - { name: service, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
-  - { name: issuer, type: string }
+  - { name: issuer, type: string, isRequired: true }
   - { name: claims, type: ClusterAuthOIDCClaims_v1 }
 
 - name: ClusterAuthOIDCClaims_v1

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -100,6 +100,7 @@ properties:
         required:
         - service
         - name
+        - issuer
   observabilityNamespace:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/openshift/namespace-1.yml"


### PR DESCRIPTION
Reverts app-sre/qontract-schemas#350

The OIDC related changes in qontract-reconcile and qontract-schemas break FedRAMP environment authentication. We have to revert and align on a strategy that can exist in parallel.

re: https://coreos.slack.com/archives/GGC2A0MS8/p1670432900179959