### PR TITLE
[change-types] reusability through composition

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3433,6 +3433,7 @@ confs:
     field: provider
     fieldMap:
       jsonPath: ChangeTypeChangeDetectorJsonPathProvider_v1
+      change-type: ChangeTypeChangeDetectorChangeTypeProvider_v1
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: changeSchema, type: string }
@@ -3445,6 +3446,14 @@ confs:
   - { name: changeSchema, type: string }
   - { name: jsonPathSelectors, type: string, isList: true, isRequired: true }
   - { name: context, type: ChangeTypeChangeDetectorContextSelector_v1 }
+
+- name: ChangeTypeChangeDetectorChangeTypeProvider_v1
+  interface: ChangeTypeChangeDetector_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: changeSchema, type: string }
+  - { name: changeTypes, type: ChangeType_v1, isList: true, isRequired: true }
+  - { name: context, type: ChangeTypeChangeDetectorContextSelector_v1, isRequired: true }
 
 - name: ChangeTypeChangeDetectorContextSelector_v1
   fields:

--- a/schemas/app-interface/change-type-1.yml
+++ b/schemas/app-interface/change-type-1.yml
@@ -41,6 +41,36 @@ properties:
     type: array
     minItems: 1
     items:
+      type: object
+      additionalProperties: false
+      properties:
+        provider:
+          type: string
+          enum:
+          - jsonPath
+          - change-type
+        changeSchema:
+          type: string
+        jsonPathSelectors:
+          type: array
+          items:
+            type: string
+        changeTypes:
+          type: array
+          items:
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef": "/app-interface/change-type-1.yml"
+        context:
+          type: object
+          additionalProperties: false
+          properties:
+            selector:
+              type: string
+            when:
+              type: string
+              enum:
+              - added
+              - removed
       oneOf:
       - type: object
         additionalProperties: false
@@ -69,6 +99,35 @@ properties:
         required:
         - provider
         - jsonPathSelectors
+      - type: object
+        additionalProperties: false
+        properties:
+          provider:
+            type: string
+            enum:
+            - change-type
+          changeSchema:
+            type: string
+          changeTypes:
+            type: array
+            items:
+              "$ref": "/common-1.json#/definitions/crossref"
+              "$schemaRef": "/app-interface/change-type-1.yml"
+          context:
+            type: object
+            additionalProperties: false
+            properties:
+              selector:
+                type: string
+              when:
+                type: string
+                enum:
+                - added
+                - removed
+        required:
+        - provider
+        - changeTypes
+        - context
   implicitOwnership:
     type: array
     items:


### PR DESCRIPTION
Add a new change provider named `change-type` to `/app-interface/change-type-1.yml#changes.provider` that can reference an existing `change-type` and put it into the context of `changes.context`.

```yaml
- provider: change-type         <-- new provider
  changeTypes:
  - $ref: namespace-owner.yml   <-- puts the existing change-type ...
  context:                      <-- ... into a new context
    selector: app.'$ref'
```

This makes the referenced change-type usable in the ownership context of the referencing change-type. It redurced ownership management toil and makes the change-types reusable. It also enables the definition of higher level concepts for ownership, e.g. the owned entity is an app and by putting existing change-types into the context of the app change-type, ownership is dynamically expanded to other entities.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>