### PR TITLE
[glitchtip-project-alert] add urlSecret attribute

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3536,7 +3536,8 @@ confs:
   interface: GlitchtipProjectAlertRecipient_v1
   fields:
   - { name: provider, type: string, isRequired: true, isContextUnique: true }
-  - { name: url, type: string, isRequired: true, isContextUnique: true }
+  - { name: url, type: string, isContextUnique: true }
+  - { name: urlSecret, type: VaultSecret_v1, isContextUnique: true }
 
 - name: GlitchtipProjects_v1
   datafile: /dependencies/glitchtip-project-1.yml

--- a/schemas/dependencies/glitchtip-project-alert-1.yml
+++ b/schemas/dependencies/glitchtip-project-alert-1.yml
@@ -28,6 +28,8 @@ properties:
           type: string
         url:
           type: string
+        urlSecret:
+          "$ref": "/common-1.json#/definitions/vaultSecret"
       oneOf:
       - additionalProperties: false
         properties:
@@ -45,9 +47,15 @@ properties:
             - webhook
           url:
             type: string
+          urlSecret:
+            "$ref": "/common-1.json#/definitions/vaultSecret"
         required:
         - provider
-        - url
+        oneOf:
+        - required:
+          - url
+        - required:
+          - urlSecret
 required:
 - name
 - description


### PR DESCRIPTION
A webhook URL may contain credentials, e.g. slack webhooks. Add an `urlSecret` attribute to retrieve a URL via Vault as well.

Ticket: [[glitchtip project-alerts] Webhook URL from vault](https://issues.redhat.com/browse/APPSRE-8288)