### PR TITLE
add optional kube role name to vault instance auth

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2497,7 +2497,7 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: secretEngine, type: string, isRequired: true }
-  - { name: saTokenPath, type: string }
+  - { name: kubeAuthEnabled, type: boolean }
 
 - name: VaultInstanceAuthApprole_v1
   interface: VaultInstanceAuth_v1
@@ -2506,7 +2506,7 @@ confs:
   - { name: secretEngine, type: string, isRequired: true }
   - { name: roleID, type: VaultSecret_v1, isRequired: true }
   - { name: secretID, type: VaultSecret_v1, isRequired: true }
-  - { name: saTokenPath, type: string }
+  - { name: kubeAuthEnabled, type: boolean }
 
 - name: VaultInstanceAuthToken_v1
   interface: VaultInstanceAuth_v1
@@ -2514,7 +2514,7 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: secretEngine, type: string, isRequired: true }
   - { name: token, type: VaultSecret_v1, isRequired: true }
-  - { name: saTokenPath, type: string }
+  - { name: kubeAuthEnabled, type: boolean }
 
 - name: OidcPermission_v1
   isInterface: true

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2497,7 +2497,7 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: secretEngine, type: string, isRequired: true }
-  - { name: kubeAuthEnabled, type: boolean }
+  - { name: kubeRoleName, type: string }
 
 - name: VaultInstanceAuthApprole_v1
   interface: VaultInstanceAuth_v1
@@ -2506,7 +2506,7 @@ confs:
   - { name: secretEngine, type: string, isRequired: true }
   - { name: roleID, type: VaultSecret_v1, isRequired: true }
   - { name: secretID, type: VaultSecret_v1, isRequired: true }
-  - { name: kubeAuthEnabled, type: boolean }
+  - { name: kubeRoleName, type: string }
 
 - name: VaultInstanceAuthToken_v1
   interface: VaultInstanceAuth_v1
@@ -2514,7 +2514,7 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: secretEngine, type: string, isRequired: true }
   - { name: token, type: VaultSecret_v1, isRequired: true }
-  - { name: kubeAuthEnabled, type: boolean }
+  - { name: kubeRoleName, type: string }
 
 - name: OidcPermission_v1
   isInterface: true

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2497,6 +2497,7 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: secretEngine, type: string, isRequired: true }
+  - { name: saTokenPath, type: string }
 
 - name: VaultInstanceAuthApprole_v1
   interface: VaultInstanceAuth_v1
@@ -2505,6 +2506,7 @@ confs:
   - { name: secretEngine, type: string, isRequired: true }
   - { name: roleID, type: VaultSecret_v1, isRequired: true }
   - { name: secretID, type: VaultSecret_v1, isRequired: true }
+  - { name: saTokenPath, type: string }
 
 - name: VaultInstanceAuthToken_v1
   interface: VaultInstanceAuth_v1
@@ -2512,6 +2514,7 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: secretEngine, type: string, isRequired: true }
   - { name: token, type: VaultSecret_v1, isRequired: true }
+  - { name: saTokenPath, type: string }
 
 - name: OidcPermission_v1
   isInterface: true

--- a/schemas/vault-config/instance-auth-1.yml
+++ b/schemas/vault-config/instance-auth-1.yml
@@ -11,8 +11,8 @@ properties:
     - /vault-config/instance-auth-1.yml
   provider:
     type: string
-  kubeAuthEnabled:
-    type: boolean
+  kubeRoleName:
+    type: string
   secretEngine:
     type: string
     enum:

--- a/schemas/vault-config/instance-auth-1.yml
+++ b/schemas/vault-config/instance-auth-1.yml
@@ -11,6 +11,8 @@ properties:
     - /vault-config/instance-auth-1.yml
   provider:
     type: string
+  saTokenPath:
+    type: string
   secretEngine:
     type: string
     enum:

--- a/schemas/vault-config/instance-auth-1.yml
+++ b/schemas/vault-config/instance-auth-1.yml
@@ -11,8 +11,8 @@ properties:
     - /vault-config/instance-auth-1.yml
   provider:
     type: string
-  saTokenPath:
-    type: string
+  kubeAuthEnabled:
+    type: boolean
   secretEngine:
     type: string
     enum:


### PR DESCRIPTION
APPSRE-7074

This will be utilized by vault-manager to determine if kube auth should be utilized instead of an approle/token. This is in the form of an optional attribute instead of a separate auth option because vault-manager will still rely on approle/token within pr checks and for local execution.