### PR TITLE
expose ACS defaultFieldsJson via escalation policy jiraCustomFieldsJSON

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2656,6 +2656,7 @@ confs:
   - { name: pagerduty, type: PagerDutyTarget_v1 }
   - { name: jiraBoard, type: JiraBoard_v1, isList: true, isRequired: true }
   - { name: jiraComponent, type: string }
+  - { name: jiraCustomFieldsJSON, type: json }
   - { name: nextEscalationPolicy, type: AppEscalationPolicy_v1 }
 
 - name: AppEndPoints_v1

--- a/schemas/app-sre/escalation-policy-1.yml
+++ b/schemas/app-sre/escalation-policy-1.yml
@@ -45,6 +45,9 @@ properties:
       jiraComponent:
         type: string
         description: component to set on jira tickets
+      jiraCustomFieldsJSON:
+        type: object
+        description: JSON values for custom fields in jira
       nextEscalationPolicy:
         "$ref": "/common-1.json#/definitions/crossref"
         "$schemaRef": "/app-sre/escalation-policy-1.yml"


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10043

following up on adding an escalation policy reference to ACS policies in #619

ACS docs: https://docs.openshift.com/acs/4.4/integration/integrate-with-jira.html#jira-configuring-acs_integrate-with-jira

with this PR we expose the ACS option in a raw manner to allow initial flexibility. we'll see usage patterns and perhaps abstract it in the future.