### PR TITLE
[cna] schema for CNA external resources

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1055,10 +1055,10 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: aws_account, type: AWSAccount_v1, isRequired: true }
-  - { name: overrides, type: CNAAssumeRoleAssetOverrides_v1 }
-  - { name: defaults, type: string, isRequired: true, isResource: true, resolveResource: true }
+  - { name: defaults, type: CNAAssumeRoleAssetConfig_v1 }
+  - { name: overrides, type: CNAAssumeRoleAssetConfig_v1 }
 
-- name: CNAAssumeRoleAssetOverrides_v1
+- name: CNAAssumeRoleAssetConfig_v1
   fields:
   - { name: slug, type: string }
 
@@ -1068,9 +1068,10 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string }
-  - { name: overrides, type: CNANullAssetOverrides_v1 }
+  - { name: defaults, type: CNANullAssetConfig_v1 }
+  - { name: overrides, type: CNANullAssetConfig_v1 }
 
-- name: CNANullAssetOverrides_v1
+- name: CNANullAssetConfig_v1
   fields:
   - { name: addr_block, type: string }
 
@@ -1079,21 +1080,28 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
-  - { name: vpc, type: AWSVPC_v1, isRequired: true }
-  - { name: defaults, type: string, isRequired: true, isResource: true, resolveResource: true }
-  - { name: overrides, type: CNARDSInstanceOverrides_v1 }
-
-- name: CNARDSInstanceOverrides_v1
-  fields:
   - { name: name, type: string }
-  - { name: engine, type: string }
-  - { name: engine_version, type: string }
-  - { name: username, type: string }
+  - { name: defaults, type: CNARDSInstanceConfig_v1 }
+  - { name: overrides, type: CNARDSInstanceConfig_v1 }
+
+- name: CNARDSInstanceConfig_v1
+  fields:
+  - { name: vpc, type: AWSVPC_v1 }
+  - { name: db_subnet_group_name, type: string }
   - { name: instance_class, type: string }
   - { name: allocated_storage, type: int }
   - { name: max_allocated_storage, type: int }
+  - { name: engine, type: string }
+  - { name: engine_version, type: string }
+  - { name: major_engine_version, type: string}
+  - { name: username, type: string }
+  - { name: maintenance_window, type: string }
   - { name: backup_retention_period, type: int }
-  - { name: db_subnet_group_name, type: string }
+  - { name: backup_window, type: string }
+  - { name: multi_az, type: boolean }
+  - { name: deletion_protection, type: boolean }
+  - { name: apply_immediately, type: boolean }
+
 
 - name: CloudflareAccount_v1
   interface: ExternalResourcesProvisioner_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1044,6 +1044,7 @@ confs:
     fieldMap:
       aws-assume-role: CNAAssumeRoleAsset_v1
       null-asset: CNANullAsset_v1
+      aws-rds: CNARDSInstance_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
@@ -1053,12 +1054,13 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
-  - { name: aws_assume_role, type: CNAAssumeRoleAssetConfig_v1, isRequired: true }
-
-- name: CNAAssumeRoleAssetConfig_v1
-  fields:
-  - { name: slug, type: string, isRequired: true }
   - { name: account, type: AWSAccount_v1, isRequired: true }
+  - { name: overrides, type: CNAAssumeRoleAssetOverrides_v1 }
+  - { name: defaults, type: string, isRequired: true, isResource: true, resolveResource: true }
+
+- name: CNAAssumeRoleAssetOverrides_v1
+  fields:
+  - { name: slug, type: string }
 
 - name: CNANullAsset_v1
   interface: CNAsset_v1
@@ -1066,7 +1068,32 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string }
+  - { name: overrides, type: CNANullAssetOverrides_v1 }
+
+- name: CNANullAssetOverrides_v1
+  fields:
   - { name: addr_block, type: string }
+
+- name: CNARDSInstance_v1
+  interface: CNAsset_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: identifier, type: string, isRequired: true, isUnique: true }
+  - { name: vpc, type: AWSVPC_v1, isRequired: true }
+  - { name: defaults, type: string, isRequired: true, isResource: true, resolveResource: true }
+  - { name: overrides, type: CNARDSInstanceOverrides_v1 }
+
+- name: CNARDSInstanceOverrides_v1
+  fields:
+  - { name: name, type: string }
+  - { name: engine, type: string }
+  - { name: engine_version, type: string }
+  - { name: username, type: string }
+  - { name: instance_class, type: string }
+  - { name: allocated_storage, type: int }
+  - { name: max_allocated_storage, type: int }
+  - { name: backup_retention_period, type: int }
+  - { name: db_subnet_group_name, type: string }
 
 - name: CloudflareAccount_v1
   interface: ExternalResourcesProvisioner_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1093,7 +1093,7 @@ confs:
   - { name: max_allocated_storage, type: int, isRequired: true }
   - { name: engine, type: string, isRequired: true }
   - { name: engine_version, type: string, isRequired: true }
-  - { name: username, type: string }
+  - { name: username, type: string, isRequired: true }
   - { name: maintenance_window, type: string }
   - { name: backup_retention_period, type: int }
   - { name: backup_window, type: string }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -994,6 +994,7 @@ confs:
   - { name: sharing, type: AWSAccountSharingOption_v1, isList: true, isInterface: true }
   - { name: terraformState, type: TerraformStateAWS_v1, isRequired: false }
   - { name: rosa, type: RosaOcmSpec_v1, isRequired: false}
+  - { name: cna, type: CNAAWSSpec_v1, isRequired: false }
 
   - name: ecrs
     type: AWSECR_v1
@@ -1007,6 +1008,16 @@ confs:
     synthetic:
       schema: /aws/policy-1.yml
       subAttr: account
+
+- name: CNAAWSSpec_v1
+  fields:
+  - { name: defaultRoleARN, type: string }
+  - { name: moduleRoleARNS, type: CNAModuleAWSARN_v1, isList: true }
+
+- name: CNAModuleAWSARN_v1
+  fields:
+  - { name: module, type: string, isRequired: true }
+  - { name: arn, type: string, isRequired: true }
 
 - name: CNAExperimentalProvisioner_v1
   interface: ExternalResourcesProvisioner_v1
@@ -1031,9 +1042,23 @@ confs:
     strategy: fieldMap
     field: provider
     fieldMap:
+      aws-assume-role: CNAAssumeRoleAsset_v1
       null-asset: CNANullAsset_v1
   fields:
   - { name: provider, type: string, isRequired: true }
+  - { name: identifier, type: string, isRequired: true, isUnique: true }
+
+- name: CNAAssumeRoleAsset_v1
+  interface: CNAsset_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: identifier, type: string, isRequired: true, isUnique: true }
+  - { name: aws_assume_role, type: CNAAssumeRoleAssetConfig_v1, isRequired: true }
+
+- name: CNAAssumeRoleAssetConfig_v1
+  fields:
+  - { name: slug, type: string, isRequired: true }
+  - { name: account, type: AWSAccount_v1, isRequired: true }
 
 - name: CNANullAsset_v1
   interface: CNAsset_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1056,7 +1056,7 @@ confs:
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: aws_account, type: AWSAccount_v1, isRequired: true }
   - { name: defaults, type: CNAAssumeRoleAssetConfig_v1 }
-  - { name: overrides, type: CNAAssumeRoleAssetConfig_v1 }
+  - { name: overrides, type: json }
 
 - name: CNAAssumeRoleAssetConfig_v1
   fields:
@@ -1069,7 +1069,7 @@ confs:
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string }
   - { name: defaults, type: CNANullAssetConfig_v1 }
-  - { name: overrides, type: CNANullAssetConfig_v1 }
+  - { name: overrides, type: json }
 
 - name: CNANullAssetConfig_v1
   fields:
@@ -1081,19 +1081,18 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
   - { name: name, type: string }
-  - { name: defaults, type: CNARDSInstanceConfig_v1 }
-  - { name: overrides, type: CNARDSInstanceConfig_v1 }
+  - { name: defaults, type: CNARDSInstanceDefaults_v1 }
+  - { name: overrides, type: json }
 
-- name: CNARDSInstanceConfig_v1
+- name: CNARDSInstanceDefaults_v1
   fields:
-  - { name: vpc, type: AWSVPC_v1 }
-  - { name: db_subnet_group_name, type: string }
-  - { name: instance_class, type: string }
-  - { name: allocated_storage, type: int }
-  - { name: max_allocated_storage, type: int }
-  - { name: engine, type: string }
-  - { name: engine_version, type: string }
-  - { name: major_engine_version, type: string}
+  - { name: vpc, type: AWSVPC_v1, isRequired: true }
+  - { name: db_subnet_group_name, type: string, isRequired: true }
+  - { name: instance_class, type: string, isRequired: true }
+  - { name: allocated_storage, type: int, isRequired: true }
+  - { name: max_allocated_storage, type: int, isRequired: true }
+  - { name: engine, type: string, isRequired: true }
+  - { name: engine_version, type: string, isRequired: true }
   - { name: username, type: string }
   - { name: maintenance_window, type: string }
   - { name: backup_retention_period, type: int }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1054,7 +1054,7 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true, isUnique: true }
-  - { name: account, type: AWSAccount_v1, isRequired: true }
+  - { name: aws_account, type: AWSAccount_v1, isRequired: true }
   - { name: overrides, type: CNAAssumeRoleAssetOverrides_v1 }
   - { name: defaults, type: string, isRequired: true, isResource: true, resolveResource: true }
 

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -105,6 +105,26 @@ properties:
     description: "Rosa related attributes in the aws account."
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/dependencies/rosa-ocm-1.yml"
+  cna:
+    type: object
+    additionalProperties: false
+    properties:
+      defaultRoleARN:
+        type: string
+      moduleRoleARNS:
+        type: array
+        items:
+          additionalProperties: false
+          properties:
+            module:
+              type: string
+            arn:
+              type: string
+          required:
+          - module
+          - arn
+    required:
+    - defaultRoleARN
 required:
 - "$schema"
 - labels

--- a/schemas/cna/asset-1.yml
+++ b/schemas/cna/asset-1.yml
@@ -17,15 +17,16 @@ properties:
     "$ref": "/common-1.json#/definitions/longIdentifier"
   addr_block:
     type: string
-  aws_assume_role:
+  aws_account:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/aws/account-1.yml"
+  vpc:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/aws/vpc-1.yml"
+  defaults:
+    type: string
+  overrides:
     type: object
-    additionalProperties: false
-    properties:
-      account:
-        "$ref": "/common-1.json#/definitions/crossref"
-        "$schemaRef": "/aws/account-1.yml"
-      slug:
-        type: string
 oneOf:
 - additionalProperties: false
   properties:
@@ -37,8 +38,12 @@ oneOf:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     description:
       type: string
-    addr_block:
-      type: string
+    overrides:
+      type: object
+      additionalProperties: false
+      properties:
+        addr_block:
+          type: string
   required:
   - identifier
 - additionalProperties: false
@@ -49,15 +54,97 @@ oneOf:
       - aws-assume-role
     identifier:
       "$ref": "/common-1.json#/definitions/longIdentifier"
-    aws_assume_role:
+    aws_account:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/aws/account-1.yml"
+    overrides:
       type: object
       additionalProperties: false
       properties:
-        account:
-          "$ref": "/common-1.json#/definitions/crossref"
-          "$schemaRef": "/aws/account-1.yml"
         slug:
+          type: string
+      required:
+      - slug
+    defaults:
+      "$ref": "/common-1.json#/definitions/resourceref"
+  required:
+  - identifier
+  - account
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - aws-rds
+    identifier:
+      type: string
+    vpc:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/aws/vpc-1.yml"
+    defaults:
+      "$ref": "/common-1.json#/definitions/resourceref"
+    overrides:
+      type: object
+      properties:
+        name:
+          type: string
+        engine:
+          type: string
+          enum:
+          - postgres
+        engine_version:
+          type: string
+        username:
+          type: string
+        instance_class:
+          type: string
+          enum:
+          - db.t2.micro
+          - db.t2.small
+          - db.t3.small
+          - db.m3.medium
+          - db.t3.medium
+          - db.m4.large
+          - db.m4.xlarge
+          - db.m4.2xlarge
+          - db.m5.large
+          - db.m5.xlarge
+          - db.m5.2xlarge
+          - db.m5.4xlarge
+          - db.m5.8xlarge
+          - db.m5.12xlarge
+          - db.m5.16xlarge
+          - db.m5.24xlarge
+          - db.m6g.large
+          - db.m6g.xlarge
+          - db.m6g.2xlarge
+          - db.m6g.4xlarge
+          - db.m6g.8xlarge
+          - db.m6g.12xlarge
+          - db.m6g.16xlarge
+          - db.r4.large
+          - db.r4.xlarge
+          - db.r4.2xlarge
+          - db.r4.4xlarge
+          - db.r4.8xlarge
+          - db.r4.16xlarge
+          - db.r5.large
+          - db.r5.xlarge
+          - db.r5.2xlarge
+          - db.r5.4xlarge
+          - db.r5.8xlarge
+          - db.r5.12xlarge
+          - db.r5.16xlarge
+          - db.r5.24xlarge
+        allocated_storage:
+          type: integer
+        max_allocated_storage:
+          type: integer
+        backup_retention_period:
+          type: integer
+        db_subnet_group_name:
           type: string
   required:
   - identifier
-  - aws_assume_role
+  - vpc
+  - defaults

--- a/schemas/cna/asset-1.yml
+++ b/schemas/cna/asset-1.yml
@@ -15,18 +15,18 @@ properties:
     "$ref": "/common-1.json#/definitions/annotations"
   identifier:
     "$ref": "/common-1.json#/definitions/longIdentifier"
-  addr_block:
+  name:
     type: string
   aws_account:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/aws/account-1.yml"
-  vpc:
-    "$ref": "/common-1.json#/definitions/crossref"
-    "$schemaRef": "/aws/vpc-1.yml"
   defaults:
-    type: string
+    "$ref": "/common-1.json#/definitions/crossref"
   overrides:
-    type: object
+    oneOf:
+      - "$ref": "/cna/null-asset-config-1.yml"
+      - "$ref": "/cna/aws-assume-role-config-1.yml"
+      - "$ref": "/cna/aws-rds-config-1.yml"
 oneOf:
 - additionalProperties: false
   properties:
@@ -38,12 +38,11 @@ oneOf:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     description:
       type: string
+    defaults:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/cna/null-asset-config-1.yml"
     overrides:
-      type: object
-      additionalProperties: false
-      properties:
-        addr_block:
-          type: string
+      "$ref": "/cna/null-asset-config-1.yml"
   required:
   - identifier
 - additionalProperties: false
@@ -57,16 +56,11 @@ oneOf:
     aws_account:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/aws/account-1.yml"
-    overrides:
-      type: object
-      additionalProperties: false
-      properties:
-        slug:
-          type: string
-      required:
-      - slug
     defaults:
-      "$ref": "/common-1.json#/definitions/resourceref"
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/cna/aws-assume-role-config-1.yml"
+    overrides:
+      "$ref": "/cna/aws-assume-role-config-1.yml"
   required:
   - identifier
   - aws_account
@@ -78,73 +72,17 @@ oneOf:
       - aws-rds
     identifier:
       type: string
-    vpc:
-      "$ref": "/common-1.json#/definitions/crossref"
-      "$schemaRef": "/aws/vpc-1.yml"
+      description: The name for the CNA
+    name:
+      type: string
+      description: |
+        The identifier for the RDS instance.
+        Defaults to the `identifier` field
     defaults:
-      "$ref": "/common-1.json#/definitions/resourceref"
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/cna/aws-rds-config-1.yml"
     overrides:
-      type: object
-      properties:
-        name:
-          type: string
-        engine:
-          type: string
-          enum:
-          - postgres
-        engine_version:
-          type: string
-        username:
-          type: string
-        instance_class:
-          type: string
-          enum:
-          - db.t2.micro
-          - db.t2.small
-          - db.t3.small
-          - db.m3.medium
-          - db.t3.medium
-          - db.m4.large
-          - db.m4.xlarge
-          - db.m4.2xlarge
-          - db.m5.large
-          - db.m5.xlarge
-          - db.m5.2xlarge
-          - db.m5.4xlarge
-          - db.m5.8xlarge
-          - db.m5.12xlarge
-          - db.m5.16xlarge
-          - db.m5.24xlarge
-          - db.m6g.large
-          - db.m6g.xlarge
-          - db.m6g.2xlarge
-          - db.m6g.4xlarge
-          - db.m6g.8xlarge
-          - db.m6g.12xlarge
-          - db.m6g.16xlarge
-          - db.r4.large
-          - db.r4.xlarge
-          - db.r4.2xlarge
-          - db.r4.4xlarge
-          - db.r4.8xlarge
-          - db.r4.16xlarge
-          - db.r5.large
-          - db.r5.xlarge
-          - db.r5.2xlarge
-          - db.r5.4xlarge
-          - db.r5.8xlarge
-          - db.r5.12xlarge
-          - db.r5.16xlarge
-          - db.r5.24xlarge
-        allocated_storage:
-          type: integer
-        max_allocated_storage:
-          type: integer
-        backup_retention_period:
-          type: integer
-        db_subnet_group_name:
-          type: string
+      "$ref": "/cna/aws-rds-config-1.yml"
   required:
   - identifier
-  - vpc
   - defaults

--- a/schemas/cna/asset-1.yml
+++ b/schemas/cna/asset-1.yml
@@ -17,6 +17,15 @@ properties:
     "$ref": "/common-1.json#/definitions/longIdentifier"
   addr_block:
     type: string
+  aws_assume_role:
+    type: object
+    additionalProperties: false
+    properties:
+      account:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "/aws/account-1.yml"
+      slug:
+        type: string
 oneOf:
 - additionalProperties: false
   properties:
@@ -32,3 +41,23 @@ oneOf:
       type: string
   required:
   - identifier
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - aws-assume-role
+    identifier:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    aws_assume_role:
+      type: object
+      additionalProperties: false
+      properties:
+        account:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/aws/account-1.yml"
+        slug:
+          type: string
+  required:
+  - identifier
+  - aws_assume_role

--- a/schemas/cna/asset-1.yml
+++ b/schemas/cna/asset-1.yml
@@ -23,10 +23,7 @@ properties:
   defaults:
     "$ref": "/common-1.json#/definitions/crossref"
   overrides:
-    oneOf:
-      - "$ref": "/cna/null-asset-config-1.yml"
-      - "$ref": "/cna/aws-assume-role-config-1.yml"
-      - "$ref": "/cna/aws-rds-config-1.yml"
+    type: object
 oneOf:
 - additionalProperties: false
   properties:
@@ -71,7 +68,7 @@ oneOf:
       enum:
       - aws-rds
     identifier:
-      type: string
+      "$ref": "/common-1.json#/definitions/longIdentifier"
       description: The name for the CNA
     name:
       type: string
@@ -82,7 +79,49 @@ oneOf:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/cna/aws-rds-config-1.yml"
     overrides:
-      "$ref": "/cna/aws-rds-config-1.yml"
+      type: object
+      additionalProperties: false
+      properties:
+        db_subnet_group_name:
+          type: string
+        instance_class:
+          "$ref": "/common-1.json#/definitions/rdsDbInstanceClass"
+        allocated_storage:
+          type: integer
+          description: allocated storage in Gi
+        max_allocated_storage:
+          type: integer
+          description: max allocated storage in Gi
+        engine_version:
+          type: string
+          description: The engine version to use
+        username:
+          type: string
+        maintenance_window:
+          type: string
+          description: |
+            The window to perform maintenance in.
+            Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00'
+        backup_retention_period:
+          type: integer
+          description: The days to retain backups for
+        backup_window:
+          type: string
+          description: |
+            The daily time range (in UTC) during which automated backups are created if they are enabled.
+            Example: '09:46-10:16'
+            Must not overlap with maintenance_window
+        multi_az:
+          type: boolean
+          description: |
+            Whether to use a multi-az configuration that includes a standby instance to improve
+            availability when a failover is required (certain upgrades, instance hardware issues, etc.)
+        deletion_protection:
+          type: boolean
+          description:
+            Protect against deletion. Defaults to true.
+        apply_immediately:
+          type: boolean
   required:
   - identifier
   - defaults

--- a/schemas/cna/asset-1.yml
+++ b/schemas/cna/asset-1.yml
@@ -69,7 +69,7 @@ oneOf:
       "$ref": "/common-1.json#/definitions/resourceref"
   required:
   - identifier
-  - account
+  - aws_account
 - additionalProperties: false
   properties:
     provider:

--- a/schemas/cna/aws-assume-role-config-1.yml
+++ b/schemas/cna/aws-assume-role-config-1.yml
@@ -1,0 +1,12 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /cna/aws-assume-role-config-1.yml
+  slug:
+    type: string

--- a/schemas/cna/aws-rds-config-1.yml
+++ b/schemas/cna/aws-rds-config-1.yml
@@ -72,3 +72,4 @@ required:
 - max_allocated_storage
 - engine
 - engine_version
+- username

--- a/schemas/cna/aws-rds-config-1.yml
+++ b/schemas/cna/aws-rds-config-1.yml
@@ -1,0 +1,110 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /cna/aws-rds-config-1.yml
+  vpc:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/aws/vpc-1.yml"
+    description: The VPC the RDS instance is created in.
+  db_subnet_group_name:
+    type: string
+    description: |
+      Name of DB subnet group. DB instance will be created in the VPC
+      associated with the DB subnet group.
+      Must exist in the referenced VPC.
+      Mandatory: must be set here or provided via a default.
+  instance_class:
+    type: string
+    enum:
+    - db.t2.micro
+    - db.t2.small
+    - db.t3.small
+    - db.m3.medium
+    - db.t3.medium
+    - db.m4.large
+    - db.m4.xlarge
+    - db.m4.2xlarge
+    - db.m5.large
+    - db.m5.xlarge
+    - db.m5.2xlarge
+    - db.m5.4xlarge
+    - db.m5.8xlarge
+    - db.m5.12xlarge
+    - db.m5.16xlarge
+    - db.m5.24xlarge
+    - db.m6.large
+    - db.m6g.large
+    - db.m6g.xlarge
+    - db.m6g.2xlarge
+    - db.m6g.4xlarge
+    - db.m6g.8xlarge
+    - db.m6g.12xlarge
+    - db.m6g.16xlarge
+    - db.r4.large
+    - db.r4.xlarge
+    - db.r4.2xlarge
+    - db.r4.4xlarge
+    - db.r4.8xlarge
+    - db.r4.16xlarge
+    - db.r5.large
+    - db.r5.xlarge
+    - db.r5.2xlarge
+    - db.r5.4xlarge
+    - db.r5.8xlarge
+    - db.r5.12xlarge
+    - db.r5.16xlarge
+    - db.r5.24xlarge
+    description: |
+      Provided via a default or overwritten here.
+  allocated_storage:
+    type: integer
+    description: allocated storage in Gi
+  max_allocated_storage:
+    type: integer
+    description: max allocated storage in Gi
+  engine:
+    type: string
+    enum:
+    - postgres
+  engine_version:
+    type: string
+    description: The engine version to use
+  major_engine_version:
+    type: string
+    description: Specifies the major version of the engine that this option group should be associated with
+  username:
+    type: string
+  maintenance_window:
+    type: string
+    description: |
+      The window to perform maintenance in.
+      Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00'
+  backup_retention_period:
+    type: integer
+    description: The days to retain backups for
+  backup_window:
+    type: string
+    description: |
+      The daily time range (in UTC) during which automated backups are created if they are enabled.
+      Example: '09:46-10:16'
+      Must not overlap with maintenance_window
+  multi_az:
+    type: boolean
+    description: |
+      Whether to use a multi-az configuration that includes a standby instance to improve
+      availability when a failover is required (certain upgrades, instance hardware issues, etc.)
+  deletion_protection:
+    type: boolean
+    description:
+      Protect against deletion. Defaults to true.
+  apply_immediately:
+    type: boolean
+    description: |
+      Indicates whether to apply changes immediately, or wait until the next maintenance window
+

--- a/schemas/cna/aws-rds-config-1.yml
+++ b/schemas/cna/aws-rds-config-1.yml
@@ -20,48 +20,7 @@ properties:
       Must exist in the referenced VPC.
       Mandatory: must be set here or provided via a default.
   instance_class:
-    type: string
-    enum:
-    - db.t2.micro
-    - db.t2.small
-    - db.t3.small
-    - db.m3.medium
-    - db.t3.medium
-    - db.m4.large
-    - db.m4.xlarge
-    - db.m4.2xlarge
-    - db.m5.large
-    - db.m5.xlarge
-    - db.m5.2xlarge
-    - db.m5.4xlarge
-    - db.m5.8xlarge
-    - db.m5.12xlarge
-    - db.m5.16xlarge
-    - db.m5.24xlarge
-    - db.m6.large
-    - db.m6g.large
-    - db.m6g.xlarge
-    - db.m6g.2xlarge
-    - db.m6g.4xlarge
-    - db.m6g.8xlarge
-    - db.m6g.12xlarge
-    - db.m6g.16xlarge
-    - db.r4.large
-    - db.r4.xlarge
-    - db.r4.2xlarge
-    - db.r4.4xlarge
-    - db.r4.8xlarge
-    - db.r4.16xlarge
-    - db.r5.large
-    - db.r5.xlarge
-    - db.r5.2xlarge
-    - db.r5.4xlarge
-    - db.r5.8xlarge
-    - db.r5.12xlarge
-    - db.r5.16xlarge
-    - db.r5.24xlarge
-    description: |
-      Provided via a default or overwritten here.
+    "$ref": "/common-1.json#/definitions/rdsDbInstanceClass"
   allocated_storage:
     type: integer
     description: allocated storage in Gi
@@ -75,9 +34,6 @@ properties:
   engine_version:
     type: string
     description: The engine version to use
-  major_engine_version:
-    type: string
-    description: Specifies the major version of the engine that this option group should be associated with
   username:
     type: string
   maintenance_window:
@@ -107,4 +63,12 @@ properties:
     type: boolean
     description: |
       Indicates whether to apply changes immediately, or wait until the next maintenance window
-
+required:
+- "$schema"
+- vpc
+- db_subnet_group_name
+- instance_class
+- allocated_storage
+- max_allocated_storage
+- engine
+- engine_version

--- a/schemas/cna/null-asset-config-1.yml
+++ b/schemas/cna/null-asset-config-1.yml
@@ -1,0 +1,12 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /cna/null-asset-config-1.yml
+  addr_block:
+    type: string

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -171,6 +171,49 @@
         "partial_outage",
         "major_outage"
       ]
+    },
+    "rdsDbInstanceClass": {
+      "type": "string",
+      "enum": [
+        "db.t2.micro",
+        "db.t2.small",
+        "db.t3.small",
+        "db.m3.medium",
+        "db.t3.medium",
+        "db.m4.large",
+        "db.m4.xlarge",
+        "db.m4.2xlarge",
+        "db.m5.large",
+        "db.m5.xlarge",
+        "db.m5.2xlarge",
+        "db.m5.4xlarge",
+        "db.m5.8xlarge",
+        "db.m5.12xlarge",
+        "db.m5.16xlarge",
+        "db.m5.24xlarge",
+        "db.m6.large",
+        "db.m6g.large",
+        "db.m6g.xlarge",
+        "db.m6g.2xlarge",
+        "db.m6g.4xlarge",
+        "db.m6g.8xlarge",
+        "db.m6g.12xlarge",
+        "db.m6g.16xlarge",
+        "db.r4.large",
+        "db.r4.xlarge",
+        "db.r4.2xlarge",
+        "db.r4.4xlarge",
+        "db.r4.8xlarge",
+        "db.r4.16xlarge",
+        "db.r5.large",
+        "db.r5.xlarge",
+        "db.r5.2xlarge",
+        "db.r5.4xlarge",
+        "db.r5.8xlarge",
+        "db.r5.12xlarge",
+        "db.r5.16xlarge",
+        "db.r5.24xlarge"
+      ]
     }
   }
 }


### PR DESCRIPTION
this schema change introduces the external-resources extension for CNA

it covers the following modules
* `null` - for simple testing purposes without any prereqs on AWS accounts or clusters etc.
* `aws-assume-role` - for testing AWS assume-role access by CNA
* `aws-rds` - create an AWS RDS database

`cna-experimental` services as the provider, indicating the experimental nature of the integration and the `CNAExperimentalProvisioner_v1` serves as the provisioner, wrapping an OCM organization and potentially adding additional config data (we will add a API URL override to this soon so we can target CNA API instances living outside of api.openshift.com)

## Provisioner

```yaml
$schema: /cna/experimental-provisioner-1.yml

name: app-sre
description: CNA provisioner for the app-sre OCM organization

ocm:
  $ref: /dependencies/ocm/stage.yml

<<<--- potential additional config options go here

```

## Example RDS

The defaults files for CNA are now datafile schemas as well. As such they enable us to use references, e.g. a VPC

Here is the example of a defaults file for a production DB

```yaml
$schema: /cna/aws-rds-config-1.yml
engine: postgres
username: postgres
engine_version: '14.2'
instance_class: db.m6.large
backup_retention_period: 7
db_subnet_group_name: default
allocated_storage: 200
max_allocated_storage: 1000
multi_az: true
vpc:
  $ref: /aws/some-account/vpcs/default-vpc.yml
```

and the external resource declaration that leverages it

```yaml
$schema: /openshift/namespace-1.yml
...
externalResources:
- provider: cna-experimental
  provisioner:
    $ref: /cna/app-sre.yml
  resources:
  - provider: aws-rds
    identifier: my-db
    defaults:
      $ref: the-defaults-file.yml
    overrides:
      backup_retention_period: 14
```

design doc: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/53097
ref: https://issues.redhat.com/browse/APPSRE-6295