### PR TITLE
/aws/parameter-group-1.yml schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1777,8 +1777,8 @@ confs:
   - { name: identifier, type: string, isRequired: true, isContextUnique: true }
   - { name: defaults, type: string, isRequired: true, isResource: true }
   - { name: availability_zone, type: string }
-  - { name: parameter_group, type: string }
-  - { name: old_parameter_group, type: string }
+  - { name: parameter_group, type: string, isResource: true }
+  - { name: old_parameter_group, type: string, isResource: true }
   - { name: overrides, type: json }
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
@@ -1863,7 +1863,7 @@ confs:
   - { name: provider, type: string, isRequired: true, isContextUnique: true }
   - { name: identifier, type: string, isRequired: true, isContextUnique: true }
   - { name: defaults, type: string, isRequired: true, isResource: true }
-  - { name: parameter_group, type: string }
+  - { name: parameter_group, type: string, isResource: true }
   - { name: region, type: string, isContextUnique: true }
   - { name: overrides, type: json }
   - { name: output_resource_name, type: string }

--- a/schemas/aws/parameter-group-1.yml
+++ b/schemas/aws/parameter-group-1.yml
@@ -1,0 +1,54 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /aws/parameter-group-1.yml
+  name:
+    type: string
+  identifier:
+    type: string
+  family:
+    type: string
+    enum:
+    - mysql5.7
+    - mysql8.0
+    - postgres9.6
+    - postgres10
+    - postgres11
+    - postgres12
+    - postgres13
+    - postgres14
+    - postgres15
+    - redis5.0
+    - redis6.x
+  description:
+    type: string
+  parameters:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        value:
+          type: [string, integer, number, boolean]
+        apply_method:
+          type: string
+          enum:
+          - immediate
+          - pending-reboot
+      required:
+      - name
+      - value
+required:
+- "$schema"
+- family
+- description
+- parameters

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -44,9 +44,9 @@ properties:
   defaults:
     type: string
   parameter_group:
-    type: string
+    "$ref": "/common-1.json#/definitions/resourceref"
   old_parameter_group:
-    type: string
+    "$ref": "/common-1.json#/definitions/resourceref"
   region:
     "$ref": "/aws/regions-1.yml#/properties/region"
   overrides:
@@ -460,9 +460,9 @@ oneOf:
     defaults:
       "$ref": "/common-1.json#/definitions/resourceref"
     parameter_group:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     old_parameter_group:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     overrides:
       type: object
       properties:
@@ -613,7 +613,7 @@ oneOf:
     defaults:
       "$ref": "/common-1.json#/definitions/resourceref"
     parameter_group:
-      type: string
+      "$ref": "/common-1.json#/definitions/resourceref"
     region:
       "$ref": "/aws/regions-1.yml#/properties/region"
     overrides:


### PR DESCRIPTION
To enable self-service on parameter groups, the parameter groups must have a schema.

This new `/aws/parameter-group-1.yml` schema supports MySQL, Postgres, and Redis (Elasticache).

Ticket: https://issues.redhat.com/browse/APPSRE-8310