### PR TITLE
FIPS Validation for Terraform Repos

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1610,6 +1610,7 @@ confs:
   - { name: ref, type: string, isRequired: true }
   - { name: projectPath, type: string, isRequired: true }
   - { name: delete, type: boolean }
+  - { name: requireFips, type: boolean }
 
 - name: NamespaceTerraformProviderResourceGCPProject_v1
   interface: NamespaceExternalResource_v1

--- a/schemas/aws/terraform-repo-1.yml
+++ b/schemas/aws/terraform-repo-1.yml
@@ -29,7 +29,7 @@ properties:
     description: set to true to delete the repo
     type: boolean
   requireFips:
-    description: whether this repo should be validated to ensure it is using FIPs endpoints for AWS
+    description: whether this repo should be validated to ensure it is using FIPS endpoints for AWS
     type: boolean
 required:
 - "$schema"

--- a/schemas/aws/terraform-repo-1.yml
+++ b/schemas/aws/terraform-repo-1.yml
@@ -28,6 +28,9 @@ properties:
   delete:
     description: set to true to delete the repo
     type: boolean
+  requireFips:
+    description: whether this repo should be validated to ensure it is using FIPs endpoints for AWS
+    type: boolean
 required:
 - "$schema"
 - account


### PR DESCRIPTION
[APPSRE-8520](https://issues.redhat.com/browse/APPSRE-8520)

Allows a user to specify that a Terraform Repo needs additional validation to use [AWS FIPS endpoints](https://aws.amazon.com/compliance/fips/). This will come with a QR change to handle the updated schema as well as a validation step that occurs in the Terraform Repo executor.

Corresponds with the following PRs:
- QR: https://github.com/app-sre/qontract-reconcile/pull/3938
- Executor: https://github.com/app-sre/terraform-repo-executor/pull/16