### PR TITLE
Add availability zone to vpc request subnets

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1516,8 +1516,13 @@ confs:
 
 - name: VPCRequestSubnets_v1
   fields:
-  - { name: private, type: string, isList: true }
-  - { name: public, type: string, isList: true }
+  - { name: availability_zone, type: string, isRequired: true }
+  - { name: cidr_block, type: string, isRequired: true }
+
+- name: VPCRequestSubnetsLists_v1
+  fields:
+  - { name: private, type: VPCRequestSubnets_v1, isList: true }
+  - { name: public, type: VPCRequestSubnets_v1, isList: true }
 
 - name: VPCRequest_v1
   datafile: /aws/vpc-request-1.yml
@@ -1530,7 +1535,7 @@ confs:
   - { name: region, type: string, isRequired: true }
   - { name: cidr_block, type: Network_v1, isRequired: true }
   - { name: account, type: AWSAccount_v1, isRequired: true }
-  - { name: subnets, type: VPCRequestSubnets_v1 }
+  - { name: subnets, type: VPCRequestSubnetsLists_v1 }
 
 - name: AWSSubnet_v1
   fields:

--- a/schemas/aws/vpc-request-1.yml
+++ b/schemas/aws/vpc-request-1.yml
@@ -31,11 +31,29 @@ properties:
       private:
         type: array
         items:
-          type: string
+          type: object
+          additionalProperties: false
+          properties:
+            availability_zone:
+              type: string
+            cidr_block:
+              type: string
+          required:
+          - availability_zone
+          - cidr_block
       public:
         type: array
         items:
-          type: string
+          type: object
+          additionalProperties: false
+          properties:
+            availability_zone:
+              type: string
+            cidr_block:
+              type: string
+          required:
+          - availability_zone
+          - cidr_block
 required:
 - "$schema"
 - identifier


### PR DESCRIPTION
I've noticed that when we create a subnet we generally provide an availability zone, so I'm adding this to the vpc-request schema.