### PR TITLE
remove jira ref from code components

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2137,7 +2137,6 @@ confs:
   - { name: showInReviewQueue, type: boolean}
   - { name: gitlabRepoOwners, type: CodeComponentGitlabOwners_v1 }
   - { name: gitlabHousekeeping, type: CodeComponentGitlabHousekeeping_v1 }
-  - { name: jira, type: JiraServer_v1 }
   - { name: mirror, type: string }
 
 - name: Product_v1

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -351,9 +351,6 @@ properties:
           required:
           - enabled
           - rebase
-        jira:
-          "$ref": "/common-1.json#/definitions/crossref"
-          "$schemaRef": "/dependencies/jira-server-1.yml"
         mirror:
           type: string
           format: uri


### PR DESCRIPTION
this has not been in use for a long time now, since the removal of the `gitlab-integrations` integration.