### PR TITLE
[glitchtip] changes for error-tracking capability

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3487,6 +3487,7 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string, isRequired: true }
   - { name: instance, type: GlitchtipInstance_v1, isRequired: true }
+  - { name: owners, type: string, isList: true }
   - name: roles
     type: Role_v1
     isList: true
@@ -3501,6 +3502,8 @@ confs:
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string, isRequired: true }
+  - { name: ldapGroups, type: string, isList: true }
+  - { name: membersOrganizationRole, type: string }
   - name: roles
     type: Role_v1
     isList: true
@@ -3557,11 +3560,12 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: projectId, type: string }
   - { name: description, type: string, isRequired: true }
-  - { name: app, type: App_v1, isRequired: true }
+  - { name: app, type: App_v1 }
   - { name: platform, type: string, isRequired: true }
   - { name: teams, type: GlitchtipTeam_v1, isRequired: true, isList: true }
   - { name: organization, type: GlitchtipOrganization_v1, isRequired: true }
   - { name: alerts, type: GlitchtipProjectAlert_v1, isList: true }
+  - { name: acceptEvents, type: boolean }
   - name: namespaces
     type: Namespace_v1
     isList: true

--- a/schemas/dependencies/glitchtip-organization-1.yml
+++ b/schemas/dependencies/glitchtip-organization-1.yml
@@ -18,6 +18,10 @@ properties:
   instance:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/dependencies/glitchtip-instance-1.yml"
+  owners:
+    type: array
+    items:
+      type: string
 required:
 - "$schema"
 - labels

--- a/schemas/dependencies/glitchtip-project-1.yml
+++ b/schemas/dependencies/glitchtip-project-1.yml
@@ -91,11 +91,11 @@ properties:
       # referenced
       - "$ref": "/common-1.json#/definitions/crossref"
         "$schemaRef": "/dependencies/glitchtip-project-alert-1.yml"
-
+  acceptEvents:
+    type: boolean
 required:
 - name
 - description
-- app
 - platform
 - teams
 - organization

--- a/schemas/dependencies/glitchtip-team-1.yml
+++ b/schemas/dependencies/glitchtip-team-1.yml
@@ -15,6 +15,17 @@ properties:
     "$ref": "/common-1.json#/definitions/identifier"
   description:
     type: string
+  ldapGroups:
+    type: array
+    items:
+      type: string
+  membersOrganizationRole:
+    type: string
+    enum:
+    - owner
+    - admin
+    - manager
+    - member
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
Refactor the glitchtip schemas to allow usage for SRE error tracking capability.

Ticket: [[SRE Capability] Error tracking](https://issues.redhat.com/browse/SDE-3254)
Design-doc: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/sre-capability-error-tracking.md
