### PR TITLE
updating schemas to include lookups for password resets APPSRE-6367

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1073,7 +1073,6 @@ confs:
   - { name: sharing, type: AWSAccountSharingOption_v1, isList: true, isInterface: true }
   - { name: terraformState, type: TerraformStateAWS_v1, isRequired: false }
   - { name: rosa, type: RosaOcmSpec_v1, isRequired: false}
-  - { name: org_username, type: string, isSearchable: true, isRequired: true, isUnique: true }
 
   - name: ecrs
     type: AWSECR_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1073,6 +1073,7 @@ confs:
   - { name: sharing, type: AWSAccountSharingOption_v1, isList: true, isInterface: true }
   - { name: terraformState, type: TerraformStateAWS_v1, isRequired: false }
   - { name: rosa, type: RosaOcmSpec_v1, isRequired: false}
+  - { name: org_username, type: string, isSearchable: true, isRequired: true, isUnique: true }
 
   - name: ecrs
     type: AWSECR_v1
@@ -2778,6 +2779,12 @@ confs:
     synthetic:
       schema: /app-sre/gabi-instance-1.yml
       subAttr: users
+  - name: aws_accounts
+    type: AWSAccount_v1
+    isList: true
+    synthetic:
+      schema: /aws/account-1.yml
+      subAttr: resetPasswords.user
 
 - name: Bot_v1
   fields:

--- a/schemas/access/user-1.yml
+++ b/schemas/access/user-1.yml
@@ -36,8 +36,6 @@ properties:
       "$schemaRef": "/access/role-1.yml"
   public_gpg_key:
     type: string
-  reset_password:
-    type: string
   tag_on_merge_requests:
     type: boolean
   tag_on_cluster_updates:

--- a/schemas/access/user-1.yml
+++ b/schemas/access/user-1.yml
@@ -8,7 +8,7 @@ properties:
   "$schema":
     type: string
     enum:
-    - /access/user-1.yml
+      - /access/user-1.yml
   labels:
     "$ref": "/common-1.json#/definitions/labels"
   name:
@@ -25,7 +25,7 @@ properties:
     type: string
   aws_username:
     type: string
-    pattern: '^[a-zA-Z_]+$'
+    pattern: "^[a-zA-Z_]+$"
   cloudflare_user:
     type: string
     format: email
@@ -36,13 +36,15 @@ properties:
       "$schemaRef": "/access/role-1.yml"
   public_gpg_key:
     type: string
+  reset_password:
+    type: string
   tag_on_merge_requests:
     type: boolean
   tag_on_cluster_updates:
     type: boolean
 required:
-- $schema
-- labels
-- name
-- org_username
-- github_username
+  - $schema
+  - labels
+  - name
+  - org_username
+  - github_username


### PR DESCRIPTION
This is part of [APPSRE-6367](https://issues.redhat.com/browse/APPSRE-6367):
```
AC:

enhance ldap-users to remove references to a deleted user file from aws account reset password sections.
```
The schema for user lookups was extended to include AWS account `resetPasswords`.  This allows the files containing the user to be included in a user lookup query:
```
aws_accounts {
      path
}
```

Testing was performed locally with qontract-reconcile-cli and qd.  

