### PR TITLE
[AUS] enable ingress gate to be auto approvable

### DIFF
--- a/schemas/openshift/cluster-upgrade-policy-1.yml
+++ b/schemas/openshift/cluster-upgrade-policy-1.yml
@@ -27,6 +27,7 @@ properties:
       enum:
       - api.openshift.com/gate-sts
       - api.openshift.com/gate-ocp
+      - api.openshift.com/gate-ingress
   conditions:
     additionalProperties: false
     properties:


### PR DESCRIPTION
add the `gate-ingress` version gate to the list of valid gates to be auto acknowledable by the AUS version-gate-approver

part of https://issues.redhat.com/browse/APPSRE-7949