### PR TITLE
Allow cpu limits to be optional

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2556,12 +2556,17 @@ confs:
 
 - name: DeployResources_v1
   fields:
-  - { name: requests, type: ResourceRequirements_v1, isRequired: true }
-  - { name: limits, type: ResourceRequirements_v1, isRequired: true }
+  - { name: requests, type: ResourceRequestsRequirements_v1, isRequired: true }
+  - { name: limits, type: ResourceLimitsRequirements_v1, isRequired: true }
 
-- name: ResourceRequirements_v1
+- name: ResourceRequestsRequirements_v1
   fields:
   - { name: cpu, type: string, isRequired: true }
+  - { name: memory, type: string, isRequired: true }
+
+- name: ResourceLimitsRequirements_v1
+  fields:
+  - { name: cpu, type: string }
   - { name: memory, type: string, isRequired: true }
 
 - name: SlackOutputNotifications_v1

--- a/schemas/openshift/deploy-resources-1.yml
+++ b/schemas/openshift/deploy-resources-1.yml
@@ -15,10 +15,10 @@ properties:
     - /openshift/deploy-resources-1.yml
   requests:
     description: "cpu and memory pod requests"
-    "$ref": "/openshift/resource-requirements-1.yml"
+    "$ref": "/openshift/resource-requests-requirements-1.yml"
   limits:
     description: "cpu and memory pod limits"
-    "$ref": "/openshift/resource-requirements-1.yml"
+    "$ref": "/openshift/resource-limits-requirements-1.yml"
 anyOf:
 - required:
   - requests

--- a/schemas/openshift/resource-limits-requirements-1.yml
+++ b/schemas/openshift/resource-limits-requirements-1.yml
@@ -1,0 +1,18 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+description: |
+  CPU and memory resources requirements to be set in pods limits configuration
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /openshift/resource-limits-requirements-1.yml
+  cpu:
+    "$ref": "/common-1.json#/definitions/k8sResourceRequirementQuantity"
+  memory:
+    "$ref": "/common-1.json#/definitions/k8sResourceRequirementQuantity"
+required:
+- memory

--- a/schemas/openshift/resource-requests-requirements-1.yml
+++ b/schemas/openshift/resource-requests-requirements-1.yml
@@ -4,13 +4,13 @@ version: '1.0'
 type: object
 description: |
   CPU and memory resources requirements to be set in pods requests
-  and limits configuration
+  configuration
 additionalProperties: false
 properties:
   "$schema":
     type: string
     enum:
-    - /openshift/resource-requirements-1.yml
+    - /openshift/resource-requests-requirements-1.yml
   cpu:
     "$ref": "/common-1.json#/definitions/k8sResourceRequirementQuantity"
   memory:


### PR DESCRIPTION
As part of [APPSRE-8174](https://issues.redhat.com/browse/APPSRE-8174), we need to allow `limits.cpu` to be not set.