### PR TITLE
Support Standalone Cloudflare DNS Zones

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3080,6 +3080,7 @@ confs:
   - { name: gabi_instances_v1, type: GabiInstance_v1, isList: true, datafileSchema: /app-sre/gabi-instance-1.yml }
   - { name: template_tests_v1, type: TemplateTest_v1, isList: true, datafileSchema: /app-interface/template-test-1.yml }
   - { name: dns_zone_v1, type: DnsZone_v1, isList: true, datafileSchema: /dependencies/dns-zone-1.yml }
+  - { name: cloudflare_dns_zone_v1, type: CloudflareDnsZone_v1, isList: true, datafileSchema: /cloudflare/dns-zone-1.yml }
   - { name: slack_workspaces_v1, type: SlackWorkspace_v1, isList: true, datafileSchema: /dependencies/slack-workspace-1.yml }
   - { name: ocp_release_mirror_v1, type: OcpReleaseMirror_v1, isList: true, datafileSchema: /dependencies/ocp-release-mirror-1.yml}
   - { name: slo_document_v1, type: SLODocument_v1, isList: true, datafileSchema: /app-sre/slo-document-1.yml}
@@ -3273,6 +3274,44 @@ confs:
   - { name: vpc, type: AWSVPC_v1 }
   - { name: origin, type: string, isRequired: true }
   - { name: records, type: DnsRecord_v1, isList: true }
+
+- name: CloudflareDnsRecordDataSettings_v1
+  fields:
+  - { name: algorithm, type: int }
+  - { name: key_tag, type: int }
+  - { name: flags, type: int }
+  - { name: protocol, type: int }
+  - { name: public_key, type: string }
+  - { name: digest_type, type: int }
+  - { name: digest, type: string }
+
+- name: CloudflareDnsRecord_v1
+  datafile: /cloudflare/dns-record-1.yml
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: identifier, type: string, isRequired: true, isUnique: true}
+  - { name: name, type: string, isRequired: true }
+  - { name: type, type: string, isRequired: true}
+  - { name: ttl, type: int, isRequired: true}
+  - { name: value, type: string }
+  - { name: data, type: CloudflareDnsRecordDataSettings_v1 }
+  - { name: proxied, type: boolean }
+  - { name: priority, type: int }
+
+
+- name: CloudflareDnsZone_v1
+  datafile: /cloudflare/dns-zone-1.yml
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: identifier, type: string, isRequired: true, isUnique: true}
+  - { name: account, type: CloudflareAccount_v1, isRequired: true }
+  - { name: zone, type: string, isRequired: true }
+  - { name: type, type: string }
+  - { name: plan, type: string }
+  - { name: records, type: CloudflareDnsRecord_v1, isList: true }
+  - { name: delete, type: boolean }
 
 - name: SLODocumentSLOSLOParameters_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3290,7 +3290,7 @@ confs:
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
-  - { name: identifier, type: string, isRequired: true, isUnique: true}
+  - { name: identifier, type: string, isRequired: true}
   - { name: name, type: string, isRequired: true }
   - { name: type, type: string, isRequired: true}
   - { name: ttl, type: int, isRequired: true}

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1347,7 +1347,7 @@ confs:
   - { name: type, type: string }
   - { name: settings, type: json }
   - { name: argo, type: CloudflareZoneArgo_v1 }
-  - { name: records, type: CloudflareZoneRecord_v1, isList: true }
+  - { name: records, type: CloudflareDnsRecord_v1, isList: true }
   - { name: workers, type: CloudflareZoneWorker_v1, isList: true }
   - { name: certificates, type: CloudflareZoneCertificate_v1, isList: true }
 
@@ -1355,14 +1355,6 @@ confs:
   fields:
   - { name: tiered_caching, type: boolean }
   - { name: smart_routing, type: boolean }
-
-- name: CloudflareZoneRecord_v1
-  fields:
-  - { name: name, type: string, isRequired: true }
-  - { name: type, type: string, isRequired: true }
-  - { name: ttl, type: int, isRequired: true }
-  - { name: value, type: string, isRequired: true }
-  - { name: proxied, type: boolean }
 
 - name: CloudflareZoneWorker_v1
   fields:
@@ -3286,10 +3278,7 @@ confs:
   - { name: digest, type: string }
 
 - name: CloudflareDnsRecord_v1
-  datafile: /cloudflare/dns-record-1.yml
   fields:
-  - { name: schema, type: string, isRequired: true }
-  - { name: path, type: string, isRequired: true }
   - { name: identifier, type: string, isRequired: true}
   - { name: name, type: string, isRequired: true }
   - { name: type, type: string, isRequired: true}

--- a/schemas/app-sre/integration-spec-1.yml
+++ b/schemas/app-sre/integration-spec-1.yml
@@ -94,6 +94,7 @@ properties:
     description: the strategy to use for sharding
     enum:
     - per-aws-account
+    - per-cloudflare-zone
     - static
   sleepDurationSecs:
     type: string

--- a/schemas/cloudflare/dns-record-1.yml
+++ b/schemas/cloudflare/dns-record-1.yml
@@ -1,0 +1,55 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /cloudflare/dns-record-1.yml
+  identifier:
+    "$ref": "/common-1.json#/definitions/longIdentifier"
+  name:
+    type: string
+  'type':
+    type: string
+    enum:
+    - A
+    - CNAME
+    - TXT
+    - NS
+    - MX
+    - DS # The record used to identify the DNSSEC signing key of a delegated zone
+    - DNSKEY # The key record used in DNSSEC. Uses the same format as the KEY record.
+  ttl:
+    type: integer
+  value:
+    type: string
+  data:
+    type: object
+    additionalProperties: false
+    properties:
+      algorithm:
+        "$ref": "/common-1.json#/definitions/dsDNSRecordAlgro"
+      key_tag:
+        "$ref": "/common-1.json#/definitions/dsDNSRecordKeyTag"
+      flags:
+        "$ref": "/common-1.json#/definitions/dsDNSRecordKeyTag"
+      protocol:
+        type: integer
+      public_key:
+        type: string
+      digest_type:
+        type: integer
+      digest:
+        type: string
+  proxied:
+    type: boolean
+  priority:
+    "$ref": "/common-1.json#/definitions/DNSRecordPriority"
+required:
+  - name
+  - type
+  - ttl

--- a/schemas/cloudflare/dns-zone-1.yml
+++ b/schemas/cloudflare/dns-zone-1.yml
@@ -1,0 +1,39 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /cloudflare/dns-zone-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  identifier:
+    "$ref": "/common-1.json#/definitions/longIdentifier"
+  zone:
+    type: string
+  plan:
+    type: string
+    enum:
+    - free
+    - enterprise
+  type:
+    enum:
+    - full
+    - partial
+  account:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/cloudflare/account-1.yml"
+  records:
+    type: array
+    maxItems: 1000
+    items:
+      "$ref": "/cloudflare/dns-record-1.yml"
+  delete:
+    type: boolean
+required:
+- "$schema"
+- zone 

--- a/schemas/cloudflare/terraform-resource-1.yml
+++ b/schemas/cloudflare/terraform-resource-1.yml
@@ -66,19 +66,7 @@ properties:
   records:
     type: array
     items:
-      type: object
-      additionalProperties: false
-      properties:
-        name:
-          type: string
-        type:
-          type: string
-        ttl:
-          type: integer
-        value:
-          type: string
-        proxied:
-          type: boolean
+      "$ref": "/cloudflare/dns-record-1.yml"
   workers:
     type: array
     items:
@@ -207,24 +195,7 @@ oneOf:
     records:
       type: array
       items:
-        type: object
-        additionalProperties: false
-        properties:
-          name:
-            type: string
-          type:
-            type: string
-          ttl:
-            type: integer
-          value:
-            type: string
-          proxied:
-            type: boolean
-        required:
-        - name
-        - type
-        - ttl
-        - value
+        "$ref": "/cloudflare/dns-record-1.yml"
     workers:
       type: array
       items:
@@ -285,4 +256,3 @@ oneOf:
   - zone
 required:
 - provider
-

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -111,6 +111,26 @@
       "minimum": 90,
       "exclusiveMaximum": 100
     },
+    "dsDNSRecordAlgro": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "dsDNSRecordKeyTag": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "dsDNSKEYRecordFlags": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "DNSRecordPriority": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 65535
+    },
     "crossref": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
### Why:
 Be able to create and manage DNS zones in Cloudflare, then eventually migrate resource from Dyn since its DNS service will soon to be not supported.

### What
- Support Cloudflare DNS Zones;
- Add new sharding strategy: per-cloudflare-zone; 
- Add identifier to dns-record-1;
- Use a common Cloudflare DNS record schema between external resource and standalone Cloudflare zone.
### Validation
Running terraform-cloudflare-dns and terraform-cloudflare-resources locally.

Following query resulted in expected response:
```
{
  zones: cloudflare_dns_zone_v1 {
    zone
    account {
      name
      description
      providerVersion
      apiCredentials {
        path
        field
        format
        version
      }
      terraformStateAccount {
        name
        consoleUrl
        terraformUsername
        automationToken {
          path
          field
        }
      }
    }
    records {
      identifier
      name
      type
      ttl
      value
      priority
      data {
        algorithm
        protocol
        public_key
        digest_type
        digest
        key_tag
        flags
      }
    }    partial
    jump_start
    plan
  }
}
```
Data as following was added to local App Interface:
```
---
$schema: /cloudflare/dns-zone-1.yml

labels: {}

zone: devshiftfake.net

partial: true

account:
 $ref: /cloudflare/app-sre/account.yml
 
records:
 - name: cdn01
   identifier: cdn01
   type: CNAME
   ttl: 1
   value: visual-app-interface.devshift.net
   proxied: true
 - name: devshift_txt
   identifier: devshifttxt
   type: TXT
   ttl: 1
   value: printer=lpr5
   proxied: true```
