### PR TITLE
[change-types] implicit ownership for change-types

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3363,6 +3363,23 @@ confs:
   - { name: disabled, type: boolean }
   - { name: inherit, type: ChangeType_v1, isList: true }
   - { name: changes, type: ChangeTypeChangeDetector_v1, isInterface: true, isRequired: true, isList: true }
+  - { name: implicitOwnership, type: ChangeTypeImplicitOwnership_v1, isInterface: true, isList: true }
+
+- name: ChangeTypeImplicitOwnership_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      jsonPath: ChangeTypeImplicitOwnershipJsonPathProvider_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+
+- name: ChangeTypeImplicitOwnershipJsonPathProvider_v1
+  interface: ChangeTypeImplicitOwnership_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: jsonPathSelector, type: string, isRequired: true }
 
 - name: ChangeTypeChangeDetector_v1
   isInterface: true

--- a/schemas/app-interface/change-type-1.yml
+++ b/schemas/app-interface/change-type-1.yml
@@ -69,6 +69,22 @@ properties:
         required:
         - provider
         - jsonPathSelectors
+  implicitOwnership:
+    type: array
+    items:
+      oneOf:
+      - type: object
+        additionalProperties: false
+        properties:
+          provider:
+            type: string
+            enum:
+            - jsonPath
+          jsonPathSelector:
+            type: string
+        required:
+        - provider
+        - jsonPathSelector
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
For certain changes, the natural approvers can be found in the datafiles themselves and would not require explicit ownership via roles. To reduce the need for such explicit ownership, we can make change-types implicitly applicable on changes.

The following example enables users to approve updates on their `public_gpg_key`s. The `jsonPathSelector` is the mechanism to find a reference to an approver, either a `/access/user-1.yml` or `/access/bot-1.yml` object. In this example the selector is `$.path` which finds the approver in the changed file itself.

```yaml
$schema: /app-interface/change-type-1.yml
...
contextSchema: /access/user-1.yml
changes:
- public_gpg_key

implicitOwnership:
- provider: jsonPath
  jsonPathSelector: $.path
```

https://issues.redhat.com/browse/APPSRE-6629

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>