### PR TITLE
Add region and delete_empty_log_group to cloudwatch cleanup option

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1280,7 +1280,9 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: regex, type: string, isRequired: true }
-  - { name: retention_in_days, type: int }
+  - { name: retention_in_days, type: int, isRequired: true }
+  - { name: region, type: string }
+  - { name: delete_empty_log_group, type: boolean }
 
 - name: AWSUserPolicy_v1
   datafile: /aws/policy-1.yml

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -69,6 +69,7 @@ properties:
           - terraform-vpc-peerings
           - terraform-tgw-attachments
           - aws-ami-cleanup
+          - aws-cloudwatch-log-retention
   deleteKeys:
     type: array
     items:

--- a/schemas/aws/cleanup-option-1.yml
+++ b/schemas/aws/cleanup-option-1.yml
@@ -25,6 +25,12 @@ properties:
   retention_in_days:
     type: integer
     description: Cloudwatch log retention
+  region:
+    type: string
+    description: AWS region.
+  delete_empty_log_group:
+    type: boolean
+    description: Enable deletion when log group is empty.
 oneOf:
 - properties:
     provider:
@@ -65,6 +71,10 @@ oneOf:
       - 150
       - 180
       - 365
+    region:
+      type: string
+    delete_empty_log_group:
+      type: boolean
   required:
   - provider
   - regex


### PR DESCRIPTION
`region` is to support cleanup in different region other than default one.

`delete_empty_log_group` is used to enable deletion of empty log groups.

Also allow `aws-cloudwatch-log-retention` to be disabled per account.

[APPSRE-8425](https://issues.redhat.com/browse/APPSRE-8425)