### PR TITLE
Increase the number of record in a Cloudflare DNS zone to 1500

### DIFF
--- a/schemas/cloudflare/dns-zone-1.yml
+++ b/schemas/cloudflare/dns-zone-1.yml
@@ -29,7 +29,7 @@ properties:
     "$schemaRef": "/cloudflare/account-1.yml"
   records:
     type: array
-    maxItems: 1000
+    maxItems: 1500
     items:
       "$ref": "/cloudflare/dns-record-1.yml"
   delete:


### PR DESCRIPTION
Increase the number of record to 1500 to accommodate a large zone from Dyn