### PR TITLE
♻️ Move availability zones to its own list

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1513,15 +1513,11 @@ confs:
   - { name: region, type: string, isRequired: true }
   - { name: subnets, type: AWSSubnet_v1, isList: true }
 
-- name: VPCRequestSubnets_v1
-  fields:
-  - { name: availability_zone, type: string, isRequired: true }
-  - { name: cidr_block, type: string, isRequired: true }
-
 - name: VPCRequestSubnetsLists_v1
   fields:
-  - { name: private, type: VPCRequestSubnets_v1, isList: true }
-  - { name: public, type: VPCRequestSubnets_v1, isList: true }
+  - { name: private, type: string, isList: true }
+  - { name: public, type: string, isList: true }
+  - { name: availability_zones, type: string, isList: true }
 
 - name: VPCRequest_v1
   datafile: /aws/vpc-request-1.yml

--- a/schemas/aws/vpc-request-1.yml
+++ b/schemas/aws/vpc-request-1.yml
@@ -29,31 +29,20 @@ properties:
     additionalProperties: false
     properties:
       private:
+        description: Private subnets CIDR blocks.
         type: array
         items:
-          type: object
-          additionalProperties: false
-          properties:
-            availability_zone:
-              type: string
-            cidr_block:
-              type: string
-          required:
-          - availability_zone
-          - cidr_block
+          type: string
       public:
+        description: Public subnets CIDR blocks.
         type: array
         items:
-          type: object
-          additionalProperties: false
-          properties:
-            availability_zone:
-              type: string
-            cidr_block:
-              type: string
-          required:
-          - availability_zone
-          - cidr_block
+          type: string
+      availability_zones:
+        description: A list of availability zones names in the region.
+        type: array
+        items:
+          type: string
 required:
 - "$schema"
 - identifier


### PR DESCRIPTION
To be able to use azs the same way we use in the [Terraform VPC Module](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest) I've moved them to their own list.