### PR TITLE
indicate an rds instance is used as a grafana datasource

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1556,6 +1556,7 @@ confs:
   - { name: output_resource_db_name, type: string }
   - { name: reset_password, type: string }
   - { name: enhanced_monitoring, type: boolean }
+  - { name: grafana_datasource, type: boolean }
   - { name: replica_source, type: string }
   - { name: ca_cert, type: VaultSecret_v1 }
   - { name: annotations, type: json }

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -55,6 +55,9 @@ properties:
     type: string
   enhanced_monitoring:
     type: boolean
+  grafana_datasource:
+    type: boolean
+    description: is rds instance used as a grafana datasource
   replica_source:
     type: string
   output_resource_db_name:
@@ -488,6 +491,9 @@ oneOf:
       type: string
     enhanced_monitoring:
       type: boolean
+    grafana_datasource:
+      type: boolean
+      description: is rds instance used as a grafana datasource
     replica_source:
       type: string
     ca_cert:


### PR DESCRIPTION
this can be used for multiple purposes, such as audit, self-service, automation, and more.