### PR TITLE
declare membership sources in a role

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3107,6 +3107,7 @@ confs:
   - { name: self_service, type: SelfServiceConfig_v1, isList: true }
   - { name: cloudflare_access, type: CloudflareAccountRole_v1, isList: true }
   - { name: ldapGroup, type: string }
+  - { name: memberSource, type: RoleMembershipSource_V1 }
   - name: users
     type: User_v1
     isList: true
@@ -3121,6 +3122,38 @@ confs:
     synthetic:
       schema: /access/bot-1.yml
       subAttr: roles
+
+- name: RoleMembershipSource_V1
+  fields:
+  - { name: provider, type: MembershipProvider_V1, isRequired: true }
+  - { name: group, type: string, isRequired: true }
+
+- name: MembershipProvider_V1
+  datafile: /access/membership-provider-1.yml
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isUnique: true }
+  - { name: description, type: string, isRequired: true }
+  - { name: hasAuditTrail, type: boolean, isRequired: true }
+  - { name: source, type: MembershipProviderSource_V1, isInterface: true, isRequired: true }
+
+- name: MembershipProviderSource_V1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      app-interface: AppInterfaceMembershipProviderSource_V1
+  fields:
+  - { name: provider, type: string, isRequired: true}
+
+- name: AppInterfaceMembershipProviderSource_V1
+  interface: MembershipProviderSource_V1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: url, type: string, isRequired: true }
+  - { name: credentials, type: VaultSecret_v1, isRequired: true }
 
 - name: SelfServiceConfig_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3107,7 +3107,7 @@ confs:
   - { name: self_service, type: SelfServiceConfig_v1, isList: true }
   - { name: cloudflare_access, type: CloudflareAccountRole_v1, isList: true }
   - { name: ldapGroup, type: string }
-  - { name: memberSource, type: RoleMembershipSource_V1 }
+  - { name: memberSources, type: RoleMembershipSource_V1, isList: true }
   - name: users
     type: User_v1
     isList: true
@@ -3153,7 +3153,8 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: url, type: string, isRequired: true }
-  - { name: credentials, type: VaultSecret_v1, isRequired: true }
+  - { name: username, type: VaultSecret_v1, isRequired: true }
+  - { name: password, type: VaultSecret_v1, isRequired: true }
 
 - name: SelfServiceConfig_v1
   fields:

--- a/schemas/access/membership-provider-1.yml
+++ b/schemas/access/membership-provider-1.yml
@@ -25,7 +25,9 @@ properties:
       url:
         type: string
         format: uri
-      credentials:
+      username:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+      password:
         "$ref": "/common-1.json#/definitions/vaultSecret"
     oneOf:
     - additionalProperties: false
@@ -37,12 +39,15 @@ properties:
         url:
           type: string
           format: uri
-        credentials:
+        username:
+          "$ref": "/common-1.json#/definitions/vaultSecret"
+        password:
           "$ref": "/common-1.json#/definitions/vaultSecret"
       required:
       - provider
       - url
-      - credentials
+      - username
+      - password
 required:
 - name
 - description

--- a/schemas/access/membership-provider-1.yml
+++ b/schemas/access/membership-provider-1.yml
@@ -1,0 +1,50 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /access/membership-provider-1.yml
+  name:
+    type: string
+  description:
+    type: string
+  hasAuditTrail:
+    type: boolean
+  source:
+    type: object
+    properties:
+      provider:
+        type: string
+        enum:
+        - app-interface
+      url:
+        type: string
+        format: uri
+      credentials:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+    oneOf:
+    - additionalProperties: false
+      properties:
+        provider:
+          type: string
+          enum:
+          - app-interface
+        url:
+          type: string
+          format: uri
+        credentials:
+          "$ref": "/common-1.json#/definitions/vaultSecret"
+      required:
+      - provider
+      - url
+      - credentials
+required:
+- name
+- description
+- hasAuditTrail
+- source

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -172,14 +172,16 @@ properties:
                   - /app-interface/query-validation-1.yml
   ldapGroup:
     "$ref": "/common-1.json#/definitions/ldapGroupName"
-  memberSource:
-    type: object
-    properties:
-      provider:
-        "$ref": "/common-1.json#/definitions/crossref"
-        "$schemaRef": "/access/membership-provider-1.yml"
-      group:
-        type: string
+  memberSources:
+    type: array
+    items:
+      type: object
+      properties:
+        provider:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/access/membership-provider-1.yml"
+        group:
+          type: string
 
 required:
 - $schema

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -172,6 +172,15 @@ properties:
                   - /app-interface/query-validation-1.yml
   ldapGroup:
     "$ref": "/common-1.json#/definitions/ldapGroupName"
+  memberSource:
+    type: object
+    properties:
+      provider:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "/access/membership-provider-1.yml"
+      group:
+        type: string
+
 required:
 - $schema
 - labels


### PR DESCRIPTION
We should be able to run integrations that rely on roles, users and role membership in the sre-capabilities repo with as little change as possible, while not being forced to manage a whole set of users and role memberships.

The central concept for grouping and permissions will still be `/access/role-1.yml` but membership will be pluggable. A configuration section memberSource can be used to bring in user and role membership information from different sources, defined via a schema `/access/membership-provider-1.yml`.

A membership provider can be any system that provides groups and users (provider pattern). User information needs to include some sort of username that can be mapped to org_username. This schema change introduces the memebership provider mechanism and offers app-interface as a first source for members.

```yaml
$schema: /access/membership-provider-1.yml

name: <provider-name>
source:
  provider: app-interface
  url: <url to qontract server of an a-i instance>
  username:
    $ref: <vault secret>
  password:
    $ref: <vault secret>
```

Then this provider can be used as follows

```yaml
---
$schema: /access/role-1.yml
...
memberSources:
- provider:
    $ref: <the provider>
  group: <a role name from the other app-interface>
```

APPSRE-8450