### PR TITLE
make the escalation-policy schema eligible for self-service

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2317,7 +2317,9 @@ confs:
   - { name: items, type: AppQuayReposItems_v1, isRequired: true, isList: true }
 
 - name: AppEscalationPolicy_v1
+  datafile: /app-sre/escalation-policy-1.yml
   fields:
+  - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
   - { name: labels, type: json }

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -168,6 +168,7 @@ properties:
                   - /dependencies/quay-org-1.yml
                   - /cloudflare/account-1.yml
                   - /cloudflare/dns-zone-1.yml
+                  - /app-sre/escalation-policy-1.yml
 required:
 - $schema
 - labels


### PR DESCRIPTION
make the /app-sre/escalation-policy-1.yml schema eligible for self-service

for a datafile to be self-serviceable, it must be mentioned in the `self_service.datafiles` enum of `/access/role-1.yml` additionally, the GQL type must define the `datafile` property referencing the schema.

https://issues.redhat.com/browse/APPSRE-7955