### PR TITLE
[terraform-tgw-attachments] control traffic to private HCP API

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -982,6 +982,7 @@ confs:
   - { name: manageRoutes, type: boolean }
   - { name: manageSecurityGroups, type: boolean }
   - { name: manageRoute53Associations, type: boolean }
+  - { name: allowPrivateHcpApiAccess, type: boolean }
   - { name: cidrBlock, type: string }
   - { name: delete, type: boolean }
   - { name: assumeRole, type: string }

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -344,6 +344,9 @@ properties:
               type: boolean
             allowPrivateHcpApiAccess:
               type: boolean
+              description: |
+                if set to true, enable traffic from attached TGW to reach the API and oauth server
+                of a private HCP by adapting the VPC endpoint security group
             cidrBlock:
               type: string
             delete:

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -342,6 +342,8 @@ properties:
               type: boolean
             manageRoute53Associations:
               type: boolean
+            allowPrivateHcpApiAccess:
+              type: boolean
             cidrBlock:
               type: string
             delete:
@@ -421,6 +423,8 @@ properties:
               manageSecurityGroups:
                 type: boolean
               manageRoute53Associations:
+                type: boolean
+              allowPrivateHcpApiAccess:
                 type: boolean
               cidrBlock:
                 type: string


### PR DESCRIPTION
add an option to control if traffic via a TGW attachment should be able to reach the API server of a private HCP

part of https://issues.redhat.com/browse/APPSRE-9883

prereq for https://github.com/app-sre/qontract-reconcile/pull/4152