### PR TITLE
add support for assume action and Federated assume principal

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1776,6 +1776,7 @@ confs:
   fields:
   - { name: AWS, type: string, isList: true }
   - { name: Service, type: string, isList: true }
+  - { name: Federated, type: string }
 
 - name: NamespaceTerraformResourceSecretsManagerServiceAccount_v1
   interface: NamespaceTerraformResourceAWS_v1
@@ -1794,6 +1795,7 @@ confs:
   - { name: identifier, type: string, isRequired: true, isContextUnique: true }
   - { name: assume_role, type: AssumeRole_v1, isRequired: true }
   - { name: assume_condition, type: json }
+  - { name: assume_action, type: string }
   - { name: inline_policy, type: json }
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -33,6 +33,8 @@ properties:
     type: object
   assume_condition:
     type: object
+  assume_action:
+    type: string
   inline_policy:
     type: object
   output_resource_name:
@@ -389,14 +391,21 @@ oneOf:
           type: array
           items:
             type: string
+        Federated:
+          type: string
       anyOf:
       - required:
         - AWS
       - required:
         - Service
+      - required:
+        - Federated
     assume_condition:
       description: condition context keys for IAM and AWS STS
       type: object
+    assume_action:
+      description: alternate sts call instead of AssumeRole
+      type: string
     inline_policy:
       type: object
     output_resource_name:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-7734

this PR adds support to allow creating roles with:
- a different assume action (instead of AssumeRole)
- a Federated assume Principal

this is required to attach IAM roles to OpenShift ServiceAccounts.

this fits the backplane usage, but is a good pattern instead of using IAM credentials, so this possibly opens up a door for https://issues.redhat.com/browse/APPSRE-4201