### PR TITLE
Enable release as a name of the git branch

### DIFF
--- a/schemas/app-sre/saas-file-target-1.yml
+++ b/schemas/app-sre/saas-file-target-1.yml
@@ -37,7 +37,7 @@ properties:
       - include
   ref:
     type: string
-    pattern: '^([0-9a-f]{40}|master|main|internal|stable)$'
+    pattern: '^([0-9a-f]{40}|master|main|internal|release|stable)$'
   promotion:
     type: object
     additionalProperties: false


### PR DESCRIPTION
We are moving the branch for staging and prod to a branch called "release" where to move with cherry picks the prs from main when are approved by the QE. But the MR fail due to the name of the git branch