### PR TITLE
[glitchtip-project-alerts] support custom jira labels

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3661,6 +3661,7 @@ confs:
   fields:
   - { name: project, type: string }
   - { name: board, type: JiraBoard_v1 }
+  - { name: labels, type: string, isList: true }
 
 - name: GlitchtipProjects_v1
   datafile: /dependencies/glitchtip-project-1.yml

--- a/schemas/dependencies/glitchtip-project-1.yml
+++ b/schemas/dependencies/glitchtip-project-1.yml
@@ -101,6 +101,10 @@ properties:
         "$schemaRef": "/dependencies/jira-board-1.yml"
       project:
         type: string
+      labels:
+        type: array
+        items:
+          type: string
     oneOf:
     - required:
       - board


### PR DESCRIPTION
Add a `jira.labels` field to `glitchtip-project-1` to support custom labels on create Jira alert tickets.

Ticket: [APPSRE-8523](https://issues.redhat.com/browse/APPSRE-8523)