### PR TITLE
[glitchtip] labels are not required

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3557,6 +3557,7 @@ confs:
   fields:
   - { name: path, type: string, isRequired: true }
   - { name: schema, type: string, isRequired: true }
+  - { name: labels, type: json }
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: projectId, type: string }
   - { name: description, type: string, isRequired: true }

--- a/schemas/dependencies/glitchtip-organization-1.yml
+++ b/schemas/dependencies/glitchtip-organization-1.yml
@@ -24,7 +24,6 @@ properties:
       type: string
 required:
 - "$schema"
-- labels
 - name
 - description
 - instance

--- a/schemas/dependencies/glitchtip-team-1.yml
+++ b/schemas/dependencies/glitchtip-team-1.yml
@@ -28,6 +28,5 @@ properties:
     - member
 required:
 - "$schema"
-- labels
 - name
 - description


### PR DESCRIPTION
To ease the glitchtip configuration, mark the `labels` attributes as non-required.