### PR TITLE
Ensure Prometheus `expr` type is consistent with prometheus-operator

### DIFF
--- a/schemas/app-interface/prometheus-rule-test-1.yml
+++ b/schemas/app-interface/prometheus-rule-test-1.yml
@@ -89,7 +89,9 @@ properties:
             additionalProperties: false
             properties:
               expr:
-                type: string
+                oneOf:
+                - type: string
+                - type: integer
               eval_time:
                 type: string
               exp_samples:

--- a/schemas/app-sre/slo-document-1.yml
+++ b/schemas/app-sre/slo-document-1.yml
@@ -77,7 +77,9 @@ properties:
           required:
           - window
         expr:
-          type: string
+          oneOf:
+          - type: string
+          - type: integer
           description: |
             Prometheus expression to calculate the SLO. It should be expressed
             in the units of the 'SLOTargetUnit'. It will be processed with jinja,

--- a/schemas/openshift/prometheus-rule-1.yml
+++ b/schemas/openshift/prometheus-rule-1.yml
@@ -64,7 +64,9 @@ properties:
                     record:
                       type: string
                     expr:
-                      type: string
+                      oneOf:
+                      - type: string
+                      - type: integer     
                     labels:
                       type: object
                   required:
@@ -151,7 +153,9 @@ properties:
                       required:
                       - service
                     expr:
-                      type: string
+                      oneOf:
+                      - type: string
+                      - type: integer
                     interval:
                       type: string
                     for:


### PR DESCRIPTION
Prometheus allows having `expr` be set to an integer or a string. You can try this out, using the example rule file below and `promtool`,
```yaml
groups:
  - interval: 30s
    name: are-valid-rules
    rules:
      - alert: AlwaysFiringAlert
        annotations:
          description: Firing alert!
          message: Alert fired.
        expr: 1
        for: 1m
        labels:
          severity: page
      - record: AlwaysTwo
        expr: 2
        labels:
          count: two
```
Promtool output,
```bash
$ promtool check rules rules.yaml
Checking rules.yaml
  SUCCESS: 2 rules found
```

Prometheus-operator also follows the same convention, and this was explicitly done in https://github.com/prometheus-operator/prometheus-operator/pull/1845 (issue ref: https://github.com/prometheus-operator/prometheus-operator/issues/1831).

This PR ensures, that the schema aligns with upstream, and converts `expr` from only string field to one of int or string.