### PR TITLE
APPSRE-8667: disallow end slash in git repo URLs

### DIFF
--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -287,6 +287,8 @@ properties:
           description: Include MRs from this repo in the AppSRE Review Queue
         url:
           type: string
+          format: uri
+          pattern: "^https:\/\/.+(?<!\/)$"
         gitlabSync:
           type: object
           properties:


### PR DESCRIPTION
With codeComponents URL ending with `/` our backup service throw errors like in https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/89905

```
6:31:16 remote: Not Found
06:31:16 fatal: repository 'https://github.com/redhat-appstudio/service-provider-integration-operator/.git/' not found
```

So it's better to catch such errors in PR-check
