### PR TITLE
acs policy introduce integrations

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -688,11 +688,23 @@ confs:
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string }
   - { name: notifiers, type: string, isList: true }
-  - { name: escalationPolicy, type: AppEscalationPolicy_v1, isRequired: true }
+  - { name: integrations, type: AcsPolicyIntegrations_v1 }
   - { name: severity, type: string, isRequired: true }
   - { name: categories, type: string, isList: true, isRequired: true }
   - { name: scope, type: AcsPolicyScope_v1, isRequired: true, isInterface: true }
   - { name: conditions, type: AcsPolicyConditions_v1, isList: true, isInterface: true, isRequired: true }
+
+- name: AcsPolicyIntegrations_v1
+  fields:
+  - { name: notifiers, type: AcsPolicyIntegrationNotifiers_v1 }
+
+- name: AcsPolicyIntegrationNotifiers_v1
+  fields:
+  - { name: jira, type: AcsPolicyIntegrationNotifierJira_v1 }
+
+- name: AcsPolicyIntegrationNotifierJira_v1
+  fields:
+  - { name: escalationPolicy, type: AppEscalationPolicy_v1, isRequired: true }
 
 - name: AcsPolicyScope_v1
   isInterface: true

--- a/schemas/acs/acs-policy-1.yml
+++ b/schemas/acs/acs-policy-1.yml
@@ -19,9 +19,26 @@ properties:
     type: array
     items:
       type: string
-  escalationPolicy:
-    "$ref": "/common-1.json#/definitions/crossref"
-    "$schemaRef": "/app-sre/escalation-policy-1.yml"
+  integrations:
+    type: object
+    description: manage integrations for a policy
+    additionalProperties: false
+    properties:
+      notifiers:
+        type: object
+        description: manage notifier integrations for a policy
+        additionalProperties: false
+        properties:
+          jira:
+            type: object
+            description: manage notifier integration for a policy with jira
+            additionalProperties: false
+            properties:
+              escalationPolicy:
+                "$ref": "/common-1.json#/definitions/crossref"
+                "$schemaRef": "/app-sre/escalation-policy-1.yml"
+            required:
+            - escalationPolicy
   severity:
     type: string
     enum:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10043

design doc: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/102231

As `notifiers` is a single form of an integration, we will add a new field to the schema: `integrations`. This object will include a new `notifiers` section, which will have a field for each notifier integration we want to implement, starting with `jira`.

The `integrations.notifiers.jira` field will include `escalationPolicy`, a reference to an Escalation Policy, which will be used to collect the required information to manage Notifiers. Specifically, the first Jira board referenced under `channels` will be used to define the default project, Severity to Priority mappings, and more.