### PR TITLE
Update machine pool min_replicas minimum to 1

### DIFF
--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -282,7 +282,7 @@ properties:
           properties:
             min_replicas:
               type: integer
-              minimum: 2
+              minimum: 1
             max_replicas:
               type: integer
           required:


### PR DESCRIPTION
ROSA HCP `min_replicas` allow 1 for multiple availability zone clusters, each availability zone has it's own pool, so 3 zone will have 3 pools, each pool can have 1 node.
[doc](https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-instance-types_rosa-service-definition)