### PR TITLE
Add data_classification to RDS schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1288,6 +1288,10 @@ confs:
   - { name: source_type, type: string}
   - { name: event_categories, type: string, isList: true}
 
+- name: AWSRDSDataClassification_v1
+  fields:
+  - { name: loss_impact, type: string }
+
 - name: TerraformState_v1
   isInterface: true
   interfaceResolve:
@@ -1748,6 +1752,7 @@ confs:
   - { name: ca_cert, type: VaultSecret_v1 }
   - { name: annotations, type: json }
   - { name: event_notifications, type: AWSRDSEventNotification_v1, isList: true}
+  - { name: data_classification, type: AWSRDSDataClassification_v1 }
 
 - name: NamespaceTerraformResourceS3_v1
   interface: NamespaceTerraformResourceAWS_v1

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -84,6 +84,16 @@ properties:
     type: array
     items:
       type: object
+  data_classification:
+    type: object
+    properties:
+      loss_impact:
+        type: string
+        enum:
+        - high
+        - medium
+        - low
+        - none
   sqs_identifier:
     type: string
   bucket_policy:
@@ -558,6 +568,16 @@ oneOf:
             type: array
             items:
               type: string
+    data_classification:
+      type: object
+      properties:
+        loss_impact:
+          type: string
+          enum:
+          - high
+          - medium
+          - low
+          - none
   required:
   - identifier
   - defaults


### PR DESCRIPTION
Part of the broader epic https://issues.redhat.com/browse/SDE-2887

https://issues.redhat.com/browse/APPSRE-7525

This PR adds support to set the data_classification field on RDS resource schema.