### PR TITLE
[jira-board] disable.integrations support

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -539,12 +539,17 @@ confs:
   - { name: issueResolveState, type: string }
   - { name: issueReopenState, type: string }
   - { name: issueSecurityId, type: string }
+  - { name: disable, type: DisableJiraBoardAutomations_v1 }
   - name: escalationPolicies
     type: AppEscalationPolicy_v1
     isList: true
     synthetic:
       schema: /app-sre/escalation-policy-1.yml
       subAttr: channels.jiraBoard
+
+- name: DisableJiraBoardAutomations_v1
+  fields:
+  - { name: integrations, type: string, isList: true }
 
 - name: SendGridAccount_v1
   fields:

--- a/schemas/dependencies/jira-board-1.yml
+++ b/schemas/dependencies/jira-board-1.yml
@@ -39,6 +39,16 @@ properties:
     type: string
   issueSecurityId:
     type: string
+  disable:
+    type: object
+    additionalProperties: false
+    properties:
+      integrations:
+        type: array
+        items:
+          type: string
+          enum:
+          - jira-permissions-validator
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
Add `disable.integrations` to jira-board to support disabling integrations in case of board errors.

Ticket: [APPSRE-8620](https://issues.redhat.com/browse/APPSRE-8620)