### PR TITLE
Add `exhaustion` label to prometheus rule schema

### DIFF
--- a/schemas/openshift/prometheus-rule-1.yml
+++ b/schemas/openshift/prometheus-rule-1.yml
@@ -138,6 +138,8 @@ properties:
                           type: string
                         group:
                           type: string
+                        exhaustion:
+                          type: string
                         exported_namespace:
                           type: string
                         exported_service:


### PR DESCRIPTION
This is a new label being added to the SLO rules created by Pyrra, which indicates the exhaustion time of the SLO.

Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>