### PR TITLE
Update schema to support Hypershift scaling

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -775,6 +775,7 @@ confs:
   - { name: id, type: string, isRequired: true }
   - { name: instance_type, type: string, isRequired: true }
   - { name: replicas, type: int, isRequired: true }
+  - { name: subnet, type: string }
   - { name: labels, type: json }
   - { name: taints, type: Taint_v1, isList: true }
 

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -214,11 +214,6 @@ properties:
     - multi_az
     - instance_type
     - private
-    oneOf:
-    - required:
-      - nodes
-    - required:
-      - autoscale
   externalConfiguration:
     type: object
     additionalProperties: false
@@ -272,6 +267,8 @@ properties:
           type: integer
         labels:
           "$ref": "/common-1.json#/definitions/labels"
+        subnet:
+          type: string
         taints:
           type: array
           items:


### PR DESCRIPTION
- For hypershift nodes and autoscale are bound to machinePools
- Adding subnet to machinePools, they are required for Hypershift clusters


https://issues.redhat.com/browse/APPSRE-7661