### PR TITLE
APPSRE-7135: Add support for read replicas waiver to GABI schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3343,6 +3343,7 @@ confs:
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
+  - { name: readReplicasWaiverPledge, type: string }
   - { name: signoffManagers, type: User_v1, isRequired: true, isList: true }
   - { name: users, type: User_v1, isRequired: true, isList: true }
   - { name: instances, type: GabiNamespace_v1, isRequired: true, isList: true }

--- a/schemas/app-sre/gabi-instance-1.yml
+++ b/schemas/app-sre/gabi-instance-1.yml
@@ -15,6 +15,8 @@ properties:
     "$ref": "/common-1.json#/definitions/extendedIdentifier"
   description:
     type: string
+  readReplicasWaiverPledge:
+    type: string
   signoffManagers:
     type: array
     items:


### PR DESCRIPTION
Add support for the read replicas requirement waiver to GABI schema through a new optional string type attribute called `readReplicasWaiverPledge` that will be used to store a free-form waiver pledge text.

Related:

- [APPSRE-7135](https://issues.redhat.com/browse/APPSRE-7135)
- [!78208](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/78208)

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>