### PR TITLE
Add run_order to integration pr_check

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3331,6 +3331,7 @@ confs:
   - { name: run_for_valid_saas_file_changes, type: boolean }
   - { name: early_exit, type: boolean }
   - { name: check_only_affected_shards, type: boolean }
+  - { name: run_order, type: int }
 
 - name: IntegrationSpecExtraEnv_v1
   fields:

--- a/schemas/app-sre/integration-1.yml
+++ b/schemas/app-sre/integration-1.yml
@@ -58,6 +58,8 @@ properties:
       check_only_affected_shards:
         type: boolean
         description: "defaults to false"
+      run_order:
+        type: integer
     required:
     - cmd
 


### PR DESCRIPTION
Add `run_order` to `pr_check` section for integration, so some integrations can be grouped to run before others.

[APPSRE-8759](https://issues.redhat.com/browse/APPSRE-8759)