### PR TITLE
Add group label to Prometheus rule schema

### DIFF
--- a/schemas/openshift/prometheus-rule-1.yml
+++ b/schemas/openshift/prometheus-rule-1.yml
@@ -134,6 +134,8 @@ properties:
                           type: string
                         short_burnrate_window:
                           type: string
+                        group:
+                          type: string
                         exported_namespace:
                           type: string
                         exported_service:


### PR DESCRIPTION
This PR adds a `group` label to the Prometheus rule schema, as it is sometimes necessary to partition metrics according to API group, and query them in a rule.