### PR TITLE
:recycle: /access/role-1.yml: refactor ldapGroup attribute

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3422,7 +3422,7 @@ confs:
   - { name: sendgrid_accounts, type: SendGridAccount_v1, isList: true }
   - { name: self_service, type: SelfServiceConfig_v1, isList: true }
   - { name: cloudflare_access, type: CloudflareAccountRole_v1, isList: true }
-  - { name: ldapGroup, type: string }
+  - { name: ldapGroup, type: LdapGroup_v1 }
   - { name: memberSources, type: RoleMembershipSource_V1, isList: true }
   - name: users
     type: User_v1
@@ -3438,6 +3438,12 @@ confs:
     synthetic:
       schema: /access/bot-1.yml
       subAttr: roles
+
+- name: LdapGroup_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: notes, type: string }
+  - { name: membersAreOwners, type: boolean }
 
 - name: RoleMembershipSource_V1
   fields:

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -177,13 +177,13 @@ properties:
     properties:
       name:
         "$ref": "/common-1.json#/definitions/ldapGroupName"
-        description: The name of the LDAP group
+        description: The name of the LDAP/Rover group
       notes:
         type: string
-        description: Notes added to the LDAP group
+        description: Notes added to the LDAP/Rover group
       membersAreOwners:
         type: boolean
-        description: If true, all members of the LDAP group will be owners as well
+        description: Grant "owner" permission to all members of the LDAP/Rover group
     required:
     - name
   memberSources:

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -173,7 +173,19 @@ properties:
                   - /access/bot-1.yml
                   - /dependencies/dynatrace-environment-1.yml
   ldapGroup:
-    "$ref": "/common-1.json#/definitions/ldapGroupName"
+    type: object
+    properties:
+      name:
+        "$ref": "/common-1.json#/definitions/ldapGroupName"
+        description: The name of the LDAP group
+      notes:
+        type: string
+        description: Notes added to the LDAP group
+      membersAreOwners:
+        type: boolean
+        description: If true, all members of the LDAP group will be owners as well
+    required:
+    - name
   memberSources:
     type: array
     items:


### PR DESCRIPTION
The goal is to enable our LDAP groups to be authZ groups for Bitwarden collections. Rover group requirements are:

* Rover group notes must contain the string `@BW@` somewhere
* At least 2 owners are set

This PR adds `notes` and `membersAreOwners` (both optional) to the `role.ldapGroup` attribute. `notes` will be Rover group notes, and `membersAreOwners: true` will also grant the `owners` permission to all group members.

Tickets
* [APPSRE-10201](https://issues.redhat.com/browse/APPSRE-10201)
* [APPSRE-8399](https://issues.redhat.com/browse/APPSRE-8399)

