### PR TITLE
Change schema to support prom tester filtering

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1308,6 +1308,7 @@ confs:
       resource-template: NamespaceOpenshiftResourceResourceTemplate_v1
       vault-secret: NamespaceOpenshiftResourceVaultSecret_v1
       route: NamespaceOpenshiftResourceRoute_v1
+      prometheus-rule: NamespaceOpenshiftResourcePrometheusRule_v1
   fields:
   - { name: provider, type: string, isRequired: true }
 
@@ -1352,6 +1353,16 @@ confs:
   - { name: path, type: string, isRequired: true, isResource: true, resolveResource: true, isContextUnique: true }
   - { name: vault_tls_secret_path, type: string }
   - { name: vault_tls_secret_version, type: int }
+
+- name: NamespaceOpenshiftResourcePrometheusRule_v1
+  interface: NamespaceOpenshiftResource_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true, isResource: true, resolveResource: true }
+  - { name: type, type: string }
+  - { name: variables, type: json }
+  - { name: enable_query_support, type: boolean }
+  - { name: tests, type: string, isList: true, isResource: true }
 
 - name: NamespaceExternalResource_v1
   isInterface: true

--- a/schemas/openshift/openshift-resource-1.yml
+++ b/schemas/openshift/openshift-resource-1.yml
@@ -38,6 +38,8 @@ properties:
     type: string
   vault_tls_secret_version:
     type: integer
+  tests:
+    type: array
 oneOf:
 - "$ref": "/openshift/openshift-resource-vault-secret-1.yml"
 - additionalProperties: false
@@ -102,5 +104,30 @@ oneOf:
     - vault_tls_secret_version
     vault_tls_secret_version:
     - vault_tls_secret_path
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - prometheus-rule
+    path:
+      "$ref": "/common-1.json#/definitions/resourceref"
+    type:
+      type: string
+      enum:
+      - resource
+      - resource-template-extracurlyjinja2
+    variables:
+      type: object
+    enable_query_support:
+      type: boolean
+      description: indicates that this resource is using graphql query results
+    tests:
+      type: array
+      items:
+        "$ref": "/common-1.json#/definitions/resourceref"
+  required:
+  - path
+  - type
 required:
 - provider


### PR DESCRIPTION
Tests have been added as a array of strings as qontract-server doesn't like them to be resources that can be resolved. That works for a single resource, not for an array of resources.

Part of APPSRE-7018