### PR TITLE
cluster OIDC provider endpoint URL

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -769,6 +769,7 @@ confs:
   - { name: hypershift, type: boolean, isRequired: false}
   - { name: subnet_ids, type: string, isList: True}
   - { name: availability_zones, type: string, isList: True}
+  - { name: oidc_endpoint_url, type: string }
 
 
 - name: ClusterSpecAutoScale_v1

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -192,6 +192,9 @@ properties:
           Hosted Clusters only: list of availability_zones to use with the cluster creation.
       hypershift:
         type: boolean
+      oidc_endpoint_url:
+        type: string
+        format: uri
     required:
     - product
     - provider


### PR DESCRIPTION
adds a field to hold the OIDC provider endpoint URL of a cluster. this field will be updated automatically by an integration, similar to `id` and `external_id` and is useful when defining IAM roles and trust policies for STS

part of https://issues.redhat.com/browse/APPSRE-8656