### PR TITLE
add new code component type - app-interface

### DIFF
--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -282,6 +282,7 @@ properties:
           - saasrepo
           - bundle
           - other
+          - app-interface
         showInReviewQueue:
           type: boolean
           description: Include MRs from this repo in the AppSRE Review Queue


### PR DESCRIPTION
a new repo type to be used later for (example) repo initiation.