### PR TITLE
Use CloudflareZoneRecord in the schema externalResource uses.

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1347,7 +1347,7 @@ confs:
   - { name: type, type: string }
   - { name: settings, type: json }
   - { name: argo, type: CloudflareZoneArgo_v1 }
-  - { name: records, type: CloudflareZoneRecord_v1, isList: true }
+  - { name: records, type: CloudflareDnsRecord_v1, isList: true }
   - { name: workers, type: CloudflareZoneWorker_v1, isList: true }
   - { name: certificates, type: CloudflareZoneCertificate_v1, isList: true }
 
@@ -1355,14 +1355,6 @@ confs:
   fields:
   - { name: tiered_caching, type: boolean }
   - { name: smart_routing, type: boolean }
-
-- name: CloudflareZoneRecord_v1
-  fields:
-  - { name: name, type: string, isRequired: true }
-  - { name: type, type: string, isRequired: true }
-  - { name: ttl, type: int, isRequired: true }
-  - { name: value, type: string, isRequired: true }
-  - { name: proxied, type: boolean }
 
 - name: CloudflareZoneWorker_v1
   fields:


### PR DESCRIPTION
Use CloudflareZoneRecord in the schema externalResource uses.

CloudflareZoneRecord is an overset of CloudflareDnsRecord, the datafile has already been updated.