### PR TITLE
APPSRE-8660 adjust schema for more self-service

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -603,7 +603,8 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string, isRequired: true }
   - { name: environmentUrl, type: string, isRequired: true, isUnique: true }
-  - { name: bootstrapToken, type: VaultSecret_v1, isRequired: true }
+  - { name: bootstrapAPIToken, type: VaultSecret_v1 }
+  - { name: automationAPIToken, type: VaultSecret_v1 }
   - { name: environment, type: string}
   - { name: dynatraceRegion, type: string}
   - { name: awsRegion, type: string, isList: true}

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -603,8 +603,7 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string, isRequired: true }
   - { name: environmentUrl, type: string, isRequired: true, isUnique: true }
-  - { name: bootstrapAPIToken, type: VaultSecret_v1 }
-  - { name: automationAPIToken, type: VaultSecret_v1 }
+  - { name: bootstrapToken, type: VaultSecret_v1, isRequired: true }
   - { name: environment, type: string}
   - { name: dynatraceRegion, type: string}
   - { name: awsRegion, type: string, isList: true}

--- a/schemas/dependencies/dynatrace-environment-1.yml
+++ b/schemas/dependencies/dynatrace-environment-1.yml
@@ -16,11 +16,8 @@ properties:
   environmentUrl:
     description: The URL to a specific Dynatrace entity called environment, which is also known as tenant.
     type: string
-  bootstrapAPIToken:
-    description: Dynatrace API token used to generate new API tokens for Hypershift
-    "$ref": "/common-1.json#/definitions/vaultSecret"
-  automationAPIToken:
-    description: Dynatrace API token used for automations in app-interface managed clusters
+  bootstrapToken:
+    description: Dynatrace API token dedicated for generating new API tokens for Hypershift.
     "$ref": "/common-1.json#/definitions/vaultSecret"
   environment:
     description: Which of integration, stage or production are the data coming from.
@@ -42,4 +39,5 @@ required:
 - name
 - description
 - environmentUrl
+- bootstrapToken
 

--- a/schemas/dependencies/dynatrace-environment-1.yml
+++ b/schemas/dependencies/dynatrace-environment-1.yml
@@ -16,7 +16,11 @@ properties:
   environmentUrl:
     description: The URL to a specific Dynatrace entity called environment, which is also known as tenant.
     type: string
-  bootstrapToken:
+  bootstrapAPIToken:
+    description: Dynatrace API token used to generate new API tokens for Hypershift
+    "$ref": "/common-1.json#/definitions/vaultSecret"
+  automationAPIToken:
+    description: Dynatrace API token used for automations in app-interface managed clusters
     "$ref": "/common-1.json#/definitions/vaultSecret"
   environment:
     description: Which of integration, stage or production are the data coming from.
@@ -28,11 +32,6 @@ properties:
   dynatraceRegion:
     description: https://gitlab.cee.redhat.com/service/app-interface/-/blame/9f303046645ebbb48e87ccf5d89778521a2d8345/data/services/osd-operators/cicd/saas/saas-dynatrace-operator.yaml#L356-433
     type: string
-    enum:
-    - us-east-virginia
-    - eu-west-ireland
-    - ap-southeast-sydney
-    - ca-central-canada
   awsRegion:
     description: A list of HCP AWS regions.
     type: array
@@ -43,4 +42,4 @@ required:
 - name
 - description
 - environmentUrl
-- bootstrapToken
+


### PR DESCRIPTION
We need to accommodate for 2 token:
- the bootstrapAPIToken is used to generate new API tokens for HS
- the automationAPIToken is used by app-interface automations to interact with dynatrace API

Note, that none of the tokens is required. I.e., a dynatrace environment is not necessarily tied to a HS region and/or app-interface automation.

Further, we remove the region enum, as onboarding a new region requires a change to the schema which is not self-servicable.