### PR TITLE
Add _records_from_vault to support DCV values from Vault in dns-recor…

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3292,6 +3292,13 @@ confs:
   - { name: namespace, type: Namespace_v1, isRequired: true }
   - { name: name, type: string, isRequired: true }
 
+- name: DnsRecordFromVault_v1
+  fields:
+    - { name: path, type: string, isRequired: true }
+    - { name: field, type: string, isRequired: true }
+    - { name: key, type: string }
+    - { name: version, type: int }
+
 - name: DnsRecordHealthcheck_v1
   fields:
   - { name: fqdn, type: string }
@@ -3331,6 +3338,7 @@ confs:
   - { name: _healthcheck, type: DnsRecordHealthcheck_v1 }
   - { name: _target_cluster, type: Cluster_v1 }
   - { name: _target_namespace_zone, type: DnsNamespaceZone_v1 }
+  - { name: _records_from_vault, type: DnsRecordFromVault_v1, isList: true }
 
 - name: DnsZone_v1
   datafile: /dependencies/dns-zone-1.yml
@@ -3344,6 +3352,7 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: account, type: AWSAccount_v1, isRequired: true }
   - { name: vpc, type: AWSVPC_v1 }
+  - { name: allowed_vault_secret_paths, type: string, isList: true }
   - { name: origin, type: string, isRequired: true }
   - { name: records, type: DnsRecord_v1, isList: true }
 

--- a/schemas/dependencies/dns-record-1.yml
+++ b/schemas/dependencies/dns-record-1.yml
@@ -120,6 +120,22 @@ properties:
     required:
     - namespace
     - name
+  _records_from_vault:
+    type: array
+    items:
+      type: object
+      properties:
+        path:
+          type: string
+        field:
+          type: string
+        key:
+          type: string
+        version:
+          type: integer
+      required:
+      - path
+      - field
 oneOf:
 - required:
   - records
@@ -129,6 +145,8 @@ oneOf:
   - _target_namespace_zone
 - required:
   - alias
+- required:
+  - _records_from_vault
 required:
 - name
 - type

--- a/schemas/dependencies/dns-zone-1.yml
+++ b/schemas/dependencies/dns-zone-1.yml
@@ -23,6 +23,11 @@ properties:
   vpc:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/aws/vpc-1.yml"
+  allowed_vault_secret_paths:
+    description: List of paths used to limit the secrets that can be accessed for creating DNS records, the primary use case being domain control validation (DCV)
+    type: array
+    items:
+      type: string
   records:
     type: array
     items:


### PR DESCRIPTION
…d-1.yml

I've decided not to use `/common-1.json#/definitions/vaultSecret` or `VaultSecret_v1` for now because they don't have the concept of using a key within a secret. This is important because the `terraform-cloudflare-resources` integration will have multiple DCV records in a single output (see https://github.com/app-sre/qontract-reconcile/pull/3081).

I'll revisit this later to see if it makes sense to have another variation of those types, or if this is a one-off need.

## Example

```yaml
---
$schema: /dependencies/dns-zone-1.yml

labels: {}

name: dev-data.domain.local
description: Example zone for dev-data.domain.local

account:
  $ref: /aws/app-int-example-01/account.yml

records:
- name: _acme-challenge.test-from-vault
  type: TXT
  _records_from_vault:
  - path: some/vault/path
    field: validation_records
    key: _acme-challenge.test-from-vault.dev-data.domain.local
```