### PR TITLE
terraform-cloudflare-resources: add schema for cache_reserve

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1401,6 +1401,7 @@ confs:
   - { name: type, type: string }
   - { name: settings, type: json }
   - { name: argo, type: CloudflareZoneArgo_v1 }
+  - { name: cache_reserve, type: CloudflareZoneCacheReserve_v1 }
   - { name: records, type: CloudflareDnsRecord_v1, isList: true }
   - { name: workers, type: CloudflareZoneWorker_v1, isList: true }
   - { name: certificates, type: CloudflareZoneCertificate_v1, isList: true }
@@ -1409,6 +1410,10 @@ confs:
   fields:
   - { name: tiered_caching, type: boolean }
   - { name: smart_routing, type: boolean }
+
+- name: CloudflareZoneCacheReserve_v1
+  fields:
+  - { name: enabled, type: boolean }
 
 - name: CloudflareZoneWorker_v1
   fields:

--- a/schemas/cloudflare/terraform-resource-1.yml
+++ b/schemas/cloudflare/terraform-resource-1.yml
@@ -63,6 +63,12 @@ properties:
         type: boolean
       smart_routing:
         type: boolean
+  cache_reserve:
+    type: object
+    additionalProperties: false
+    properties:
+      enabled:
+        type: boolean
   records:
     type: array
     items:
@@ -191,6 +197,12 @@ oneOf:
         tiered_caching:
           type: boolean
         smart_routing:
+          type: boolean
+    cache_reserve:
+      type: object
+      additionalProperties: false
+      properties:
+        enabled:
           type: boolean
     records:
       type: array


### PR DESCRIPTION
This adds a `cache_reserve` schema under `NamespaceTerraformResourceCloudflareZone_v1` 

Ref.: https://issues.redhat.com/browse/APPSRE-7319