### PR TITLE
Add aws-ami-cleanup to list of integrations allowed to be disabled

### DIFF
--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -67,6 +67,7 @@ properties:
           - terraform-users
           - terraform-aws-route53
           - terraform-vpc-peerings
+          - aws-ami-cleanup
   deleteKeys:
     type: array
     items:

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -535,6 +535,7 @@ properties:
           - slack-usergroups
           - skupper-network
           - glitchtip-project-dsn
+          - aws-ami-cleanup
   awsInfrastructureAccess:
     type: array
     items:


### PR DESCRIPTION
Add the `aws-ami-cleanup` integration to the list of integrations allowed to be disabled on the account and cluster level.

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>