### PR TITLE
Supporting AAAA record.

### DIFF
--- a/schemas/cloudflare/dns-record-1.yml
+++ b/schemas/cloudflare/dns-record-1.yml
@@ -17,6 +17,7 @@ properties:
     type: string
     enum:
     - A
+    - AAAA
     - CNAME
     - TXT
     - NS


### PR DESCRIPTION
Tested by locally adding AAAA record and seeing it in the query.