### PR TITLE
make cluster.kibanaUrl optional

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -924,7 +924,7 @@ confs:
   - { name: observabilityNamespace, type: Namespace_v1 }
   - { name: grafanaUrl, type: string }
   - { name: consoleUrl, type: string, isRequired: true }
-  - { name: kibanaUrl, type: string, isRequired: true }
+  - { name: kibanaUrl, type: string }
   - { name: prometheusUrl, type: string, isRequired: true }
   - { name: alertmanagerUrl, type: string, isRequired: true }
   - { name: serverUrl, type: string, isRequired: true }

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -616,7 +616,6 @@ required:
 - labels
 - name
 - consoleUrl
-- kibanaUrl
 - prometheusUrl
 - serverUrl
 - elbFQDN


### PR DESCRIPTION
many moons ago, we used to have a per-cluster EFK stack.