### PR TITLE
[change-owners] resourcefile backrefs for ownership expansion

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3833,6 +3833,7 @@ confs:
 - name: ChangeTypeChangeDetectorContextSelector_v1
   fields:
   - { name: selector, type: string, isRequired: true }
+  - { name: where, type: "string" }
   - { name: when, type: "string" }
 
 - name: RosaOcmSpec_v1

--- a/schemas/app-interface/change-type-1.yml
+++ b/schemas/app-interface/change-type-1.yml
@@ -66,6 +66,10 @@ properties:
           properties:
             selector:
               type: string
+            where:
+              type: string
+              enum:
+              - backrefs
             when:
               type: string
               enum:
@@ -91,6 +95,10 @@ properties:
             properties:
               selector:
                 type: string
+              where:
+                type: string
+                enum:
+                - backrefs
               when:
                 type: string
                 enum:
@@ -119,6 +127,10 @@ properties:
             properties:
               selector:
                 type: string
+              where:
+                type: string
+                enum:
+                - backrefs
               when:
                 type: string
                 enum:


### PR DESCRIPTION
introduce a change-type context field `where: backrefs` to indicate that ownership expansion should be driven by resourcefile backrefs

```yaml
changes:
- provider: change-type
  changeTypes:
  - $ref: /app-interface/changetype/rds-defaults-maintainer.yaml
  context:
    where: backrefs (1)
    selector: externalResources[?(@.provider=="aws")].resources[?(@.provider=="rds")].defaults (2)
```

(1) `where: backrefs` defines that the backrefs of a resourcefile need to be inspected in order to relate it back to the owned namespace file
(2) ... but to be more restrictive, the RDS resource file must be used in a very specific location within the namespace file