### PR TITLE
Add `slo`, `long_burnrate_window` & `short_burnrate_window` labels to Prometheus rule schema

### DIFF
--- a/schemas/openshift/prometheus-rule-1.yml
+++ b/schemas/openshift/prometheus-rule-1.yml
@@ -128,6 +128,12 @@ properties:
                           type: string
                         query:
                           type: string
+                        slo:
+                          type: string
+                        long_burnrate_window:
+                          type: string
+                        short_burnrate_window:
+                          type: string
                         exported_namespace:
                           type: string
                         exported_service:


### PR DESCRIPTION
We (RHOBS) team are in the process of migrating our SLO rules to Pyrra, as app-interface also plans to migrate to it. It is a tool which helps generate multi-burn rate alerts in Prometheus format, when a availability or latency SLO is specified
We are now in the process of deploying our new SLO alerts to stage (see stage MR with full details: [!67722](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/67722))

We would like to add three labels (`slo`, `short_burnrate_window` and `long_burnrate_window`) to the prometheus schema in order to better represent the alerts and which SLO they guard, and what burn rate window they represent (alert example with mentioned label [here](https://github.com/rhobs/configuration/blob/main/resources/observability/prometheusrules/rhobs-slos-mst-stage.prometheusrules.yaml#L97))