### PR TITLE
[glitchtip] eventThrottleRate attribute

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3802,7 +3802,7 @@ confs:
   - { name: teams, type: GlitchtipTeam_v1, isRequired: true, isList: true }
   - { name: organization, type: GlitchtipOrganization_v1, isRequired: true }
   - { name: alerts, type: GlitchtipProjectAlert_v1, isList: true }
-  - { name: acceptEvents, type: boolean }
+  - { name: eventThrottleRate, type: int }
   - { name: jira, type: GlitchtipProjectJira_v1 }
   - name: namespaces
     type: Namespace_v1

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -216,6 +216,11 @@
     "positiveInteger": {
       "type": "number",
       "minimum": 1
+    },
+    "percentage": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100
     }
   }
 }

--- a/schemas/dependencies/glitchtip-project-1.yml
+++ b/schemas/dependencies/glitchtip-project-1.yml
@@ -91,8 +91,9 @@ properties:
       # referenced
       - "$ref": "/common-1.json#/definitions/crossref"
         "$schemaRef": "/dependencies/glitchtip-project-alert-1.yml"
-  acceptEvents:
-    type: boolean
+  eventThrottleRate:
+    "$ref": "/common-1.json#/definitions/percentage"
+    description: Percentage of new events to deny. 0-100
   jira:
     type: object
     properties:


### PR DESCRIPTION
Replace unused `glitchtip-project.acceptEvents` with `glitchtip-project.eventThrottleRate` to throttle Glitchtip event ingests.

Ticket: [APPSRE-9732](https://issues.redhat.com/browse/APPSRE-9732)