### PR TITLE
APPSRE-8144 add dynatrace environment

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -572,6 +572,14 @@ confs:
   - { name: icon_emoji, type: string, isRequired: true }
   - { name: username, type: string, isRequired: true }
 
+- name: DynatraceEnvironment_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isUnique: true }
+  - { name: description, type: string, isRequired: true }
+  - { name: environmentUrl, type: string, isRequired: true, isUnique: true }
+
 - name: GithubOrg_v1
   fields:
   - { name: schema, type: string, isRequired: true }
@@ -902,6 +910,7 @@ confs:
   - { name: managedGroups, type: string, isList: true }
   - { name: managedClusterRoles, type: boolean }
   - { name: ocm, type: OpenShiftClusterManager_v1 }
+  - { name: dynatraceEnvironment, type: DynatraceEnvironment_v1 }
   - { name: spec, type: ClusterSpec_v1, isInterface: true }
   - { name: externalConfiguration, type: ClusterExternalConfiguration_v1 }
   - { name: upgradePolicy, type: ClusterUpgradePolicy_v1 }
@@ -2228,6 +2237,7 @@ confs:
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
   - { name: delete, type: boolean }
+  - { name: enableDynatraceLogging, type: boolean }
   - { name: description, type: string, isRequired: true }
   - { name: grafanaUrl, type: string }
   - { name: cluster, type: Cluster_v1, isRequired: true }
@@ -3436,6 +3446,7 @@ confs:
   - { name: cloudflare_account_role_v1, type: CloudflareAccountRole_v1, isList: true, datafileSchema: /cloudflare/account-role-1.yml }
   - { name: terraform_repo_v1, type: TerraformRepo_v1, isList: true, datafileSchema: /aws/terraform-repo-1.yml }
   - { name: status_board_v1, type: StatusBoard_v1, isList: true, datafileSchema: /dependencies/status-board-1.yml }
+  - { name: dynatrace_environment_v1, type: DynatraceEnvironment_v1, isList: true, datafileSchema: /dependencies/dynatrace-environment-1.yml }
 
 - name: GlitchtipInstance_v1
   fields:

--- a/schemas/dependencies/dynatrace-environment-1.yml
+++ b/schemas/dependencies/dynatrace-environment-1.yml
@@ -1,0 +1,22 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /dependencies/dynatrace-environment-1.yml
+  name:
+    type: string
+  description:
+    type: string
+  environmentUrl:
+    type: string
+required:
+- "$schema"
+- name
+- description
+- environmentUrl

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -109,6 +109,9 @@ properties:
   ocm:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/openshift/openshift-cluster-manager-1.yml"
+  dynatraceEnvironment:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/dependencies/dynatrace-environment-1.yml"
   managedGroups:
     type: array
     items:

--- a/schemas/openshift/namespace-1.yml
+++ b/schemas/openshift/namespace-1.yml
@@ -22,6 +22,9 @@ properties:
   description:
     type: string
 
+  enableDynatraceLogging:
+    type: boolean
+
   grafanaUrl:
     type: string
     format: uri


### PR DESCRIPTION
This introduces the dynatrace environment as a dependency. That dependency can be used by clusters to specify where to send logs to. Additionally, namespaces have a flag to turn on/off dynatrace log ingestion.

Further, this schema can be easily extended to inhibit token information.