### PR TITLE
Fix jvmOptions field name case

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -448,7 +448,7 @@ confs:
 - name: JenkinsSSHConnector_v1
   fields:
   - { name: credentialsId, type: string, isRequired: true }
-  - { name: JVMOptions, type: string, isRequired: false }
+  - { name: jvmOptions, type: string, isRequired: false }
   - { name: launchTimeoutSeconds, type: int, isRequired: false }
   - { name: maxNumRetries, type: int, isRequired: false}
   - { name: port, type: int, isRequired: false}

--- a/schemas/dependencies/jenkins-instance-1.yml
+++ b/schemas/dependencies/jenkins-instance-1.yml
@@ -71,7 +71,7 @@ properties:
             credentialsId:
               type: string
               description: Jenkins credential name of ssh private key to be used for logging in to the remote host.
-            JVMOptions:
+            jvmOptions:
               type: string
               description: JAVA Options to set in the agents
             launchTimeoutSeconds:


### PR DESCRIPTION
Field name returned in jenkins api response is `jvmOptions` [doc]( https://javadoc.jenkins.io/plugin/ssh-slaves/hudson/plugins/sshslaves/SSHConnector.html), update schema to use the same case to avoid reconcile loop by sharing model.

Follow up for https://github.com/app-sre/qontract-schemas/pull/524