### PR TITLE
add soakDays for saas promotions

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2645,7 +2645,7 @@ confs:
   - { name: auto, type: boolean }
   - { name: publish, type: string, isList: true }
   - { name: subscribe, type: string, isList: true }
-  - { name: soakDays, type: integer }
+  - { name: soakDays, type: int }
   - { name: promotion_data, type: PromotionData_v1, isList: true }
 
 - name: SaasSecretParameters_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2645,6 +2645,7 @@ confs:
   - { name: auto, type: boolean }
   - { name: publish, type: string, isList: true }
   - { name: subscribe, type: string, isList: true }
+  - { name: soakDays, type: integer }
   - { name: promotion_data, type: PromotionData_v1, isList: true }
 
 - name: SaasSecretParameters_v1

--- a/schemas/app-sre/saas-file-target-1.yml
+++ b/schemas/app-sre/saas-file-target-1.yml
@@ -54,6 +54,9 @@ properties:
         items:
           type: string
         minItems: 1
+      soakDays:
+        type: integer
+        description: number of days to wait for promotion
       promotion_data:
         type: array
         items:


### PR DESCRIPTION
the idea would be to store version history continuously and only promote once soakDays passed

this concept is similar to the one of AUS, and may bring a standard to our different promotion processes.