### PR TITLE
remove enum for rds intsance class overrides

### DIFF
--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -475,54 +475,6 @@ oneOf:
           type: string
         instance_class:
           type: string
-          enum:
-          - db.t2.micro
-          - db.t2.small
-          - db.t3.small
-          - db.m3.medium
-          - db.t3.medium
-          - db.t3.large
-          - db.t3.xlarge
-          - db.t3.2xlarge
-          - db.m4.large
-          - db.m4.xlarge
-          - db.m4.2xlarge
-          - db.m5.large
-          - db.m5.xlarge
-          - db.m5.2xlarge
-          - db.m5.4xlarge
-          - db.m5.8xlarge
-          - db.m5.12xlarge
-          - db.m5.16xlarge
-          - db.m5.24xlarge
-          - db.m6g.large
-          - db.m6g.xlarge
-          - db.m6g.2xlarge
-          - db.m6g.4xlarge
-          - db.m6g.8xlarge
-          - db.m6g.12xlarge
-          - db.m6g.16xlarge
-          - db.m7g.large
-          - db.m7g.xlarge
-          - db.m7g.2xlarge
-          - db.m7g.4xlarge
-          - db.m7g.8xlarge
-          - db.m7g.12xlarge
-          - db.m7g.16xlarge
-          - db.r4.large
-          - db.r4.xlarge
-          - db.r4.2xlarge
-          - db.r4.4xlarge
-          - db.r4.8xlarge
-          - db.r4.16xlarge
-          - db.r5.large
-          - db.r5.xlarge
-          - db.r5.2xlarge
-          - db.r5.4xlarge
-          - db.r5.8xlarge
-          - db.r5.12xlarge
-          - db.r5.16xlarge
-          - db.r5.24xlarge
         allocated_storage:
           type: integer
         backup_retention_period:


### PR DESCRIPTION
we don't need to enforce, nor to maintain a list of instance classes.