### PR TITLE
[pr-check] Shell GQL Logic Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
-	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG) && \
+	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG); \
 	 timeout 5 $(CONTAINER_ENGINE) run --rm \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
 	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG)
-	timeout 5 $(CONTAINER_ENGINE) run --rm \
+	@timeout 5 $(CONTAINER_ENGINE) run --rm \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,7 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
-	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG)
-	@timeout 5 $(CONTAINER_ENGINE) run --rm \
+	@timeout 20 $(CONTAINER_ENGINE) run --rm \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
 	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG)
-	@timeout 10 $(CONTAINER_ENGINE) run --rm \
+	@timeout 5 $(CONTAINER_ENGINE) run --rm \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,11 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 		$(VALIDATOR_IMAGE):$(VALIDATOR_IMAGE_TAG) \
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
 
+pull_server:
+	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG)
+
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
-	@timeout 20 $(CONTAINER_ENGINE) run --rm \
+	@timeout 10 $(CONTAINER_ENGINE) run --rm \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
 	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG)
-	@timeout 5 $(CONTAINER_ENGINE) run --rm \
+	@timeout 10 $(CONTAINER_ENGINE) run --rm \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \

--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,14 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
 
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
-	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG); \
-	 timeout 5 $(CONTAINER_ENGINE) run --rm \
+	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG)
+	timeout 5 $(CONTAINER_ENGINE) run --rm \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \
 		-e DATAFILES_FILE=/bundle/$(BUNDLE_FILENAME) \
 		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG) || \
-	 if [ $$? -eq 124 ]; then exit 0; else exit $$?; fi
+	if [ $$? -eq 124 ]; then exit 0; else exit $$?; fi
 	
 
 build-test: clean

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make test bundle validate gql_validate
+make test bundle validate pull_server gql_validate


### PR DESCRIPTION
[APPSRE-6676](https://issues.redhat.com/browse/APPSRE-6676)

With the existing Makefile logic, it appears that Qontract Server is not run if `docker pull quay.io/app-sre/qontract-server` pulls a new version of the Qontract Server image. I'm not entirely sure why and troubleshoot using various different methods like splitting out to separate lines of the Makefile instruction but the issue persisted. Here, I'm splitting out the `docker pull` to a different Makefile instruction. Not 100% confident that this will fix the issue and it is difficult to test since the issue is so sporadic. However, I'll keep an eye on schemas checks and see if the behavior continues.