### PR TITLE
disable integrations for an OCM organizations

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1040,6 +1040,7 @@ confs:
   - { name: upgradePolicyClusters, type: OpenShiftClusterManagerUpgradePolicyCluster_v1, isList: true }
   - { name: inheritVersionData, type: OpenShiftClusterManager_v1, isList: true }
   - { name: publishVersionData, type: OpenShiftClusterManager_v1, isList: true }
+  - { name: disable, type: DisableClusterAutomations_v1 }
   - name: clusters
     type: Cluster_v1
     isList: true

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -197,6 +197,22 @@ properties:
     items:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": /openshift/openshift-cluster-manager-1.yml
+  disable:
+    type: object
+    additionalProperties: false
+    properties:
+      integrations:
+        type: array
+        items:
+          type: string
+          enum:
+          - ocm-standalone-user-management
+          - advanced-upgrade-scheduler
+          - ocm-upgrade-scheduler-org
+          - ocm-addons-upgrade-scheduler-org
+          - ocm-addons-upgrade-tests-trigger
+          - ocm-update-recommended-version
+          - ocm-upgrade-scheduler-org-updater
 dependencies:
   upgradePolicyDefaults:
   - upgradePolicyClusters


### PR DESCRIPTION
disabling integrations per OCM organization (similar to AWS accounts and clusters)

part of https://issues.redhat.com/browse/APPSRE-8436