### PR TITLE
Add cloudflare custom ssl certificates to cloudflare terraform resources

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1568,6 +1568,7 @@ confs:
   - { name: records, type: CloudflareDnsRecord_v1, isList: true }
   - { name: workers, type: CloudflareZoneWorker_v1, isList: true }
   - { name: certificates, type: CloudflareZoneCertificate_v1, isList: true }
+  - { name: custom_ssl_certificates, type: CloudflareCustomSSLCertificate_v1, isList: true }
 
 - name: CloudflareZoneArgo_v1
   fields:
@@ -1598,6 +1599,19 @@ confs:
   - { name: certificate_authority, type: string, isRequired: true }
   - { name: cloudflare_branding, type: boolean }
   - { name: wait_for_active_status, type: boolean }
+
+- name: CertificateSecret_v1
+  fields:
+  - { name: certificate, type: VaultSecret_v1, isRequired: true }
+  - { name: key, type: VaultSecret_v1, isRequired: true }
+
+- name: CloudflareCustomSSLCertificate_v1
+  fields:
+  - { name: identifier, type: string, isRequired: true }
+  - { name: type, type: string, isRequired: true }
+  - { name: bundle_method, type: string }
+  - { name: geo_restrictions, type: string }
+  - { name: certificate_secret, type: CertificateSecret_v1, isRequired: true }
 
 - name: NamespaceTerraformResourceCloudflareWorkerScript_v1
   interface: NamespaceTerraformResourceCloudflare_v1

--- a/schemas/cloudflare/terraform-resource-1.yml
+++ b/schemas/cloudflare/terraform-resource-1.yml
@@ -139,6 +139,48 @@ properties:
       - validation_method
       - validity_days
       - certificate_authority
+  # https://registry.terraform.io/providers/cloudflare/cloudflare/3.32.0/docs/resources/custom_ssl
+  custom_ssl_certificates:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        identifier:
+          type: string
+        type:
+          type: string
+          enum:
+            - legacy_custom
+            - sni_custom
+        bundle_method:
+          type: string
+          enum:
+            - ubiquitous
+            - optimal
+            - force
+        geo_restrictions:
+          type: string
+          enum:
+            - us
+            - eu
+            - highest_security
+        certificate_secret:
+          type: object
+          additionalProperties: false
+          properties:
+            certificate:
+              "$ref": "/common-1.json#/definitions/vaultSecret"
+            key:
+              "$ref": "/common-1.json#/definitions/vaultSecret"
+          required:
+            - certificate
+            - key
+    required:
+      - identifier
+      - type
+      - bundle_method
+      - certificate_secret
   destination_conf:
     type: string
     pattern: 's3:\/\/.+$'
@@ -303,6 +345,48 @@ oneOf:
         - validation_method
         - validity_days
         - certificate_authority
+    # https://registry.terraform.io/providers/cloudflare/cloudflare/3.32.0/docs/resources/custom_ssl
+    custom_ssl_certificates:
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          identifier:
+            type: string
+          type:
+            type: string
+            enum:
+              - legacy_custom
+              - sni_custom
+          bundle_method:
+            type: string
+            enum:
+              - ubiquitous
+              - optimal
+              - force
+          geo_restrictions:
+            type: string
+            enum:
+              - us
+              - eu
+              - highest_security
+          certificate_secret:
+            type: object
+            additionalProperties: false
+            properties:
+              certificate:
+                "$ref": "/common-1.json#/definitions/vaultSecret"
+              key:
+                "$ref": "/common-1.json#/definitions/vaultSecret"
+            required:
+              - certificate
+              - key
+      required:
+        - identifier
+        - type
+        - bundle_method
+        - certificate_secret
   required:
   - identifier
   - zone


### PR DESCRIPTION
This adds a new kind of resources to cloudflare terraform resources schema.

Related to:
https://issues.redhat.com/browse/APPSRE-8315

It it backwards compatible. It was tested by adding the following object to `externalResources.[provider["cloudflare"]][provider["zone"]]` in `data/services/quayio/namespaces/quays02ue1.yml` in `app-interface`.

```yaml
   custom_ssl_certificates:
    - identifier: quayio-stage-custom-ssl
      type: legacy_custom
      bundle_method: ubiquitous
      geo_restriction: "us"
      certificate_secret:
        certificate:
          path: some/path
          field: cert.csr
          version: 1
        key:
          path: some/other/path
          field: cert.key
          version: 1
```