### PR TITLE
APPSRE-9922: Add network claim schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2541,7 +2541,7 @@ confs:
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
-  - { name: name, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isSearchable: true, isUnique: true }
   - { name: labels, type: json }
   - { name: description, type: string, isRequired: true }
   - { name: channels, type: AppEscalationPolicyChannels_v1, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1126,6 +1126,11 @@ confs:
   - { name: workload, type: string, isRequired: true }
   - { name: channel, type: string }
 
+- name: AusClusterHealthCheck_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: enforced, type: boolean, isRequired: true }
+
 - name: OpenShiftClusterManager_v1
   datafile: /openshift/openshift-cluster-manager-1.yml
   fields:
@@ -1147,6 +1152,7 @@ confs:
   - { name: blockedVersions, type: string, isList: true }
   - { name: upgradePolicyAllowedWorkloads, type: string, isList: true }
   - { name: upgradePolicyAllowedMutexes, type: string, isList: true }
+  - { name: ausClusterHealthChecks, type: AusClusterHealthCheck_v1, isList: true }
   - { name: sectors, type: OpenShiftClusterManagerSector_v1, isList: true }
   - { name: upgradePolicyDefaults, type: OpenShiftClusterManagerUpgradePolicyDefault_v1, isList: true }
   - { name: upgradePolicyClusters, type: OpenShiftClusterManagerUpgradePolicyCluster_v1, isList: true }
@@ -1172,6 +1178,7 @@ confs:
   - { name: accessTokenClientId, type: string, isRequired: true }
   - { name: accessTokenUrl, type: string, isRequired: true }
   - { name: accessTokenClientSecret, type: VaultSecret_v1, isRequired: true }
+  - { name: telemeter, type: PrometheusInstance_v1 }
 
 - name: AddonUpgradeTest_v1
   fields:
@@ -3720,9 +3727,11 @@ confs:
   - { name: terraform_repo_v1, type: TerraformRepo_v1, isList: true, datafileSchema: /aws/terraform-repo-1.yml }
   - { name: status_board_v1, type: StatusBoard_v1, isList: true, datafileSchema: /dependencies/status-board-1.yml }
   - { name: dynatrace_environment_v1, type: DynatraceEnvironment_v1, isList: true, datafileSchema: /dependencies/dynatrace-environment-1.yml }
+  - { name: prometheus_instances_v1, type: PrometheusInstance_v1, isList: true, datafileSchema: /dependencies/prometheus-instance-1.yml }
   - { name: template_collection_v1, type: TemplateCollection_v1, isList: true, datafileSchema: /app-interface/template-collection-1.yml }
   - { name: template_v1, type: Template_v1, isList: true, datafileSchema: /app-interface/template-1.yml }
   - { name: network_v1, type: Network_v1, isList: true, datafileSchema: /app-sre/network-1.yml }
+
 
 - name: GlitchtipInstance_v1
   fields:
@@ -4284,6 +4293,43 @@ confs:
   - { name: network, type: SkupperNetwork_v1, isRequired: true }
   - { name: delete, type: boolean }
   - { name: siteControllerTemplates, type: SkupperSiteControllerTemplate_v1, isList: true }
+
+- name: PrometheusInstance_v1
+  datafile: /dependencies/prometheus-instance-1.yml
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isUnique: true}
+  - { name: labels, type: json }
+  - { name: description, type: string }
+  - { name: baseUrl, type: string, isRequired: true }
+  - { name: queryPath, type: string }
+  - { name: auth, type: PrometheusInstanceAuth_v1, isInterface: true, isRequired: true }
+
+- name: PrometheusInstanceAuth_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: provider
+    fieldMap:
+      bearer: PrometheusInstanceBearerAuth_v1
+      oidc: PrometheusInstanceOidcAuth_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+
+- name: PrometheusInstanceBearerAuth_v1
+  interface: PrometheusInstanceAuth_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: token, type: VaultSecret_v1, isRequired: true }
+
+- name: PrometheusInstanceOidcAuth_v1
+  interface: PrometheusInstanceAuth_v1
+  fields:
+  - { name: provider, type: string, isRequired: true }
+  - { name: accessTokenClientId, type: string, isRequired: true }
+  - { name: accessTokenUrl, type: string, isRequired: true }
+  - { name: accessTokenClientSecret, type: VaultSecret_v1, isRequired: true }
 
 - name: Template_v1
   datafile: /app-interface/template-1.yml

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4387,7 +4387,12 @@ confs:
   - { name: path, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: false }
-  - { name: inUseBy, type: DatafileObject_v1, isInterface: true }
+  - { name: inUseBy, type: NetworkInUseBy_v1 }
   - { name: networkAddress, type: string, isRequired: true }
   - { name: region, type: string, isRequired: false }
   - { name: parentNetwork, type: Network_v1, isRequired: false }
+
+- name: NetworkInUseBy_v1
+  fields:
+  - { name: vpc, type: AWSVPC_v1 }
+  - { name: app, type: App_v1 }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4395,4 +4395,3 @@ confs:
 - name: NetworkInUseBy_v1
   fields:
   - { name: vpc, type: AWSVPC_v1 }
-  - { name: app, type: App_v1 }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1411,13 +1411,14 @@ confs:
   - { name: policy, type: json, isRequired: true }
 
 - name: AWSVPC_v1
+  datafile: /aws/vpc-1.yml
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
   - { name: account, type: AWSAccount_v1, isRequired: true }
   - { name: name, type: string, isRequired: true }
-  - { name: description, type: string }
+  - { name: description, type: string, isRequired: true }
   - { name: vpc_id, type: string, isRequired: true }
   - { name: cidr_block, type: string, isRequired: true }
   - { name: region, type: string, isRequired: true }
@@ -4340,7 +4341,7 @@ confs:
   - { name: path, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: false }
-  - { name: inUseBy, type: string, isRequired: false }
+  - { name: inUseBy, type: DatafileObject_v1, isInterface: true }
   - { name: networkAddress, type: string, isRequired: true }
   - { name: region, type: string, isRequired: false }
   - { name: parentNetwork, type: Network_v1, isRequired: false }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3721,6 +3721,7 @@ confs:
   - { name: dynatrace_environment_v1, type: DynatraceEnvironment_v1, isList: true, datafileSchema: /dependencies/dynatrace-environment-1.yml }
   - { name: template_collection_v1, type: TemplateCollection_v1, isList: true, datafileSchema: /app-interface/template-collection-1.yml }
   - { name: template_v1, type: Template_v1, isList: true, datafileSchema: /app-interface/template-1.yml }
+  - { name: network_v1, type: Network_v1, isList: true, datafileSchema: /app-sre/network-1.yml }
 
 - name: GlitchtipInstance_v1
   fields:
@@ -4331,3 +4332,15 @@ confs:
   fields:
   - { name: name, type: string, isRequired: true }
   - { name: query, type: string, isRequired: true }
+
+- name: Network_v1
+  datafile: /app-sre/network-1.yml
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true }
+  - { name: description, type: string, isRequired: false }
+  - { name: inUseBy, type: string, isRequired: false }
+  - { name: networkAddress, type: string, isRequired: true }
+  - { name: region, type: string, isRequired: false }
+  - { name: parentNetwork, type: Network_v1, isRequired: false }

--- a/schemas/app-interface/template-1.yml
+++ b/schemas/app-interface/template-1.yml
@@ -33,6 +33,7 @@ properties:
   templateTest:
     type: array
     description: list of tests
+    minItems: 1
     items:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/app-interface/template-test-1.yml"

--- a/schemas/app-sre/network-1.yml
+++ b/schemas/app-sre/network-1.yml
@@ -22,16 +22,18 @@ properties:
   inUseBy:
     description: "A reference to some entity that is able to, and has claimed this network. If this network is unclaimed, this will have a null value."
     type: object
-    "$ref": "/common-1.json#/definitions/crossref"
-    "$schemaRef": 
-      type: object
-      properties:
-        '$schema':
-          type: string
-          enum:
-          # Add other claimants to the list so long as they implement the
-          # datafile interface.
-          - /aws/vpc-1.yml
+    properties:
+      vpc:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": /aws/vpc-1.yml
+      app:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "/app-sre/app-1.yml"
+    oneOf:
+    - required:
+      - vpc
+    - required:
+      - app
   networkAddress:
     description: "The network address in CIDR format"
     type: string

--- a/schemas/app-sre/network-1.yml
+++ b/schemas/app-sre/network-1.yml
@@ -1,0 +1,45 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum: 
+      - /app-sre/network-1.yml
+
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+
+  name:
+    "$ref": "/common-1.json#/definitions/extendedIdentifier"
+
+  description:
+    type: string
+
+  inUseBy:
+    description: "A reference to some entity that is able to, and has claimed this network. If this network is unclaimed, this will have a null value."
+    type: object
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": 
+      type: object
+      properties:
+        '$schema':
+          type: string
+          enum:
+          - /aws/vpc-1.yml
+          - /app-sre/app.yml
+  networkAddress:
+    description: "The network address in CIDR format"
+    type: string
+    # Naive regeg; validate in code before use.
+    pattern: "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\/\\d+$"
+  parentNetwork:
+    description: "A reference to this network's parent network. If this is a 'root' network, it will have no parent."
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/app-sre/network-1.yml"
+  region:
+    description: "Region where this network resides"
+    type: string

--- a/schemas/app-sre/network-1.yml
+++ b/schemas/app-sre/network-1.yml
@@ -29,8 +29,9 @@ properties:
         '$schema':
           type: string
           enum:
+          # Add other claimants to the list so long as they implement the
+          # datafile interface.
           - /aws/vpc-1.yml
-          - /app-sre/app.yml
   networkAddress:
     description: "The network address in CIDR format"
     type: string
@@ -43,3 +44,9 @@ properties:
   region:
     description: "Region where this network resides"
     type: string
+
+required:
+- $schema
+- name
+- description
+- networkAddress

--- a/schemas/app-sre/network-1.yml
+++ b/schemas/app-sre/network-1.yml
@@ -26,14 +26,9 @@ properties:
       vpc:
         "$ref": "/common-1.json#/definitions/crossref"
         "$schemaRef": /aws/vpc-1.yml
-      app:
-        "$ref": "/common-1.json#/definitions/crossref"
-        "$schemaRef": "/app-sre/app-1.yml"
     oneOf:
     - required:
       - vpc
-    - required:
-      - app
   networkAddress:
     description: "The network address in CIDR format"
     type: string

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -1220,8 +1220,7 @@ oneOf:
                   properties:
                     target_group:
                       type: array
-                      # https://github.com/hashicorp/terraform-provider-aws/pull/12574#issuecomment-639642524
-                      minItems: 2
+                      minItems: 1
                       items:
                         type: object
                         additionalProperties: false

--- a/schemas/dependencies/prometheus-instance-1.yml
+++ b/schemas/dependencies/prometheus-instance-1.yml
@@ -1,0 +1,74 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+
+type: object
+additionalProperties: false
+
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /dependencies/prometheus-instance-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    "$ref": "/common-1.json#/definitions/identifier"
+  description:
+    type: string
+  baseUrl:
+    type: string
+    format: uri
+  queryPath:
+    type: string
+  auth:
+    type: object
+    additionalProperties: false
+    properties:
+      provider:
+        type: string
+        enum:
+        - bearer
+        - oidc
+      token:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+      accessTokenClientId:
+        type: string
+      accessTokenUrl:
+        type: string
+        format: uri
+      accessTokenClientSecret:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+    oneOf:
+    - properties:
+        provider:
+          type: string
+          enum:
+          - bearer
+        token:
+          "$ref": "/common-1.json#/definitions/vaultSecret"
+      required:
+      - provider
+      - token
+    - properties:
+        provider:
+          type: string
+          enum:
+          - oidc
+        accessTokenClientId:
+          type: string
+        accessTokenUrl:
+          type: string
+          format: uri
+        accessTokenClientSecret:
+          "$ref": "/common-1.json#/definitions/vaultSecret"
+      required:
+      - provider
+      - accessTokenClientId
+      - accessTokenUrl
+      - accessTokenClientSecret
+required:
+- "$schema"
+- name
+- baseUrl
+- auth

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -102,6 +102,22 @@ properties:
     type: array
     items:
       type: string
+  ausClusterHealthChecks:
+    description: List of cluster health check providers
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        provider:
+          type: string
+          enum:
+          - telemeter
+        enforced:
+          type: boolean
+      required:
+      - provider
+      - enforced
   sectors:
     description: List of allowed deployment sectors and their dependencies
     type: array

--- a/schemas/openshift/openshift-cluster-manager-environment-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-environment-1.yml
@@ -25,6 +25,9 @@ properties:
     format: uri
   accessTokenClientSecret:
     "$ref": "/common-1.json#/definitions/vaultSecret"
+  telemeter:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/dependencies/prometheus-instance-1.yml"
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
As it stands, this will not validate because the
`  - { name: inUseBy, type: string, isRequired: false }` is wrong; it should pair with the definition to be properly supportive of the polymorphic nature of allowing multiple things to claim a network. On the topic of claiming a network, vpc-1 and app-1 are used as placeholders and do not necessarily represent the final configuration.

fyi @geoberle 