### PR TITLE
[glitchtip-project] introduce Jira attributes

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -26,7 +26,6 @@ confs:
   - { name: endpointMonitoringBlackboxExporterModules, type: string, isList: true }
   - { name: ldap, type: LdapSettings_v1, isRequired: false}
   - { name: jiraWatcher, type: JiraWatcherSettings_v1, isRequired: false}
-  - { name: glitchtip, type: GlitchtipSettings_v1, isRequired: false}
   - { name: cloudflareEmailDomainAllowList, type: string, isList: true }
   - { name: cloudflareDNSZoneMaxRecords, type: int }
   - { name: state, type: AppInterfaceStateConfiguration_v1, isInterface: true }
@@ -74,14 +73,6 @@ confs:
   fields:
   - { name: readTimeout, type: int, isRequired: true }
   - { name: connectTimeout, type: int, isRequired: true }
-
-- name: GlitchtipSettings_v1
-  fields:
-  - { name: readTimeout, type: int }
-  - { name: maxRetries, type: int }
-  - { name: mailDomain, type: string }
-  - { name: glitchtipJiraBridgeAlertUrl, type: string }
-  - { name: glitchtipJiraBridgeToken, type: VaultSecret_v1 }
 
 - name: LdapGroupsSettings_v1
   fields:
@@ -3490,6 +3481,11 @@ confs:
   - { name: consoleUrl, type: string, isRequired: true }
   - { name: automationUserEmail, type: VaultSecret_v1, isRequired: true }
   - { name: automationToken, type: VaultSecret_v1, isRequired: true }
+  - { name: readTimeout, type: int }
+  - { name: maxRetries, type: int }
+  - { name: mailDomain, type: string }
+  - { name: glitchtipJiraBridgeAlertUrl, type: string }
+  - { name: glitchtipJiraBridgeToken, type: VaultSecret_v1 }
   - name: organizations
     type: GlitchtipOrganization_v1
     isList: true

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -80,6 +80,8 @@ confs:
   - { name: readTimeout, type: int }
   - { name: maxRetries, type: int }
   - { name: mailDomain, type: string }
+  - { name: glitchtipJiraBridgeAlertUrl, type: string }
+  - { name: glitchtipJiraBridgeToken, type: VaultSecret_v1 }
 
 - name: LdapGroupsSettings_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3568,6 +3568,11 @@ confs:
   - { name: url, type: string, isContextUnique: true }
   - { name: urlSecret, type: VaultSecret_v1, isContextUnique: true }
 
+- name: GlitchtipProjectJira_v1
+  fields:
+  - { name: project, type: string }
+  - { name: board, type: JiraBoard_v1 }
+
 - name: GlitchtipProjects_v1
   datafile: /dependencies/glitchtip-project-1.yml
   fields:
@@ -3583,6 +3588,7 @@ confs:
   - { name: organization, type: GlitchtipOrganization_v1, isRequired: true }
   - { name: alerts, type: GlitchtipProjectAlert_v1, isList: true }
   - { name: acceptEvents, type: boolean }
+  - { name: jira, type: GlitchtipProjectJira_v1 }
   - name: namespaces
     type: Namespace_v1
     isList: true

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -166,6 +166,10 @@ properties:
         type: integer
       mailDomain:
         type: string
+      glitchtipJiraBridgeAlertUrl:
+        type: string
+      glitchtipJiraBridgeToken:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
   cloudflareEmailDomainAllowList:
     type: array
     description: Email domain allow list restricts user with specific email domain to get access to Cloudflare systems

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -156,20 +156,6 @@ properties:
     required:
     - readTimeout
     - connectTimeout
-  glitchtip:
-    type: object
-    additionalProperties: false
-    properties:
-      readTimeout:
-        type: integer
-      maxRetries:
-        type: integer
-      mailDomain:
-        type: string
-      glitchtipJiraBridgeAlertUrl:
-        type: string
-      glitchtipJiraBridgeToken:
-        "$ref": "/common-1.json#/definitions/vaultSecret"
   cloudflareEmailDomainAllowList:
     type: array
     description: Email domain allow list restricts user with specific email domain to get access to Cloudflare systems

--- a/schemas/dependencies/glitchtip-instance-1.yml
+++ b/schemas/dependencies/glitchtip-instance-1.yml
@@ -22,6 +22,16 @@ properties:
     "$ref": "/common-1.json#/definitions/vaultSecret"
   automationToken:
     "$ref": "/common-1.json#/definitions/vaultSecret"
+  readTimeout:
+    type: integer
+  maxRetries:
+    type: integer
+  mailDomain:
+    type: string
+  glitchtipJiraBridgeAlertUrl:
+    type: string
+  glitchtipJiraBridgeToken:
+    "$ref": "/common-1.json#/definitions/vaultSecret"
 required:
 - "$schema"
 - labels

--- a/schemas/dependencies/glitchtip-project-1.yml
+++ b/schemas/dependencies/glitchtip-project-1.yml
@@ -93,6 +93,19 @@ properties:
         "$schemaRef": "/dependencies/glitchtip-project-alert-1.yml"
   acceptEvents:
     type: boolean
+  jira:
+    type: object
+    properties:
+      board:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "/dependencies/jira-board-1.yml"
+      project:
+        type: string
+    oneOf:
+    - required:
+      - board
+    - required:
+      - project
 required:
 - name
 - description

--- a/schemas/dependencies/jira-board-1.yml
+++ b/schemas/dependencies/jira-board-1.yml
@@ -12,7 +12,7 @@ properties:
   labels:
     "$ref": "/common-1.json#/definitions/labels"
   name:
-    type: string
+    "$ref": "/common-1.json#/definitions/identifier"
   description:
     type: string
   server:


### PR DESCRIPTION
Add two new jira related attributes to the `glitchtip-project` schema to support Jira ticket creation for Glitchtip alerts.

Set the `jenkins.name` type to an identifier because it's the Jira project key that doesn't allow spaces.

Ticket: https://issues.redhat.com/browse/APPSRE-8238
Design doc: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/glitchtip-jira.md