### PR TITLE
aws/asg-defaults-1: add support for `price-capacity-optimized`

### DIFF
--- a/schemas/aws/asg-defaults-1.yml
+++ b/schemas/aws/asg-defaults-1.yml
@@ -40,11 +40,14 @@ properties:
         type: string
         enum:
         - lowest-price
+        - price-capacity-optimized
         - capacity-optimized
         - capacity-optimized-prioritized
       on_demand_base_capacity:
         type: integer
       on_demand_percentage_above_base_capacity:
+        type: integer
+      spot_instance_pools:
         type: integer
   instance_refresh_preferences:
     type: object


### PR DESCRIPTION
This new strategy strikes a balance between cost and interruption risk.

The `spot_instance_pools` parameter is only available with the
    `lowest-price` strategy, so it needs to be set to 0 for other
    strategies.


https://aws.amazon.com/blogs/compute/introducing-price-capacity-optimized-allocation-strategy-for-ec2-spot-instances/