### PR TITLE
make bots self-servicable

### DIFF
--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -170,6 +170,7 @@ properties:
                   - /cloudflare/dns-zone-1.yml
                   - /app-sre/escalation-policy-1.yml
                   - /app-interface/query-validation-1.yml
+                  - /access/bot-1.yml
   ldapGroup:
     "$ref": "/common-1.json#/definitions/ldapGroupName"
   memberSources:


### PR DESCRIPTION
Would like to enable our `bot-owner` changetype, but its missing from the schema.