### PR TITLE
Adding region and environment information for Dynatrace environments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 data.json
 .tox
 test/__pycache__/
+.DS_Store
+schemas/.DS_Store

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -591,6 +591,9 @@ confs:
   - { name: description, type: string, isRequired: true }
   - { name: environmentUrl, type: string, isRequired: true, isUnique: true }
   - { name: bootstrapToken, type: VaultSecret_v1, isRequired: true }
+  - { name: environment, type: string}
+  - { name: dynatraceRegion, type: string}
+  - { name: awsRegion, type: string}
 
 - name: GithubOrg_v1
   fields:

--- a/schemas/dependencies/dynatrace-environment-1.yml
+++ b/schemas/dependencies/dynatrace-environment-1.yml
@@ -14,11 +14,12 @@ properties:
   description:
     type: string
   environmentUrl:
-    description: the URL to a specific Dynatrace entity called environment, which is also known as tenant.
+    description: The URL to a specific Dynatrace entity called environment, which is also known as tenant.
     type: string
   bootstrapToken:
     "$ref": "/common-1.json#/definitions/vaultSecret"
   environment:
+    description: Which of integration, stage or production are the data coming from.
     type: string
     enum:
     - integration
@@ -31,10 +32,10 @@ properties:
     - eu-west-ireland
     - ap-southeast-singapore
   awsRegion:
-    description: a list of HCP AWS regions
+    description: A list of HCP AWS regions.
     type: array
     items:
-      type: string
+      "$ref": "/aws/regions-1.yml#/properties/region"
 required:
 - "$schema"
 - name

--- a/schemas/dependencies/dynatrace-environment-1.yml
+++ b/schemas/dependencies/dynatrace-environment-1.yml
@@ -14,9 +14,27 @@ properties:
   description:
     type: string
   environmentUrl:
+    description: the URL to a specific Dynatrace entity called environment, which is also known as tenant.
     type: string
   bootstrapToken:
     "$ref": "/common-1.json#/definitions/vaultSecret"
+  environment:
+    type: string
+    enum:
+    - integration
+    - stage
+    - production
+  dynatraceRegion:
+    type: string
+    enum:
+    - us-east-virginia
+    - eu-west-ireland
+    - ap-southeast-singapore
+  awsRegion:
+    description: a list of HCP AWS regions
+    type: array
+    items:
+      type: string
 required:
 - "$schema"
 - name


### PR DESCRIPTION
### Why
OSDFM need to be able to generate configmap about the mapping of DT regions and HCP AWS regions.

### Validation:
I have run qontract server with this branch locally.