### PR TITLE
Add support to filter repos when mirroring orgs

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -361,12 +361,19 @@ confs:
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
   - { name: mirror, type: QuayOrg_v1 }
+  - { name: mirrorFilters, type: QuayOrgMirrorFilter_v1, isList: true }
   - { name: managedRepos, type: boolean, isRequired: true }
   - { name: instance, type: QuayInstance_v1, isRequired: true }
   - { name: serverUrl, type: string }
   - { name: managedTeams, type: string, isList: true, isRequired: true }
   - { name: automationToken, type: VaultSecret_v1 }
   - { name: pushCredentials, type: VaultSecret_v1 }
+
+- name: QuayOrgMirrorFilter_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: tags, type: string, isList: true }
+  - { name: tagsExclude, type: string, isList: true }
 
 - name: QuayInstance_v1
   fields:

--- a/schemas/dependencies/quay-org-1.yml
+++ b/schemas/dependencies/quay-org-1.yml
@@ -19,6 +19,36 @@ properties:
   mirror:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/dependencies/quay-org-1.yml"
+  mirrorFilters:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          description: Name of the repository to filter.
+          type: string
+        tags:
+          description: |
+            This limits which tags to mirror to the ones in the list.
+            They will take preference over the ones excluded.
+            Regular expressions are supported.
+          type: array
+          items:
+            type: string
+        tagsExclude:
+          description: |
+            Tags to exclude. Regular expression are supported.
+          type: array
+          items:
+            type: string
+      required:
+      - name
+      oneOf:
+      - required:
+        - tags
+      - required:
+        - tagsExclude
   managedTeams:
     type: array
     items:


### PR DESCRIPTION
The schema mimics how we include/exclude tags when we mirror containers.

part of APPSRE-6916

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>