### PR TITLE
allowlist for OCM cluster external config labels

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1012,6 +1012,7 @@ confs:
   - { name: accessTokenClientId, type: string }
   - { name: accessTokenUrl, type: string }
   - { name: accessTokenClientSecret, type: VaultSecret_v1 }
+  - { name: allowedClusterExternalConfigLabels, type: string, isList: true }
   - { name: addonManagedUpgrades, type: boolean }
   - { name: addonUpgradeTests, type: AddonUpgradeTest_v1, isList: true }
   - { name: recommendedVersions, type: OpenShiftClusterManagerRecommendedVersions_v1, isList: true }

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -30,6 +30,10 @@ properties:
     format: uri
   accessTokenClientSecret:
     "$ref": "/common-1.json#/definitions/vaultSecret"
+  allowedClusterExternalConfigLabels:
+    type: array
+    items:
+      type: string
   addonManagedUpgrades:
     type: boolean
   addonUpgradeTests:


### PR DESCRIPTION
Right now a-i is the source of truth for external configuration labels on clusters. We use them to mark hive shards and backplane shards. But it seems that other parties also put labels on clusters, e.g. cluster service adds "legacy-ingress-support" when a cluster gets upgraded to 4.14. our current integrations are deleting such labels because they are not listed in cluster files.

This PR introduces an allow list for labels in an OCM organizations. clusters of that organization can only manage labels from that list and will ignore all others.

https://issues.redhat.com/browse/APPSRE-8521