### PR TITLE
aws/asg-defaults: allow specifying instance_requirements

### DIFF
--- a/schemas/aws/asg-defaults-1.yml
+++ b/schemas/aws/asg-defaults-1.yml
@@ -89,6 +89,27 @@ properties:
               - st1
             encrypted:
               type: boolean
+  instance_requirements:
+    type: object
+    additionalProperties: false
+    properties:
+      vcpu_count:
+        type: object
+        additionalProperties: false
+        properties:
+          min:
+            type: integer
+          max:
+            type: integer
+      memory_mib:
+        min:
+          type: integer
+        max:
+          type: integer
+      excluded_instance_types:
+        type: array
+        items:
+          type: string
 required:
 - "$schema"
 - max_size


### PR DESCRIPTION
Adds the ability to specify vcpu, memory, and excluded instance types. While instance_requirements supports more parameters, expose just the ones needed for basic usage at first.

app-sre/qontract-reconcile#3595