### PR TITLE
rename from targetNamespace to SLONamespace

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3804,7 +3804,7 @@ confs:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: namespace, type: Namespace_v1, isRequired: true}
-  - { name: targetNamespace, type: Namespace_v1 }
+  - { name: SLONamespace, type: Namespace_v1 }
   - { name: prometheusAccess, type: SLOExternalPrometheusAccess_v1 }
 
 - name: SLOExternalPrometheusAccess_v1

--- a/schemas/app-sre/slo-document-1.yml
+++ b/schemas/app-sre/slo-document-1.yml
@@ -28,13 +28,15 @@ properties:
           "$schemaRef": "/openshift/namespace-1.yml"
         SLONamespace:
           description: |
-            This field is used to determine in which namespace to generate the PrometheusRules
-            that contain the dynamic alerts generated for the SLO, that are being used in the
-            slo-to-status-board flow:
+            This field is used to determine in which namespace PrometheusRule
+            object that contain the alerts generated from the expressions of
+            this SLO document is going to be created. Those alerts are being
+            used in the slo-to-status-board flow:
             https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/status-board/statusboard-alertmanager-receiver.md
 
-            If omitted, the rules will be generated in the Observability namespace of the cluster
-            to which `namespace` belongs to.
+            If omitted, the rules will be generated in the namespace
+            observabilityNamespace of the cluster to which the `namespace` of
+            this SLO document belongs to.
           "$ref": "/common-1.json#/definitions/crossref"
           "$schemaRef": "/openshift/namespace-1.yml"
         prometheusAccess:

--- a/schemas/app-sre/slo-document-1.yml
+++ b/schemas/app-sre/slo-document-1.yml
@@ -26,7 +26,15 @@ properties:
         namespace:
           "$ref": "/common-1.json#/definitions/crossref"
           "$schemaRef": "/openshift/namespace-1.yml"
-        targetNamespace:
+        SLONamespace:
+          description: |
+            This field is used to determine in which namespace to generate the PrometheusRules
+            that contain the dynamic alerts generated for the SLO, that are being used in the
+            slo-to-status-board flow:
+            https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/status-board/statusboard-alertmanager-receiver.md
+
+            If omitted, the rules will be generated in the Observability namespace of the cluster
+            to which `namespace` belongs to.
           "$ref": "/common-1.json#/definitions/crossref"
           "$schemaRef": "/openshift/namespace-1.yml"
         prometheusAccess:


### PR DESCRIPTION
`targetNamespace` is confusing, it has been renamed to `SLONamespace` and it now includes a description explaining its purpose.