### PR TITLE
deprecate acs policy notifiers

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -687,7 +687,6 @@ confs:
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string }
-  - { name: notifiers, type: string, isList: true }
   - { name: integrations, type: AcsPolicyIntegrations_v1 }
   - { name: severity, type: string, isRequired: true }
   - { name: categories, type: string, isList: true, isRequired: true }

--- a/schemas/acs/acs-policy-1.yml
+++ b/schemas/acs/acs-policy-1.yml
@@ -15,10 +15,6 @@ properties:
     type: string
   name:
     type: string
-  notifiers:
-    type: array
-    items:
-      type: string
   integrations:
     type: object
     description: manage integrations for a policy


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10043

design document: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/102231

following https://github.com/app-sre/qontract-reconcile/pull/4275, the root level `notifiers` field is deprecated in favor of `integrations.notifiers`.