### PR TITLE
Cleanup cluster schema for default machine pool handling

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -714,11 +714,8 @@ confs:
   - { name: version, type: string, isRequired: true }
   - { name: initial_version, type: string, isRequired: true }
   - { name: multi_az, type: boolean, isRequired: true }
-  - { name: nodes, type: int }
-  - { name: instance_type, type: string, isRequired: true }
   - { name: private, type: boolean, isRequired: true }
   - { name: provision_shard_id, type: string }
-  - { name: autoscale, type: ClusterSpecAutoScale_v1 }
   - { name: disable_user_workload_monitoring, type: boolean }
   - { name: hypershift, type: boolean, isRequired: false}
 
@@ -734,11 +731,8 @@ confs:
   - { name: version, type: string, isRequired: true }
   - { name: initial_version, type: string, isRequired: true }
   - { name: multi_az, type: boolean, isRequired: true }
-  - { name: nodes, type: int }
-  - { name: instance_type, type: string, isRequired: true }
   - { name: private, type: boolean, isRequired: true }
   - { name: provision_shard_id, type: string }
-  - { name: autoscale, type: ClusterSpecAutoScale_v1 }
   - { name: disable_user_workload_monitoring, type: boolean }
   - { name: hypershift, type: boolean, isRequired: false}
   - { name: storage, type: int, isRequired: true }
@@ -757,11 +751,8 @@ confs:
   - { name: version, type: string, isRequired: true }
   - { name: initial_version, type: string, isRequired: true }
   - { name: multi_az, type: boolean, isRequired: true }
-  - { name: nodes, type: int }
-  - { name: instance_type, type: string, isRequired: true }
   - { name: private, type: boolean, isRequired: true }
   - { name: provision_shard_id, type: string }
-  - { name: autoscale, type: ClusterSpecAutoScale_v1 }
   - { name: disable_user_workload_monitoring, type: boolean }
   - { name: hypershift, type: boolean, isRequired: false}
   - { name: subnet_ids, type: string, isList: True}

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -146,10 +146,6 @@ properties:
         type: string
       multi_az:
         type: boolean
-      nodes:
-        type: integer
-      instance_type:
-        type: string
       private:
         type: boolean
       storage:
@@ -177,18 +173,6 @@ properties:
         - 20
       provision_shard_id:
         type: string
-      autoscale:
-        type: object
-        additionalProperties: false
-        properties:
-          min_replicas:
-            type: integer
-            minimum: 4
-          max_replicas:
-            type: integer
-        required:
-        - min_replicas
-        - max_replicas
       disable_user_workload_monitoring:
         type: boolean
       account:
@@ -215,7 +199,6 @@ properties:
     - version
     - initial_version
     - multi_az
-    - instance_type
     - private
   externalConfiguration:
     type: object
@@ -257,6 +240,7 @@ properties:
         type: string
   machinePools:
     type: array
+    minItems: 1
     items:
       type: object
       additionalProperties: false


### PR DESCRIPTION
`nodes`, `instance_type` and `autoscale` are no long used after https://github.com/app-sre/qontract-reconcile/pull/3825.

Also set `machinePools` to have at least 1 item.

[APPSRE-8258](https://issues.redhat.com/browse/APPSRE-8258)