### PR TITLE
APPSRE-8436 enable disabling integrations for ocm organizations

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1024,6 +1024,7 @@ confs:
   - { name: upgradePolicyClusters, type: OpenShiftClusterManagerUpgradePolicyCluster_v1, isList: true }
   - { name: inheritVersionData, type: OpenShiftClusterManager_v1, isList: true }
   - { name: publishVersionData, type: OpenShiftClusterManager_v1, isList: true }
+  - { name: disable, type: DisableClusterAutomations_v1 }
   - name: clusters
     type: Cluster_v1
     isList: true

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -197,6 +197,32 @@ properties:
     items:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": /openshift/openshift-cluster-manager-1.yml
+  disable:
+    type: object
+    additionalProperties: false
+    properties:
+      integrations:
+        type: array
+        description: integrations to disable for the ocm organization
+        items:
+          type: string
+          enum:
+          - ocm-additional-routers
+          - ocm-addons-upgrade-scheduler-org
+          - ocm-addons-upgrade-tests-trigger
+          - ocm-addons
+          - ocm-aws-infrastructure-access
+          - ocm-clusters
+          - ocm-external-configuration-labels
+          - ocm-machine-pools
+          - ocm-oidc-idp
+          - ocm-upgrade-scheduler-org
+          - ocm-subscription-labels
+          - ocm-labels
+          - ocm-standalone-user-management
+          - ocm-update-recommended-version
+          - ocm-upgrade-scheduler-org-updater
+          - ocm-groups
 dependencies:
   upgradePolicyDefaults:
   - upgradePolicyClusters


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-8436

this PR adds the `disable` option to ocm orgs, same as for aws accounts and clusters.