### PR TITLE
[ocm] add mandatory orgId field

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -982,6 +982,7 @@ confs:
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
   - { name: description, type: string }
+  - { name: orgId, type: string, isRequired: true, isUnique: true }
   - { name: url, type: string, isRequired: true }
   - { name: accessTokenClientId, type: string, isRequired: true }
   - { name: accessTokenUrl, type: string, isRequired: true }

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -18,7 +18,7 @@ properties:
   orgId:
     type: string
     description: |
-      The internal OCM organization ID that that can be found via
+      The internal OCM organization ID that can be found via
       ocm whoami | jq .organization.id
   url:
     type: string

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -15,6 +15,11 @@ properties:
     type: string
   description:
     type: string
+  orgId:
+    type: string
+    description: |
+      The internal OCM organization ID that that can be found via
+      ocm whoami | jq .organization.id
   url:
     type: string
     format: uri
@@ -200,6 +205,7 @@ required:
 - labels
 - name
 - url
+- orgId
 - description
 - accessTokenClientId
 - accessTokenUrl


### PR DESCRIPTION
SA tokens usually have no org id associated with them but we rely on `ocm whoami` to find the org id to use when filtering for clusters. when we move forward with SAs that don't have an org association, we need another way to identify the org of an `/openshift/openshift-cluster-manager-1.yml`.

this schema changes makes the org association of an `/openshift/openshift-cluster-manager-1.yml` explicit by adding an `orgId` property to it.

attention: this is a mandatory new property, so a breaking schema change

https://issues.redhat.com/browse/APPSRE-7252