### PR TITLE
allow ocm-organization sharding for integrations

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3191,6 +3191,7 @@ confs:
       static: StaticSharding_v1
       per-aws-account: AWSAccountSharding_v1
       per-openshift-cluster: OpenshiftClusterSharding_v1
+      per-ocm-organization: OCMOrganizationSharding_v1
       per-cloudflare-dns-zone: CloudflareDNSZoneSharding_v1
   fields:
   - { name: strategy, type: string, isRequired: true}
@@ -3232,6 +3233,19 @@ confs:
     - { name: resources, type: DeployResources_v1, isRequired: false }
     - { name: disabled, type: boolean, isRequired: false}
     - { name: subSharding, type: SubSharding_v1, isRequired: false, isInterface: true}
+
+- name: OCMOrganizationSharding_v1
+  interface: IntegrationSharding_v1
+  fields:
+    - { name: strategy, type: string, isRequired: true }
+    - { name: shardSpecOverrides, type: OCMOrganizationShardSpecOverride_v1, isList: true}
+
+- name: OCMOrganizationShardSpecOverride_v1
+  fields:
+    - { name: shard, type: OpenShiftClusterManager_v1, isRequired: true}
+    - { name: imageRef, type: string, isRequired: false }
+    - { name: resources, type: DeployResources_v1, isRequired: false }
+    - { name: disabled, type: boolean, isRequired: false}
 
 - name: AWSAccountSharding_v1
   interface: IntegrationSharding_v1

--- a/schemas/app-sre/integration-sharding-1.yml
+++ b/schemas/app-sre/integration-sharding-1.yml
@@ -16,6 +16,7 @@ properties:
       - per-aws-account
       - per-cloudflare-dns-zone
       - per-openshift-cluster
+      - per-ocm-organization
       - static
   # Static Sharding
   shards:   # Static sharding
@@ -36,6 +37,7 @@ properties:
                 type: string
                 enum:
                 - /openshift/cluster-1.yml
+                - /openshift/openshift-cluster-manager-1.yml
                 - /aws/account-1.yml
                 - /cloudflare/dns-zone-1.yml
         imageRef:


### PR DESCRIPTION
sharding and shard-spec overrides for ocm-organizations allows us to spread the load, isolate error domains and test integration upgrades in selected organizations

```yaml
$schema: /app-sre/integration-1.yml

name: an-ocm-related-organization

managed:
- namespace:
    $ref: /a-namespace.yml
  ...
  sharding:
    strategy: per-ocm-organization
    shardSpecOverrides:
    - shard:
        $ref: /org-1.yml
      imageRef: abcdefg
    - shard:
        $ref: /org-2.yml
      disabled: true
```

part of https://issues.redhat.com/browse/APPSRE-8414