### PR TITLE
Allow branch name `stage`

### DIFF
--- a/schemas/app-sre/saas-file-target-1.yml
+++ b/schemas/app-sre/saas-file-target-1.yml
@@ -37,7 +37,7 @@ properties:
       - include
   ref:
     type: string
-    pattern: '^([0-9a-f]{40}|master|main|internal|stable)$'
+    pattern: '^([0-9a-f]{40}|master|main|internal|stable|stage)$'
   promotion:
     type: object
     additionalProperties: false


### PR DESCRIPTION
We'd like to be able to have our:
- `integration` environment to follow the `main` branch
- `stage` environment to follow the `stage` branch
- `production` environment to be pinned to a commit

Currently this [fails validation](https://ci.int.devshift.net/job/service-app-interface-gl-pr-check/281770/artifact/temp/reports/index.html).