### PR TITLE
add jira labels to escalation policy

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2656,6 +2656,7 @@ confs:
   - { name: pagerduty, type: PagerDutyTarget_v1 }
   - { name: jiraBoard, type: JiraBoard_v1, isList: true, isRequired: true }
   - { name: jiraComponent, type: string }
+  - { name: jiraLabels, type: string, isList: true }
   - { name: nextEscalationPolicy, type: AppEscalationPolicy_v1 }
 
 - name: AppEndPoints_v1

--- a/schemas/app-sre/escalation-policy-1.yml
+++ b/schemas/app-sre/escalation-policy-1.yml
@@ -45,6 +45,11 @@ properties:
       jiraComponent:
         type: string
         description: component to set on jira tickets
+      jiraLabels:
+        type: array
+        description: labels to add on jira tickets
+        items:
+          type: string
       nextEscalationPolicy:
         "$ref": "/common-1.json#/definitions/crossref"
         "$schemaRef": "/app-sre/escalation-policy-1.yml"


### PR DESCRIPTION
to be able to use for labeling jira tickets created by our automation.

for example, with jiralert: https://github.com/prometheus-community/jiralert/blob/d43cbab62126d543e8e789f6374d9e745693cce2/examples/jiralert.yml#L27