### PR TITLE
vault secret path must not start or end with a /

### DIFF
--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -56,6 +56,10 @@
       "type": "string",
       "minLength": 1
     },
+    "vaultSecretPath": {
+      "type": "string",
+      "pattern": "^[^\\/][A-Za-z0-9-_\\/\\.]+[^\\/]$"
+    },
     "k8sValidContainerName": {
       "type": "string",
       "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",

--- a/schemas/openshift/openshift-resource-vault-secret-1.yml
+++ b/schemas/openshift/openshift-resource-vault-secret-1.yml
@@ -16,7 +16,7 @@ properties:
   name:
     type: string
   path:
-    type: string
+    "$ref": "/common-1.json#/definitions/vaultSecretPath"
   version:
     type: integer
   labels:


### PR DESCRIPTION
To avoid `Replacing double-slashes ("//") in path with single slash ("/") to avoid Vault redirect response.` openshift-vault-secret warnings, enforce vault secret path without leading or ending /


Ticket: [APPSRE-7398](https://issues.redhat.com/browse/APPSRE-7398)