### PR TITLE
Allow for more names in the saas deploy template

### DIFF
--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -35,6 +35,7 @@ properties:
     type: string
     enum:
     - openshift-saas-deploy
+    - saas-deploy
   hashLength:
     type: integer
     enum:


### PR DESCRIPTION
We need to shorten the name due to how Tekton names PipelineRun retries, see APPSRE-6031 for details.

This property is actually only used by Visual Qontract and it should be removed as it only partially reflects the reality after openshift-tekton-resources.