### PR TITLE
add engagement model to app file

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2452,6 +2452,7 @@ confs:
   - { name: name, type: string, isRequired: true, isSearchable: true, isUnique: true }
   - { name: description, type: string, isRequired: true }
   - { name: onboardingStatus, type: string, isRequired: true }
+  - { name: engagementModel, type: string, isRequired: false }
   - { name: grafanaUrls, isList: true, type: GrafanaDashboardUrls_v1, isRequired: true }
   - { name: sopsUrl, type: string, isRequired: true }
   - { name: architectureDocument, type: string, isRequired: true }

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -28,6 +28,13 @@ properties:
     - OffBoarding      # The app is being off-boarded
     - BestEffort       # The app is supported on a best effort basis
 
+  engagmentModel:
+    type: string
+    description: level of engagement with the service
+    enum:
+    - Standard
+    - HighTouch
+
   grafanaUrls:
     type: array
     description: |


### PR DESCRIPTION
supporting the proposal in https://gitlab.cee.redhat.com/app-sre/contract/-/merge_requests/109

adding `engagementModel` to app files will help determine the engagement level with each different service.

this attribute can be added to either child apps or parent apps, illustrating the engagement level per component if needed.

starting out with this attribute as optional so we don't create a breaking change that requires every instance to add this attribute to all app files. we can make it mandatory down the line, or not. perhaps the default is `Standard`, unless otherwise specified.