### PR TITLE
openshift/cluster-1.yml: make `auth` required

### DIFF
--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -599,6 +599,7 @@ required:
 - elbFQDN
 - description
 - internal
+- auth
 dependencies:
   jumpHost:
   - automationToken


### PR DESCRIPTION
In https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/65388, I was getting the following when I worked with a file without `auth`:

```
reconcile.utils.gql.GqlApiError: `error` returned with GraphQL response
{
  "message": "Cannot return null for non-nullable field Cluster_v1.auth.",
  "locations": [
    {
      "line": 25,
      "column": 5
    }
  ],
  "path": [
    "clusters",
    40,
    "auth"
  ],
  "extensions": {
    "code": "INTERNAL_SERVER_ERROR"
  }
}
```