### PR TITLE
add missing replication_configurations property

### DIFF
--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -80,6 +80,10 @@ properties:
     type: array
     items:
       type: string
+  replication_configurations:
+    type: array
+    items:
+      type: object
   event_notifications:
     type: array
     items:


### PR DESCRIPTION
the s3 provider defines `replication_configurations` as a valid config option, but it also needs to be defined outside of the `oneOf` sections to be verifiable by jsonschema.