### PR TITLE
[AUS] individual version blocks per upgrade policy / cluster

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -761,6 +761,7 @@ confs:
   - { name: soakDays, type: int }
   - { name: mutexes, type: string, isList: true }
   - { name: sector, type: string }
+  - { name: blockedVersions, type: string, isList: true }
 
 - name: ClusterUpgradePolicy_v1
   fields:

--- a/schemas/openshift/cluster-upgrade-policy-1.yml
+++ b/schemas/openshift/cluster-upgrade-policy-1.yml
@@ -40,6 +40,13 @@ properties:
           defined in openshift-cluster-manager-1.yml. A cluster will be
           upgraded to a version only if clusters in previous sectors are
           running that version or higher.
+      blockedVersions:
+        description: |
+          List of versions that will be rejected for upgrades.
+          They can be regular expressions"
+        type: array
+        items:
+          type: string
     oneOf:
     - required:
       - soakDays


### PR DESCRIPTION
implement version blocks per-cluster. this can be used to individually freeze/stop the upgrade process

part of https://issues.redhat.com/browse/APPSRE-7870