### PR TITLE
add optional escalation policy to aws account and cluster

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -881,6 +881,7 @@ confs:
   - { name: labels, type: json }
   - { name: name, type: string, isUnique: true, isSearchable: true, isRequired: true }
   - { name: description, type: string }
+  - { name: escalationPolicy, type: AppEscalationPolicy_v1 }
   - { name: auth, type: ClusterAuth_v1, isInterface: true, isList: true, isRequired: true }
   - { name: observabilityNamespace, type: Namespace_v1 }
   - { name: grafanaUrl, type: string }
@@ -1079,6 +1080,7 @@ confs:
   - { name: qontractReconcileVersion, type: string }
   - { name: terraformUsername, type: string }
   - { name: accountOwners, type: Owner_v1, isList: true, isRequired: true }
+  - { name: escalationPolicy, type: AppEscalationPolicy_v1 }
   - { name: automationToken, type: VaultSecret_v1, isRequired: true }
   - { name: garbageCollection, type: boolean }
   - { name: enableDeletion, type: boolean }

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -43,6 +43,9 @@ properties:
       required:
       - name
       - email
+  escalationPolicy:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/app-sre/escalation-policy-1.yml"
   automationToken:
     "$ref": "/common-1.json#/definitions/vaultSecret"
   garbageCollection:

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -497,6 +497,9 @@ properties:
     "$ref": "/common-1.json#/definitions/vaultSecret"
   description:
     type: string
+  escalationPolicy:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/app-sre/escalation-policy-1.yml"
   internal:
     type: boolean
   disable:


### PR DESCRIPTION
with an escalation policy referenced from an aws account or a cluster, we can use [dynamically generated per-resource alerts](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/sop/catch-all-alerts-routing.md) that will alert the tenant instead of AppSRE.