### PR TITLE
define a telemeter instance for an OCM environment

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1172,6 +1172,7 @@ confs:
   - { name: accessTokenClientId, type: string, isRequired: true }
   - { name: accessTokenUrl, type: string, isRequired: true }
   - { name: accessTokenClientSecret, type: VaultSecret_v1, isRequired: true }
+  - { name: telemeter, type: PrometheusInstance_v1 }
 
 - name: AddonUpgradeTest_v1
   fields:
@@ -3719,8 +3720,10 @@ confs:
   - { name: terraform_repo_v1, type: TerraformRepo_v1, isList: true, datafileSchema: /aws/terraform-repo-1.yml }
   - { name: status_board_v1, type: StatusBoard_v1, isList: true, datafileSchema: /dependencies/status-board-1.yml }
   - { name: dynatrace_environment_v1, type: DynatraceEnvironment_v1, isList: true, datafileSchema: /dependencies/dynatrace-environment-1.yml }
+  - { name: prometheus_instances_v1, type: PrometheusInstance_v1, isList: true, datafileSchema: /dependencies/prometheus-instance-1.yml }
   - { name: template_collection_v1, type: TemplateCollection_v1, isList: true, datafileSchema: /app-interface/template-collection-1.yml }
   - { name: template_v1, type: Template_v1, isList: true, datafileSchema: /app-interface/template-1.yml }
+
 
 - name: GlitchtipInstance_v1
   fields:
@@ -4282,6 +4285,34 @@ confs:
   - { name: network, type: SkupperNetwork_v1, isRequired: true }
   - { name: delete, type: boolean }
   - { name: siteControllerTemplates, type: SkupperSiteControllerTemplate_v1, isList: true }
+
+- name: PrometheusInstance_v1
+  datafile: /dependencies/prometheus-instance-1.yml
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isUnique: true}
+  - { name: labels, type: json }
+  - { name: description, type: string }
+  - { name: baseUrl, type: string, isRequired: true }
+  - { name: queryPath, type: string }
+  - { name: auth, type: PrometheusInstanceAuth_v1, isInterface: true, isRequired: true }
+
+- name: PrometheusInstanceAuth_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      bearer: PrometheusInstanceBearerAuth_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+
+- name: PrometheusInstanceBearerAuth_v1
+  interface: PrometheusInstanceAuth_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: token, type: VaultSecret_v1, isRequired: true }
 
 - name: Template_v1
   datafile: /app-interface/template-1.yml

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4311,6 +4311,7 @@ confs:
     field: provider
     fieldMap:
       bearer: PrometheusInstanceBearerAuth_v1
+      oidc: PrometheusInstanceOidcAuth_v1
   fields:
   - { name: provider, type: string, isRequired: true }
 
@@ -4319,6 +4320,14 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: token, type: VaultSecret_v1, isRequired: true }
+
+- name: PrometheusInstanceOidcAuth_v1
+  interface: PrometheusInstanceAuth_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: accessTokenClientId, type: string, isRequired: true }
+  - { name: accessTokenUrl, type: string, isRequired: true }
+  - { name: accessTokenClientSecret, type: VaultSecret_v1, isRequired: true }
 
 - name: Template_v1
   datafile: /app-interface/template-1.yml

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1126,6 +1126,11 @@ confs:
   - { name: workload, type: string, isRequired: true }
   - { name: channel, type: string }
 
+- name: AusClusterHealthCheck_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: enforced, type: boolean, isRequired: true }
+
 - name: OpenShiftClusterManager_v1
   datafile: /openshift/openshift-cluster-manager-1.yml
   fields:
@@ -1147,6 +1152,7 @@ confs:
   - { name: blockedVersions, type: string, isList: true }
   - { name: upgradePolicyAllowedWorkloads, type: string, isList: true }
   - { name: upgradePolicyAllowedMutexes, type: string, isList: true }
+  - { name: ausClusterHealthChecks, type: AusClusterHealthCheck_v1, isList: true }
   - { name: sectors, type: OpenShiftClusterManagerSector_v1, isList: true }
   - { name: upgradePolicyDefaults, type: OpenShiftClusterManagerUpgradePolicyDefault_v1, isList: true }
   - { name: upgradePolicyClusters, type: OpenShiftClusterManagerUpgradePolicyCluster_v1, isList: true }

--- a/schemas/dependencies/prometheus-instance-1.yml
+++ b/schemas/dependencies/prometheus-instance-1.yml
@@ -1,0 +1,46 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+
+type: object
+additionalProperties: false
+
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /dependencies/prometheus-instance-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    "$ref": "/common-1.json#/definitions/identifier"
+  description:
+    type: string
+  baseUrl:
+    type: string
+    format: uri
+  queryPath:
+    type: string
+  auth:
+    type: object
+    additionalProperties: false
+    properties:
+      provider:
+        type: string
+        enum:
+        - bearer
+      token:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+    oneOf:
+    - properties:
+        provider:
+          type: string
+          enum:
+          - bearer
+        token:
+          "$ref": "/common-1.json#/definitions/vaultSecret"
+required:
+- "$schema"
+- name
+- baseUrl
+- auth

--- a/schemas/dependencies/prometheus-instance-1.yml
+++ b/schemas/dependencies/prometheus-instance-1.yml
@@ -29,7 +29,15 @@ properties:
         type: string
         enum:
         - bearer
+        - oidc
       token:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+      accessTokenClientId:
+        type: string
+      accessTokenUrl:
+        type: string
+        format: uri
+      accessTokenClientSecret:
         "$ref": "/common-1.json#/definitions/vaultSecret"
     oneOf:
     - properties:
@@ -39,6 +47,26 @@ properties:
           - bearer
         token:
           "$ref": "/common-1.json#/definitions/vaultSecret"
+      required:
+      - provider
+      - token
+    - properties:
+        provider:
+          type: string
+          enum:
+          - oidc
+        accessTokenClientId:
+          type: string
+        accessTokenUrl:
+          type: string
+          format: uri
+        accessTokenClientSecret:
+          "$ref": "/common-1.json#/definitions/vaultSecret"
+      required:
+      - provider
+      - accessTokenClientId
+      - accessTokenUrl
+      - accessTokenClientSecret
 required:
 - "$schema"
 - name

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -102,6 +102,22 @@ properties:
     type: array
     items:
       type: string
+  ausClusterHealthChecks:
+    description: List of cluster health check providers
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        provider:
+          type: string
+          enum:
+          - telemeter
+        enforced:
+          type: boolean
+      required:
+      - provider
+      - enforced
   sectors:
     description: List of allowed deployment sectors and their dependencies
     type: array

--- a/schemas/openshift/openshift-cluster-manager-environment-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-environment-1.yml
@@ -25,6 +25,9 @@ properties:
     format: uri
   accessTokenClientSecret:
     "$ref": "/common-1.json#/definitions/vaultSecret"
+  telemeter:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/dependencies/prometheus-instance-1.yml"
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
this way cluster health information can be queried for a fleet of clusters under an environment

Define a prometheus instance representing telemeter...

```yaml
---
$schema: /dependencies/prometheus-instance-1.yml

name: telemeter
baseUrl: https://infogw-proxy.api.openshift.com
queryPath: /api/v1/query
auth:
  provider: bearer
  token:
    field: token
    path: path/to/vault/secret
```

... and link it to an OCM environment

```yaml
---
$schema: /openshift/openshift-cluster-manager-environment-1.yml
name: ocm-production
url: https://api.openshift.com
...
telemeter:
  $ref: /dependencies/prometheus/telemeter-production.yaml
```

part of https://issues.redhat.com/browse/APPSRE-8789