### PR TITLE
add datafile reference to CloudflareAccount_V1 GQL type

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1140,6 +1140,7 @@ confs:
   - { name: addr_block, type: string }
 
 - name: CloudflareAccount_v1
+  datafile: /cloudflare/account-1.yml
   interface: ExternalResourcesProvisioner_v1
   fields:
   - { name: schema, type: string, isRequired: true }


### PR DESCRIPTION
add the jsonschema type to the CloudflareAccount_V1 GQL type. this is required for the `interfaceResolver.strategy = schema` configuration of `DatafileObject_V1`