### PR TITLE
[terraform-msk] make users name attribute an identifier

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1731,7 +1731,12 @@ confs:
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
-  - { name: users, type: SaasSecretParameters_v1, isList: true }
+  - { name: users, type: MskSecretParameters_v1, isList: true }
+
+- name: MskSecretParameters_v1
+  fields:
+  - { name: name, type: string, isRequired: true, isContextUnique: true }
+  - { name: secret, type: VaultSecret_v1, isRequired: true }
 
 - name: NamespaceTerraformResourceRDS_v1
   interface: NamespaceTerraformResourceAWS_v1

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -219,7 +219,15 @@ properties:
   users:
     type: array
     items:
-      "$ref": "/app-sre/vault-secret-parameter-1.yml"
+      type: object
+      properties:
+        name:
+          "$ref": "/common-1.json#/definitions/identifierLowercase64"
+        secret:
+          "$ref": "/common-1.json#/definitions/vaultSecret"
+      required:
+      - name
+      - secret
 oneOf:
 - additionalProperties: false
   properties:
@@ -1421,7 +1429,15 @@ oneOf:
     users:
       type: array
       items:
-        "$ref": "/app-sre/vault-secret-parameter-1.yml"
+        type: object
+        properties:
+          name:
+            "$ref": "/common-1.json#/definitions/identifierLowercase64"
+          secret:
+            "$ref": "/common-1.json#/definitions/vaultSecret"
+        required:
+        - name
+        - secret
   required:
   - identifier
   - defaults


### PR DESCRIPTION
The `users.name` attribute is used as an AWS resource identifier. Make this attribute an identifier in the schemas and limit it to 64 chars.