### PR TITLE
add backref from app to role self-service

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2471,6 +2471,12 @@ confs:
     synthetic:
       schema: /dependencies/glitchtip-project-1.yml
       subAttr: app
+  - name: selfServiceRoles
+    type: Role_v1
+    isList: true
+    synthetic:
+      schema: /access/role-1.yml
+      subAttr: self_service.datafiles
 
 - name: SaasFile_v2
   datafile: /app-sre/saas-file-2.yml


### PR DESCRIPTION
the use case is to validate that all apps are covered by self-service.

querying via the app is much simpler.