### PR TITLE
aws-policy: limit policy name to max 128 chars

### DIFF
--- a/schemas/aws/policy-1.yml
+++ b/schemas/aws/policy-1.yml
@@ -15,7 +15,7 @@ properties:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/aws/account-1.yml"
   name:
-    type: string
+    "$ref": "/common-1.json#/definitions/awsPolicyName"
   description:
     type: string
   mandatory:

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -221,6 +221,10 @@
       "type": "number",
       "minimum": 0,
       "maximum": 100
+    },
+    "awsPolicyName": {
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9-_]{0,126}[A-Za-z0-9]$"
     }
   }
 }


### PR DESCRIPTION
Limit the policy name length to 128.

See [IAM quotas](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) for more details