### PR TITLE
SDCICD-1254: allow release-* branch names

### DIFF
--- a/schemas/app-sre/saas-file-target-1.yml
+++ b/schemas/app-sre/saas-file-target-1.yml
@@ -37,7 +37,7 @@ properties:
       - include
   ref:
     type: string
-    pattern: '^([0-9a-f]{40}|master|main|internal|stable)$'
+    pattern: '^([0-9a-f]{40}|master|main|internal|stable|release-4\.\d+)$'
   promotion:
     type: object
     additionalProperties: false


### PR DESCRIPTION
the schema needs to be updated to allow branches following the new
branch strategy that OCP follows (release-*). This was discussed before
in #120 but decided against. With the new progressive delivery strategy,
this will need to be allowed.

Signed-off-by: Brady Pratt <bpratt@redhat.com>
