### PR TITLE
[ocm] introduce schema to for an OCM environment

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -986,9 +986,9 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
   - { name: description, type: string }
   - { name: orgId, type: string, isRequired: true, isUnique: true }
-  - { name: url, type: string, isRequired: true }
-  - { name: accessTokenClientId, type: string, isRequired: true }
-  - { name: accessTokenUrl, type: string, isRequired: true }
+  - { name: environment, type: OpenShiftClusterManagerEnvironment_v1, isRequired: true }
+  - { name: accessTokenClientId, type: "string" }
+  - { name: accessTokenUrl, type: string }
   - { name: accessTokenClientSecret, type: VaultSecret_v1 }
   - { name: addonManagedUpgrades, type: boolean }
   - { name: addonUpgradeTests, type: AddonUpgradeTest_v1, isList: true }
@@ -1008,6 +1008,19 @@ confs:
     synthetic:
       schema: /openshift/cluster-1.yml
       subAttr: cluster
+
+- name: OpenShiftClusterManagerEnvironment_v1
+  datafile: /openshift/openshift-cluster-manager-environment-1.yml
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: labels, type: json }
+  - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
+  - { name: url, type: string, isRequired: true }
+  - { name: description, type: string }
+  - { name: accessTokenClientId, type: string, isRequired: true }
+  - { name: accessTokenUrl, type: string, isRequired: true }
+  - { name: accessTokenClientSecret, type: VaultSecret_v1, isRequired: true }
 
 - name: AddonUpgradeTest_v1
   fields:
@@ -3132,6 +3145,7 @@ confs:
   - { name: shared_resources_v1, type: SharedResources_v1, isList: true, datafileSchema: /openshift/shared-resources-1.yml }
   - { name: pagerduty_instances_v1, type: PagerDutyInstance_v1, isList: true, datafileSchema: /dependencies/pagerduty-instance-1.yml }
   - { name: ocm_instances_v1, type: OpenShiftClusterManager_v1, isList: true, datafileSchema: /openshift/openshift-cluster-manager-1.yml }
+  - { name: ocm_environments_v1, type: OpenShiftClusterManagerEnvironment_v1, isList: true, isRequired: true, datafileSchema: /openshift/openshift-cluster-manager-environment-1.yml }
   - { name: dyn_traffic_directors_v1, type: DynTrafficDirector_v1, isList: true, datafileSchema: /dependencies/dyn-traffic-director-1.yml }
   - { name: status_page_v1, type: StatusPage_v1, isList: true, datafileSchema: /dependencies/status-page-1.yml }
   - { name: status_page_component_v1, type: StatusPageComponent_v1, isList: true, datafileSchema: /dependencies/status-page-component-1.yml }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -987,7 +987,7 @@ confs:
   - { name: description, type: string }
   - { name: orgId, type: string, isRequired: true, isUnique: true }
   - { name: environment, type: OpenShiftClusterManagerEnvironment_v1, isRequired: true }
-  - { name: accessTokenClientId, type: "string" }
+  - { name: accessTokenClientId, type: string }
   - { name: accessTokenUrl, type: string }
   - { name: accessTokenClientSecret, type: VaultSecret_v1 }
   - { name: addonManagedUpgrades, type: boolean }

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -20,9 +20,9 @@ properties:
     description: |
       The internal OCM organization ID that can be found via
       ocm whoami | jq .organization.id
-  url:
-    type: string
-    format: uri
+  environment:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/openshift/openshift-cluster-manager-environment-1.yml"
   accessTokenClientId:
     type: string
   accessTokenUrl:
@@ -77,7 +77,7 @@ properties:
     type: object
     additionalProperties: false
     properties:
-      majority: 
+      majority:
         description: most used version currently running that workload
         type: number
       highest:
@@ -204,9 +204,6 @@ required:
 - "$schema"
 - labels
 - name
-- url
+- environment
 - orgId
 - description
-- accessTokenClientId
-- accessTokenUrl
-- accessTokenClientSecret

--- a/schemas/openshift/openshift-cluster-manager-environment-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-environment-1.yml
@@ -1,0 +1,36 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /openshift/openshift-cluster-manager-environment-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    type: string
+  description:
+    type: string
+  url:
+    type: string
+    format: uri
+  accessTokenClientId:
+    type: string
+  accessTokenUrl:
+    type: string
+    format: uri
+  accessTokenClientSecret:
+    "$ref": "/common-1.json#/definitions/vaultSecret"
+required:
+- "$schema"
+- labels
+- name
+- url
+- description
+- accessTokenClientId
+- accessTokenUrl
+- accessTokenClientSecret


### PR DESCRIPTION
# What
add a schema `/openshift/openshift-cluster-manager-environment-1.yml` which represents an actual instance of OCM like stage, integration or prod.

# Why
the current `/openshift/openshift-cluster-manager-1.yml` schema represents an OCM organization and not a instance of OCM. since we are adding more and more OCM organizations, this will lead to repeating metadata like URLs and credentials.

certain integrations will also start revolving around OCM instances and not organizations so having all of them as referenceable resources is a good next schema evolution.

# How
All OCM environments will be referenced by a datafile like this ...

```yaml
$schema: /openshift/openshift-cluster-manager-environment-1.yml
name: ocm-production
description: OpenShift Cluster Manager Production Environment
url: https://api.openshift.com
accessTokenClientId: xxx
accessTokenUrl: https://xxx
accessTokenClientSecret:
  path: path/to/secret
  field: client_secret
```

... and OCM organization files can reference them ...

```yaml
---
$schema: /openshift/openshift-cluster-manager-1.yml
name: my-org
environment:
  $ref: /dependencies/ocm/environments/production.yml
orgId: xxx
```

It is still possible to keep authentication information in the organization file, which act as an override to the ones from the /app-sre/environment-1.yml

```yaml
$schema: /openshift/openshift-cluster-manager-1.yml
name: my-org
environment:
  $ref: /dependencies/ocm/environments/production.yml
orgId: xxx
support: critical
accessTokenClientId: xxx
accessTokenUrl: https://xxx
accessTokenClientSecret:
  path: path/to/secret
  field: client_secret
```

https://issues.redhat.com/browse/APPSRE-7281