### PR TITLE
cloudflare/dns-record-1: support CAA record type

### DIFF
--- a/schemas/cloudflare/dns-record-1.yml
+++ b/schemas/cloudflare/dns-record-1.yml
@@ -18,6 +18,7 @@ properties:
     enum:
     - A
     - AAAA
+    - CAA
     - CNAME
     - TXT
     - NS


### PR DESCRIPTION
Ref.: https://issues.redhat.com/browse/APPSRE-10082