### PR TITLE
[glitchtip-project-alerts] attributes

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3503,6 +3503,40 @@ confs:
   - { name: role, type: string, isRequired: true }
   - { name: organization, type: GlitchtipOrganization_v1, isRequired: true, isUnique: true }
 
+- name: GlitchtipProjectAlert_v1
+  datafile: /dependencies/glitchtip-project-alert-1.yml
+  fields:
+  - { name: path, type: string, isRequired: true }
+  - { name: schema, type: string, isRequired: true }
+  - { name: labels, type: json }
+  - { name: name, type: string, isRequired: true, isContextUnique: true }
+  - { name: description, type: string, isRequired: true }
+  - { name: quantity, type: int, isRequired: true }
+  - { name: timespanMinutes, type: int, isRequired: true }
+  - { name: recipients, type: GlitchtipProjectAlertRecipient_v1, isRequired: true, isList: true, isInterface: true }
+
+- name: GlitchtipProjectAlertRecipient_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      email-project-members: GlitchtipProjectAlertRecipientEmail_v1
+      webhook: GlitchtipProjectAlertRecipientWebhook_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+
+- name: GlitchtipProjectAlertRecipientEmail_v1
+  interface: GlitchtipProjectAlertRecipient_v1
+  fields:
+  - { name: provider, type: string, isRequired: true, isContextUnique: true }
+
+- name: GlitchtipProjectAlertRecipientWebhook_v1
+  interface: GlitchtipProjectAlertRecipient_v1
+  fields:
+  - { name: provider, type: string, isRequired: true, isContextUnique: true }
+  - { name: url, type: string, isRequired: true, isContextUnique: true }
+
 - name: GlitchtipProjects_v1
   datafile: /dependencies/glitchtip-project-1.yml
   fields:
@@ -3515,6 +3549,7 @@ confs:
   - { name: platform, type: string, isRequired: true }
   - { name: teams, type: GlitchtipTeam_v1, isRequired: true, isList: true }
   - { name: organization, type: GlitchtipOrganization_v1, isRequired: true }
+  - { name: alerts, type: GlitchtipProjectAlert_v1, isList: true }
   - name: namespaces
     type: Namespace_v1
     isList: true

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -204,6 +204,10 @@
     "ldapGroupName": {
       "type": "string",
       "pattern": "^ai-[a-z][a-z0-9-_.]+[a-z0-9]*$"
+    },
+    "positiveInteger": {
+      "type": "number",
+      "minimum": 1
     }
   }
 }

--- a/schemas/dependencies/glitchtip-project-1.yml
+++ b/schemas/dependencies/glitchtip-project-1.yml
@@ -82,6 +82,16 @@ properties:
   organization:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/dependencies/glitchtip-organization-1.yml"
+  alerts:
+    type: array
+    items:
+      oneOf:
+      # inline
+      - "$ref": "/dependencies/glitchtip-project-alert-1.yml"
+      # referenced
+      - "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "/dependencies/glitchtip-project-alert-1.yml"
+
 required:
 - name
 - description

--- a/schemas/dependencies/glitchtip-project-alert-1.yml
+++ b/schemas/dependencies/glitchtip-project-alert-1.yml
@@ -1,0 +1,56 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /dependencies/glitchtip-project-alert-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    "$ref": "/common-1.json#/definitions/identifier"
+  description:
+    type: string
+  quantity:
+    "$ref": "/common-1.json#/definitions/positiveInteger"
+  timespanMinutes:
+    "$ref": "/common-1.json#/definitions/positiveInteger"
+  recipients:
+    type: array
+    items:
+      additionalProperties: false
+      properties:
+        provider:
+          type: string
+        url:
+          type: string
+      oneOf:
+      - additionalProperties: false
+        properties:
+          provider:
+            type: string
+            enum:
+            - email-project-members
+        required:
+        - provider
+      - additionalProperties: false
+        properties:
+          provider:
+            type: string
+            enum:
+            - webhook
+          url:
+            type: string
+        required:
+        - provider
+        - url
+required:
+- name
+- description
+- quantity
+- timespanMinutes
+- recipients


### PR DESCRIPTION
Introduce additional schema to represent Glitchtip project alerts.

Example: https://gitlab.cee.redhat.com/app-sre/app-interface-dev-data/-/merge_requests/79
Ticket: [APPSRE-7521](https://issues.redhat.com/browse/APPSRE-7521)
Design-doc: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/glitchtip-project-alerts.md