### PR TITLE
make change-type context.selector optional

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3888,7 +3888,7 @@ confs:
 
 - name: ChangeTypeChangeDetectorContextSelector_v1
   fields:
-  - { name: selector, type: string, isRequired: true }
+  - { name: selector, type: string }
   - { name: where, type: "string" }
   - { name: when, type: "string" }
 


### PR DESCRIPTION
It will default to `$.path` thanks to https://github.com/app-sre/qontract-reconcile/pull/3663

cc @geoberle 