### PR TITLE
Schema addition for log retention

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1251,7 +1251,7 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: regex, type: string, isRequired: true }
-  - { name: retention_in_days, type: string }
+  - { name: retention_in_days, type: int }
 
 - name: AWSUserPolicy_v1
   datafile: /aws/policy-1.yml

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1251,7 +1251,6 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: regex, type: string, isRequired: true }
-  - { name: region, type: string }
   - { name: retention_in_days, type: string }
 
 - name: AWSUserPolicy_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1234,6 +1234,7 @@ confs:
     field: provider
     fieldMap:
       ami: AWSAccountCleanupOptionAMI_v1
+      cloudwatch: AWSAccountCleanupOptionCloudWatch_v1
   fields:
   - { name: provider, type: string, isRequired: true }
 
@@ -1244,6 +1245,14 @@ confs:
   - { name: regex, type: string, isRequired: true }
   - { name: age, type: string, isRequired: true }
   - { name: region, type: string }
+
+- name: AWSAccountCleanupOptionCloudWatch_v1
+  interface: AWSAccountCleanupOption_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: regex, type: string, isRequired: true }
+  - { name: region, type: string }
+  - { name: retention_in_days, type: string }
 
 - name: AWSUserPolicy_v1
   datafile: /aws/policy-1.yml

--- a/schemas/aws/cleanup-option-1.yml
+++ b/schemas/aws/cleanup-option-1.yml
@@ -23,7 +23,7 @@ properties:
     "$ref": "/common-1.json#/definitions/dhmsDuration"
     description: AMI age from which we can consider deletion.
   retention_in_days:
-    type: string
+    type: integer
     description: Cloudwatch log retention
 oneOf:
 - properties:
@@ -51,7 +51,24 @@ oneOf:
     regex:
       type: string
     retention_in_days:
-      type: string
+      type: integer
+      enum:
+      - 1
+      - 3
+      - 5
+      - 7
+      - 14
+      - 30
+      - 60
+      - 90
+      - 120
+      - 150
+      - 180
+      - 365
+      - 400
+      - 545
+      - 731
+      - 1096
   required:
   - provider
   - regex

--- a/schemas/aws/cleanup-option-1.yml
+++ b/schemas/aws/cleanup-option-1.yml
@@ -15,12 +15,16 @@ properties:
     description: Type of cleanup to implement.
     enum:
     - ami
+    - cloudwatch
   regex:
     type: string
     description: Regex expression to filter items by.
   age:
     "$ref": "/common-1.json#/definitions/dhmsDuration"
     description: AMI age from which we can consider deletion.
+  retention_in_days:
+    type: string
+    description: Cloudwatch log retention
 oneOf:
 - properties:
     provider:
@@ -45,8 +49,6 @@ oneOf:
       enum:
       - cloudwatch
     regex:
-      type: string
-    region:
       type: string
     retention_in_days:
       type: string

--- a/schemas/aws/cleanup-option-1.yml
+++ b/schemas/aws/cleanup-option-1.yml
@@ -22,8 +22,7 @@ properties:
     "$ref": "/common-1.json#/definitions/dhmsDuration"
     description: AMI age from which we can consider deletion.
 oneOf:
-- additionalProperties: false
-  properties:
+- properties:
     provider:
       type: string
       description: cleanup AMIs
@@ -39,5 +38,21 @@ oneOf:
   - provider
   - regex
   - age
+- properties:
+    provider:
+      type: string
+      description: Set CloudWatch log retention
+      enum:
+      - cloudwatch
+    regex:
+      type: string
+    region:
+      type: string
+    retention_in_days:
+      type: string
+  required:
+  - provider
+  - regex
+  - retention_in_days
 required:
 - provider

--- a/schemas/aws/cleanup-option-1.yml
+++ b/schemas/aws/cleanup-option-1.yml
@@ -65,10 +65,6 @@ oneOf:
       - 150
       - 180
       - 365
-      - 400
-      - 545
-      - 731
-      - 1096
   required:
   - provider
   - regex


### PR DESCRIPTION
Log groups are created with infinite log retention. All log groups should have a retention period of 3 months in order to keep storage costs in check. This change would create the following within an account file in app-interface:

```
---
$schema: /aws/account-1.yml

name: <aws-account-name>

cleanup:
- provider: cloudwatch
  regex: '<some-log-path>'
  retention_in_days: 90d
```

Note that this change is not affecting log groups managed by CLO.

Part of [APPSRE-7249](https://issues.redhat.com/browse/APPSRE-7249)