### PR TITLE
[pr-check] Move timeout into container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,17 +49,15 @@ validate: ## Use qcontract-validator image to show any validation errors of sche
 		$(VALIDATOR_IMAGE):$(VALIDATOR_IMAGE_TAG) \
 		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
 
-pull_server:
-	@$(CONTAINER_ENGINE) pull $(SERVER_IMAGE):$(SERVER_IMAGE_TAG)
-
 gql_validate: ## Run qontract-server with the schema bundle and no data to reveal any GQL schema issues
-	@timeout 10 $(CONTAINER_ENGINE) run --rm \
+	@$(CONTAINER_ENGINE) run --rm \
 		-v $(OUTPUT_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \
 		-e DATAFILES_FILE=/bundle/$(BUNDLE_FILENAME) \
-		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG) || \
-	if [ $$? -eq 124 ]; then exit 0; else exit $$?; fi
+		$(SERVER_IMAGE):$(SERVER_IMAGE_TAG) \
+		timeout 10 yarn server || \
+	if [ $$? -eq 124 ]; then exit 0; else exit $$?; fi;
 	
 
 build-test: clean

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make test bundle validate pull_server gql_validate
+make test bundle validate gql_validate


### PR DESCRIPTION
[APPSRE-6676](https://issues.redhat.com/browse/APPSRE-6676)

Move the timeout command to run within the container itself to avoid an issue where pulling the qontract-server container resulted in it not actually running.