### PR TITLE
glitchtip-project-dsn cluster.disable property

### DIFF
--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -528,6 +528,7 @@ properties:
           - ocm-upgrade-scheduler
           - slack-usergroups
           - skupper-network
+          - glitchtip-project-dsn
       e2eTests:
         type: array
         items:


### PR DESCRIPTION
The `glitchtip-project-dsn` integration can be disabled per cluster