### PR TITLE
add assume_role for all peering connections

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -866,6 +866,7 @@ confs:
 
 - name: ClusterPeering_v1
   fields:
+  - { name: assumeRole, type: string }
   - { name: connections, type: ClusterPeeringConnection_v1, isRequired: true, isList: true, isInterface: true }
 
 - name: ClusterPrometheus_v1

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -300,6 +300,9 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      assumeRole:
+        type: string
+        description: role to assume for all peering connections
       connections:
         type: array
         items:


### PR DESCRIPTION
we currently define `assume_role` at the connection level.

a given cluster is either OSD or ROSA.
OSD - peering connections are managed via OCM Infrastructure Access.
ROSA - peering connections are managed via an IAM role created per cluster (`osd-experience`).

a cluster is only OSD or ROSA, thus if a single peering connection needs `assume_role`, all connections need them. might as well make this field global for all connections.

note: this is a proposal looking for someone to implement the corresponding qontract-reconcile side, along with a proper deprecation so we don't shoot ourselves in the foot.