### PR TITLE
[cluster.auth] remove obsolete OIDC attributes

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -670,15 +670,6 @@ confs:
   fields:
   - { name: service, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
-  - { name: issuer, type: string }
-  - { name: claims, type: ClusterAuthOIDCClaims_v1 }
-
-- name: ClusterAuthOIDCClaims_v1
-  fields:
-  - { name: email, type: string, isList: true }
-  - { name: username, type: string, isList: true }
-  - { name: name, type: string, isList: true }
-  - { name: groups, type: string, isList: true }
 
 - name: KafkaClusterSpec_v1
   fields:

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -77,26 +77,6 @@ properties:
             - oidc
           name:
             type: string
-          issuer:
-            type: string
-            format: uri
-          claims:
-            email:
-              type: array
-              items:
-                type: string
-            username:
-              type: array
-              items:
-                type: string
-            name:
-              type: array
-              items:
-                type: string
-            groups:
-              type: array
-              items:
-                type: string
         required:
         - service
         - name


### PR DESCRIPTION
These attributes aren't needed anymore, because all OIDC attributes have been migrated to OCM labels.

Ticket: [APPSRE-8126](https://issues.redhat.com/browse/APPSRE-8126)