### PR TITLE
[glitchtip] get automation user email from vault secret

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3057,7 +3057,7 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string, isRequired: true }
   - { name: consoleUrl, type: string, isRequired: true }
-  - { name: automationUserEmail, type: string, isRequired: true }
+  - { name: automationUserEmail, type: VaultSecret_v1, isRequired: true }
   - { name: automationToken, type: VaultSecret_v1, isRequired: true }
   - name: organizations
     type: GlitchtipOrganization_v1

--- a/schemas/dependencies/glitchtip-instance-1.yml
+++ b/schemas/dependencies/glitchtip-instance-1.yml
@@ -19,8 +19,7 @@ properties:
     type: string
     format: uri
   automationUserEmail:
-    type: string
-    format: email
+    "$ref": "/common-1.json#/definitions/vaultSecret"
   automationToken:
     "$ref": "/common-1.json#/definitions/vaultSecret"
 required:


### PR DESCRIPTION
Refactor `glitchtip-instance-1` and get the automation user email address from a vault secret instead of specifying it manually. The vault secret is used by the glitchtip application during the startup to create/reconcile the API users.
This avoids glitchtip instance misconfigurations.

Ticket: [APPSRE-6904](https://issues.redhat.com/browse/APPSRE-6904)