### PR TITLE
Add app to required in jenkins-config-1

### DIFF
--- a/schemas/dependencies/jenkins-config-1.yml
+++ b/schemas/dependencies/jenkins-config-1.yml
@@ -112,6 +112,7 @@ required:
 - labels
 - name
 - description
+- app
 - instance
 - type
 oneOf:


### PR DESCRIPTION
`app` field should be required in `jenkins-config-1`, it's `isRequired: true` in https://github.com/app-sre/qontract-schemas/blob/5a6d56f2db197b20d36b72ccf004204a13d9d6bd/graphql-schemas/schema.yml#L482