### PR TITLE
enable parameter promotion

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2723,6 +2723,7 @@ confs:
   - { name: auto, type: boolean }
   - { name: publish, type: string, isList: true }
   - { name: subscribe, type: string, isList: true }
+  - { name: parameters, type: string, isList: true }
   - { name: promotion_data, type: PromotionData_v1, isList: true }
 
 - name: SaasSecretParameters_v1

--- a/schemas/app-sre/saas-file-target-1.yml
+++ b/schemas/app-sre/saas-file-target-1.yml
@@ -54,6 +54,11 @@ properties:
         items:
           type: string
         minItems: 1
+      parameters:
+        type: array
+        description: parameters to be promoted
+        items:
+          type: string
       promotion_data:
         type: array
         items:


### PR DESCRIPTION
this PR adds a `parameters` section to the saas file target promotion section to indicate that changes to values of these parameters should be rolled out according to the progressive rollout definitions (exact same behavior as for `ref`)