### PR TITLE
add targetNamespace to slo-document

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3770,6 +3770,7 @@ confs:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: namespace, type: Namespace_v1, isRequired: true}
+  - { name: targetNamespace, type: Namespace_v1 }
   - { name: prometheusAccess, type: SLOExternalPrometheusAccess_v1 }
 
 - name: SLOExternalPrometheusAccess_v1

--- a/schemas/app-sre/slo-document-1.yml
+++ b/schemas/app-sre/slo-document-1.yml
@@ -26,6 +26,9 @@ properties:
         namespace:
           "$ref": "/common-1.json#/definitions/crossref"
           "$schemaRef": "/openshift/namespace-1.yml"
+        targetNamespace:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/openshift/namespace-1.yml"
         prometheusAccess:
           type: object
           additionalProperties: false


### PR DESCRIPTION
Currently the slo-document `.namespaces` contains a list of `namespace` objects linked to the app, where the SLOs in the slo document is applicable.

In addition to the `namespace` property, this MR introduces a new  `targetNamespace` property which will inform the SLO-Document alertmanager-to-status-board flow where to create the dynamic rules:
https://gitlab.cee.redhat.com/jmelisba/app-interface/-/blob/259c9c72635c3c7e4dbaf1905d327e756970e66c/resources/observability/prometheusrules/status-board-slo-generated-alerts.prometheusrules.yaml.j2

 