### PR TITLE
__identifier field on crossrefs to enable validation of context uniqeness in lists of crossref objects

### DIFF
--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -141,6 +141,10 @@
         "$ref": {
           "type": "string",
           "format": "uri-reference"
+        },
+        "__identifier": {
+          "type": "string",
+          "description": "this is the field that holds the context uniqueness hash for a crossref. it is managed by qontract-bundler during the bundling process if a crossref datafile defines at least one isContextUnique field"
         }
       },
       "required": [


### PR DESCRIPTION
the `__identifier` field is a field managed by qontract-validator when an object defines one or many `isContextUnique` fields. it holds a hash which is then used to figure out if an object is really unique within the context.

to enable the context uniqueness check also on lists of crossrefs, the crossref jsonschema type needs to declare it so that qontract-bundler can add it and qontract-validator can still validate the schema.

completements https://github.com/app-sre/qontract-validator/pull/58
part of https://issues.redhat.com/browse/APPSRE-8308