### PR TITLE
[tf-repo schemas] Versioning and Vault Secrets

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1848,6 +1848,13 @@ confs:
   - { name: projectPath, type: string, isRequired: true }
   - { name: delete, type: boolean }
   - { name: requireFips, type: boolean }
+  - { name: tfVersion, type: string, isRequired: true }
+  - { name: variables, type: TerraformRepoVariables_v1 }
+
+- name: TerraformRepoVariables_v1
+  fields:
+  - { name: inputs, type: VaultSecret_v1, isRequired: true }
+  - { name: outputs, type: VaultSecret_v1, isRequired: true }
 
 - name: NamespaceTerraformProviderResourceGCPProject_v1
   interface: NamespaceExternalResource_v1

--- a/schemas/aws/terraform-repo-1.yml
+++ b/schemas/aws/terraform-repo-1.yml
@@ -31,6 +31,24 @@ properties:
   requireFips:
     description: whether this repo should be validated to ensure it is using FIPS endpoints for AWS
     type: boolean
+  tfVersion:
+    description: Which version of terraform binary to use
+    type: string
+    enum:
+    - "1.4.5"
+    - "1.4.7"
+    - "1.5.7" # last version pre hashicorp license change
+  variables:
+    type: object
+    description: Vault paths defining where Terraform inputs are read from and where Terraform outputs are written to
+    properties:
+      inputs:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+      outputs:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+    required:
+    - inputs
+    - outputs
 required:
 - "$schema"
 - account
@@ -38,4 +56,4 @@ required:
 - repository
 - ref
 - projectPath
-
+- tfVersion


### PR DESCRIPTION
[APPSRE-8705](https://issues.redhat.com/browse/APPSRE-8705)

Implements new functionality for Terraform Repo based off of the [Milestone 1 design document](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/initiatives/terraform-repo-commercial.md?ref_type=heads#milestone-1-commercialize-terraform-repo). 

This adds two fields to a Terraform Repo representation in App Interface. The first of which allows a user to specify which version of the Terraform binary to use when planning/applying. The second allows them to load Vault secrets from a specified path as [Input Variables](https://developer.hashicorp.com/terraform/language/values/variables) and write any outputs from their Terraform apply to Vault using [outputs](https://developer.hashicorp.com/terraform/language/values/outputs).

Other PRs that depend on this one:
- https://github.com/app-sre/qontract-reconcile/pull/4260
- https://github.com/app-sre/terraform-repo-executor/pull/17