### PR TITLE
integration pr-check flag to check only affected shards on dry-runs

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2767,6 +2767,7 @@ confs:
   - { name: no_validate_schemas, type: boolean }
   - { name: run_for_valid_saas_file_changes, type: boolean }
   - { name: early_exit, type: boolean }
+  - { name: check_only_affected_shards, type: boolean }
   - { name: shardSpecOverride, type: IntegrationSpecShardSpecOverride_v1, isList: true, isInterface: true }
 
 - name: IntegrationSpecExtraEnv_v1

--- a/schemas/app-sre/integration-1.yml
+++ b/schemas/app-sre/integration-1.yml
@@ -55,6 +55,8 @@ properties:
         type: boolean
       early_exit:
         type: boolean
+      check_only_affected_shards:
+        type: boolean
       shardSpecOverride:
         type: array
         items:

--- a/schemas/app-sre/integration-1.yml
+++ b/schemas/app-sre/integration-1.yml
@@ -57,6 +57,7 @@ properties:
         type: boolean
       check_only_affected_shards:
         type: boolean
+        description: "defaults to false"
       shardSpecOverride:
         type: array
         items:


### PR DESCRIPTION
the selective dry-run feature implemented as part of https://issues.redhat.com/browse/APPSRE-6785 will benefit greatly from an activation/deactivation flag per integration. in case of an issue/bug, selective dry-runs can be disabled. defaults to `false`

Example:

```yaml
$schema: /app-sre/integration-1.yml

name: terraform-resources

pr_check:
  ...
  check_only_affected_shards: true
```

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>