### PR TITLE
[OSD-14637] allow sms protocol for aws sns terraform

### DIFF
--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -632,6 +632,7 @@ oneOf:
             type: string
             enum:
             - email
+            - sms
           endpoint:
             type: string
   required:


### PR DESCRIPTION
Adding SMS as an accepted protocol. Originally found by @TGPSKI in OSD-14571