### PR TITLE
Revert "OIDC IDP cluster auth object"

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -574,16 +574,6 @@ confs:
   interface: ClusterAuth_v1
   fields:
   - { name: service, type: string, isRequired: true }
-  - { name: name, type: string, isRequired: true }
-  - { name: issuer, type: string, isRequired: true }
-  - { name: claims, type: ClusterAuthOIDCClaims_v1 }
-
-- name: ClusterAuthOIDCClaims_v1
-  fields:
-  - { name: email, type: string, isList: true }
-  - { name: username, type: string, isList: true }
-  - { name: name, type: string, isList: true }
-  - { name: groups, type: string, isList: true }
 
 - name: KafkaClusterSpec_v1
   fields:

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -75,32 +75,8 @@ properties:
             type: string
             enum:
             - oidc
-          name:
-            type: string
-          issuer:
-            type: string
-            format: uri
-          claims:
-            email:
-              type: array
-              items:
-                type: string
-            username:
-              type: array
-              items:
-                type: string
-            name:
-              type: array
-              items:
-                type: string
-            groups:
-              type: array
-              items:
-                type: string
         required:
         - service
-        - name
-        - issuer
   observabilityNamespace:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/openshift/namespace-1.yml"
@@ -523,7 +499,6 @@ properties:
           - ocm-external-configuration-labels
           - ocm-clusters
           - ocm-github-idp
-          - ocm-oidc-idp
           - ocm-groups
           - ocm-machine-pools
           - ocm-upgrade-scheduler


### PR DESCRIPTION
Reverts app-sre/qontract-schemas#341

The OIDC related changes in qontract-reconcile and qontract-schemas break FedRAMP environment authentication. We have to revert and align on a strategy that can exist in parallel.

re: https://coreos.slack.com/archives/GGC2A0MS8/p1670432900179959