### PR TITLE
add backref from jira board to escalation policy via channel

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -521,6 +521,12 @@ confs:
   - { name: slack, type: SlackOutput_v1 }
   - { name: issueResolveState, type: string }
   - { name: issueReopenState, type: string }
+  - name: escalationPolicies
+    type: AppEscalationPolicy_v1
+    isList: true
+    synthetic:
+      schema: /app-sre/escalation-policy-1.yml
+      subAttr: channels.jiraBoard
 
 - name: SendGridAccount_v1
   fields:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4926

to be able to find escalation policies referencing jira boards (to get the jira component implemented in #477)