### PR TITLE
terraform allow setting ip_address_type to ipv4/dualstack for alb

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1790,6 +1790,7 @@ confs:
   - { name: certificate_arn, type: string, isRequired: true }
   - { name: idle_timeout, type: int }
   - { name: ingress_cidr_blocks, type: string, isRequired: true, isList: true }
+  - { name: ip_address_type, type: string }
   - { name: targets, type: NamespaceTerraformResourceALBTargets_v1, isRequired: true, isList: true }
   - { name: rules, type: NamespaceTerraformResourceALBRules_v1, isRequired: true, isList: true }
   - { name: vpc, type: AWSVPC_v1, isRequired: true }

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -117,6 +117,11 @@ properties:
     type: array
     items:
       type: string
+  ip_address_type:
+    type: string
+    enum:
+    - ipv4
+    - dualstack
   targets:
     type: array
     items:
@@ -903,6 +908,11 @@ oneOf:
       type: array
       items:
         type: string
+    ip_address_type:
+      type: string
+      enum:
+      - ipv4
+      - dualstack
     targets:
       type: array
       items:


### PR DESCRIPTION
Add option to configure ip_address_type for ALB resources

part of https://issues.redhat.com/browse/APPSRE-7044