### PR TITLE
add validate targets in app attribute to saas file

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2443,6 +2443,7 @@ confs:
   - { name: parameters, type: json }
   - { name: allowedSecretParameterPaths, type: string, isList: true }
   - { name: secretParameters, type: SaasSecretParameters_v1, isList: true }
+  - { name: validateTargetsInApp, type: boolean }
   - { name: resourceTemplates, type: SaasResourceTemplate_v2, isRequired: true, isList: true }
   - { name: imagePatterns, type: string, isRequired: true, isList: true }
   - { name: takeover, type: boolean }

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -78,6 +78,9 @@ properties:
     description: saas file level parameters from vault secrets
     items:
       "$ref": "/app-sre/vault-secret-parameter-1.yml"
+  validateTargetsInApp:
+    description: indicates a desire to validate that all targets belong to the same app as the saas file itself
+    type: boolean
   resourceTemplates:
     type: array
     items:


### PR DESCRIPTION
with such a flag set to `true`, we can put more trust in a saas file owner and grant them wider permissions, such as full management over `targets`.