### PR TITLE
add kube sa token auth option for vault instances

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2494,9 +2494,10 @@ confs:
     fieldMap:
       approle: VaultInstanceAuthApprole_v1
       token: VaultInstanceAuthToken_v1
+      kubernetes: VaultInstanceAuthKubernetes_v1
   fields:
   - { name: provider, type: string, isRequired: true }
-  - { name: secretEngine, type: string, isRequired: true }
+  - { name: secretEngine, type: string }
 
 - name: VaultInstanceAuthApprole_v1
   interface: VaultInstanceAuth_v1
@@ -2512,6 +2513,13 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: secretEngine, type: string, isRequired: true }
   - { name: token, type: VaultSecret_v1, isRequired: true }
+
+- name: VaultInstanceAuthKubernetes_v1
+  interface: VaultInstanceAuth_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: sa_token_path, type: string, isRequired: true }
+  - { name: secretEngine, type: string }
 
 - name: OidcPermission_v1
   isInterface: true

--- a/schemas/vault-config/instance-auth-1.yml
+++ b/schemas/vault-config/instance-auth-1.yml
@@ -22,6 +22,8 @@ properties:
     "$ref": "/common-1.json#/definitions/vaultSecret"
   token:
     "$ref": "/common-1.json#/definitions/vaultSecret"
+  sa_token_path:
+    type: string
 oneOf:
 - properties:
     provider:
@@ -44,6 +46,14 @@ oneOf:
       "$ref": "/common-1.json#/definitions/vaultSecret"
   required:
   - token
+- properties:
+    provider:
+      type: string
+      enum:
+      - kubernetes
+    sa_token_path:
+      type: string
+  required:
+  - sa_token_path
 required:
 - provider
-- secretEngine


### PR DESCRIPTION
APPSRE-7074

Note: `secret-engine` is removed from required list on interface as this new auth option does not require interaction with vault to obtain creds