### PR TITLE
schema for proposed slack notifications

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2548,6 +2548,7 @@ confs:
 - name: SlackOutputNotifications_v1
   fields:
   - { name: start, type: boolean }
+  - { name: proposed, type: boolean }
 
 - name: SlackOutput_v1
   fields:

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -42,6 +42,9 @@ properties:
         properties:
           start:
             type: boolean
+          proposed:
+            type: boolean
+            description: post slack notification when promotion is proposed (merge request created)
     required:
     - workspace
     - channel


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-8064

this is an implementation idea for how to configure slack notifications for when a MR is raised to promote a sha in a saas file.

with a matching (stateful?) handle in qontract-reconcile/openshift-saas-deploy, i bet we can make this happen.

qontract-reconcile part is up for grabs!