### PR TITLE
Fix change VPC request name to identifier

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1511,7 +1511,7 @@ confs:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
-  - { name: name, type: string, isRequired: true }
+  - { name: identifier, type: string, isRequired: true }
   - { name: description, type: string }
   - { name: region, type: string, isRequired: true }
   - { name: cidr_block, type: Network_v1, isRequired: true }

--- a/schemas/aws/vpc-request-1.yml
+++ b/schemas/aws/vpc-request-1.yml
@@ -11,8 +11,8 @@ properties:
     - /aws/vpc-request-1.yml
   labels:
     "$ref": "/common-1.json#/definitions/labels"
-  name:
-    type: string
+  identifier:
+    "$ref": "/common-1.json#/definitions/longIdentifier"
   region:
     type: string
   description:
@@ -38,6 +38,6 @@ properties:
           type: string
 required:
 - "$schema"
-- name
+- identifier
 - cidr_block
 - region


### PR DESCRIPTION
Name is good in app-interface universe but for a Terraform resource identifier has better restrictions. The same identifier can serve as a `Name` tag.