### PR TITLE
add backref from namespace to gabi instances

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2452,6 +2452,12 @@ confs:
   - { name: glitchtipProjects, type: GlitchtipProjects_v1, isList: true }
   - { name: kafkaCluster, type: KafkaCluster_v1 }
   - { name: skupperSite, type: NamespaceSkupperSiteConfig_v1 }
+  - name: gabi_instances
+    type: GabiInstance_v1
+    isList: true
+    synthetic:
+      schema: /app-sre/gabi-instance-1.yml
+      subAttr: instances.namespace
 
 - name: Owner_v1
   fields:


### PR DESCRIPTION
this will enable self-service for instances in a gabi instance file approved by the namespace (app) owners.