### PR TITLE
Refactor AWS ALB action to support multiple action types

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1978,7 +1978,7 @@ confs:
 - name: NamespaceTerraformResourceALBRules_v1
   fields:
   - { name: condition, type: NamespaceTerraformResourceALBConditon_v1, isRequired: true}
-  - { name: action, type: NamespaceTerraformResourceALBAction_v1, isRequired: true, isList: true}
+  - { name: action, type: NamespaceTerraformResourceALBAction_v1, isRequired: true, isInterface: true}
 
 - name: NamespaceTerraformResourceALBConditon_v1
   fields:
@@ -1986,9 +1986,29 @@ confs:
   - { name: methods, type: string, isList: true, isRequired: false}
 
 - name: NamespaceTerraformResourceALBAction_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: type
+    fieldMap:
+      forward: NamespaceTerraformResourceALBActionForward_v1
   fields:
-  - { name: target, type: string, isRequired: true}
-  - { name: weight, type: int, isRequired: true}
+  - { name: type, type: string, isRequired: true }
+
+- name: NamespaceTerraformResourceALBActionForward_v1
+  interface: NamespaceTerraformResourceALBAction_v1
+  fields:
+  - { name: type, type: string, isRequired: true }
+  - { name: forward, type: NamespaceTerraformResourceALBActionForwardSettings_v1, isRequired: true }
+
+- name: NamespaceTerraformResourceALBActionForwardSettings_v1
+  fields:
+  - { name: target_group, type: NamespaceTerraformResourceALBTargetGroup_v1, isList: true, isRequired: true }
+
+- name: NamespaceTerraformResourceALBTargetGroup_v1
+  fields:
+  - { name: target, type: string, isRequired: true }
+  - { name: weight, type: int, isRequired: true }
 
 - name: ResourceValues_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1992,6 +1992,7 @@ confs:
     field: type
     fieldMap:
       forward: NamespaceTerraformResourceALBActionForward_v1
+      fixed-response: NamespaceTerraformResourceALBActionFixedResponse_v1
   fields:
   - { name: type, type: string, isRequired: true }
 
@@ -2001,6 +2002,12 @@ confs:
   - { name: type, type: string, isRequired: true }
   - { name: forward, type: NamespaceTerraformResourceALBActionForwardSettings_v1, isRequired: true }
 
+- name: NamespaceTerraformResourceALBActionFixedResponse_v1
+  interface: NamespaceTerraformResourceALBAction_v1
+  fields:
+  - { name: type, type: string, isRequired: true }
+  - { name: fixed_response, type: NamespaceTerraformResourceALBActionFixedResponseSettings_v1, isRequired: true }
+
 - name: NamespaceTerraformResourceALBActionForwardSettings_v1
   fields:
   - { name: target_group, type: NamespaceTerraformResourceALBTargetGroup_v1, isList: true, isRequired: true }
@@ -2009,6 +2016,13 @@ confs:
   fields:
   - { name: target, type: string, isRequired: true }
   - { name: weight, type: int, isRequired: true }
+
+- name: NamespaceTerraformResourceALBActionFixedResponseSettings_v1
+  fields:
+  - { name: content_type, type: string, isRequired: true }
+  - { name: message_body, type: string, isRequired: true }
+  - { name: status_code, type: string, isRequired: true }
+
 
 - name: ResourceValues_v1
   fields:

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -974,20 +974,43 @@ oneOf:
             required:
             - path
           action:
-            type: array
-            # https://github.com/hashicorp/terraform-provider-aws/pull/12574#issuecomment-639642524
-            minItems: 2
-            items:
-              type: object
-              additionalProperties: false
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                - forward
+            oneOf:
+            - additionalProperties: false
               properties:
-                target:
+                type:
                   type: string
-                weight:
-                  type: integer
+                  enum:
+                  - forward
+                forward:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    target_group:
+                      type: array
+                      # https://github.com/hashicorp/terraform-provider-aws/pull/12574#issuecomment-639642524
+                      minItems: 2
+                      items:
+                        type: object
+                        additionalProperties: false
+                        properties:
+                          target:
+                            type: string
+                          weight:
+                            type: integer
+                        required:
+                        - target
+                        - weight
+                  required:
+                  - target_group
               required:
-              - target
-              - weight
+              - type
+              - forward
         required:
         - condition
         - action

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -979,8 +979,32 @@ oneOf:
               type:
                 type: string
                 enum:
+                - fixed-response
                 - forward
             oneOf:
+            - additionalProperties: false
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - fixed-response
+                fixed_response:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    content_type:
+                      type: string
+                    message_body:
+                      type: string
+                    status_code:
+                      type: integer
+                  required:
+                  - content_type
+                  - message_body
+                  - status_code
+              required:
+              - type
+              - fixed_response
             - additionalProperties: false
               properties:
                 type:


### PR DESCRIPTION
Also adds support for the fixed-response action type

The refactoring was needed as previously the `forward` action was implied as that was the only one we supported. Now the schema supports additional action types and better aligns with the corresponding [terraform resource arguments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule#action-blocks)

Before
```yaml
rules:
- condition:
    path: /v2/foo/*
  action:
    - target: main-target
      weight: 100
    - target: other-target
      weight: 0
```

After
```yaml
rules:
- condition:
    path: /v2/foo/*
  action:
    type: forward
    forward:
      target_group:
      - target: main-target
        weight: 100
      - target: other-target
        weight: 0
- condition:
    path: /v2/*
  action:
    type: fixed-response
    fixed_response:
      content_type: text/plain
      message_body: YOU ARE NOT ALLOWED HERE
      status_code: 403
```


Ref.: https://issues.redhat.com/browse/APPSRE-7483