### PR TITLE
enable saas file authentication to be inlined or referenced

### DIFF
--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -59,12 +59,7 @@ properties:
     items:
       "$ref": "/openshift/managed-resource-name-1.yml"
   authentication:
-    type: object
-    properties:
-      code:
-        "$ref": "/common-1.json#/definitions/vaultSecret"
-      image:
-        "$ref": "/common-1.json#/definitions/vaultSecret"
+    "$ref": "/app-sre/saas-file-authentication-1.yml"
   parameters:
     type: object
   allowedSecretParameterPaths:

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -59,7 +59,12 @@ properties:
     items:
       "$ref": "/openshift/managed-resource-name-1.yml"
   authentication:
-    "$ref": "/app-sre/saas-file-authentication-1.yml"
+    oneOf:
+    # inline
+    - "$ref": "/app-sre/saas-file-authentication-1.yml"
+    # referenced
+    - "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/app-sre/saas-file-authentication-1.yml"
   parameters:
     type: object
   allowedSecretParameterPaths:

--- a/schemas/app-sre/saas-file-authentication-1.yml
+++ b/schemas/app-sre/saas-file-authentication-1.yml
@@ -1,0 +1,17 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+description: saas file authentication section for image and/or code credentials
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /app-sre/saas-file-authentication-1.yml
+  code:
+    "$ref": "/common-1.json#/definitions/vaultSecret"
+  image:
+    "$ref": "/common-1.json#/definitions/vaultSecret"
+required: []


### PR DESCRIPTION
by extracting the schema to its own object, and adding a `oneOf` validation such that authentication is either inlined in the saas file or referenced in a different file.

wondering if this is working? here is a live example: https://github.com/app-sre/qontract-schemas/blob/973b61443fe6923d6f24288237252cba5a219ca4/schemas/app-sre/saas-file-2.yml#L113-L118