### PR TITLE
[glitchtip-project-1.yml] add glitchtipId attribute

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3505,6 +3505,7 @@ confs:
   - { name: path, type: string, isRequired: true }
   - { name: schema, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true, isUnique: true }
+  - { name: glitchtipId, type: string }
   - { name: description, type: string, isRequired: true }
   - { name: app, type: App_v1, isRequired: true }
   - { name: platform, type: string, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3505,7 +3505,7 @@ confs:
   - { name: path, type: string, isRequired: true }
   - { name: schema, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true, isUnique: true }
-  - { name: glitchtipId, type: string }
+  - { name: projectId, type: string }
   - { name: description, type: string, isRequired: true }
   - { name: app, type: App_v1, isRequired: true }
   - { name: platform, type: string, isRequired: true }

--- a/schemas/dependencies/glitchtip-project-1.yml
+++ b/schemas/dependencies/glitchtip-project-1.yml
@@ -13,6 +13,8 @@ properties:
     "$ref": "/common-1.json#/definitions/labels"
   name:
     "$ref": "/common-1.json#/definitions/identifierLowercase64"
+  glitchtipId:
+    "$ref": "/common-1.json#/definitions/identifierLowercase64"
   description:
     type: string
   app:

--- a/schemas/dependencies/glitchtip-project-1.yml
+++ b/schemas/dependencies/glitchtip-project-1.yml
@@ -13,7 +13,7 @@ properties:
     "$ref": "/common-1.json#/definitions/labels"
   name:
     "$ref": "/common-1.json#/definitions/identifierLowercase64"
-  glitchtipId:
+  projectId:
     "$ref": "/common-1.json#/definitions/identifierLowercase64"
   description:
     type: string


### PR DESCRIPTION
### What
Add an optional `glitchtip-project-1.projectId` attribute. 

### Why
In Glitchtip, a project is referenced by a `slug`; for convenience, the integration deviates this `slug` based on the `glitchtip-project-1.name` attribute. If a tenant wants to rename a project, the integration can't figure out the original `slug` anymore and will delete and recreate the project. To omit that, a tenant can manually specify the `slug` via `glitchtip-project-1.projectId ` to rename a project.