### PR TITLE
Add issueType to jira board schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -519,6 +519,7 @@ confs:
   - { name: server, type: JiraServer_v1, isRequired: true }
   - { name: severityPriorityMappings, type: JiraSeverityPriorityMappings_v1, isRequired: true }
   - { name: slack, type: SlackOutput_v1 }
+  - { name: issueType, type: string }
   - { name: issueResolveState, type: string }
   - { name: issueReopenState, type: string }
   - name: escalationPolicies

--- a/schemas/dependencies/jira-board-1.yml
+++ b/schemas/dependencies/jira-board-1.yml
@@ -31,6 +31,8 @@ properties:
         type: string
     required:
     - workspace
+  issueType:
+    type: string
   issueResolveState:
     type: string
   issueReopenState:


### PR DESCRIPTION
This permits a team to specify a new issue type for jiralert to use.

See downstream: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/76908

Issue https://issues.redhat.com/browse/RHTAPSRE-129