### PR TITLE
Add field to code component to specify image build job URL

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2733,6 +2733,7 @@ confs:
   - { name: gitlabHousekeeping, type: CodeComponentGitlabHousekeeping_v1 }
   - { name: jira, type: JiraServer_v1 }
   - { name: mirror, type: string }
+  - { name: imageBuildUrl, type: string }
 
 - name: Product_v1
   datafile: /app-sre/product-1.yml

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -295,20 +295,20 @@ properties:
             sourceProject:
               type: object
               properties:
-                name: 
+                name:
                   type: string
-                group: 
+                group:
                   type: string
-                branch: 
+                branch:
                   type: string
             destinationProject:
               type: object
               properties:
-                name: 
+                name:
                   type: string
-                group: 
+                group:
                   type: string
-                branch: 
+                branch:
                   type: string
           required:
           - sourceProject
@@ -362,6 +362,11 @@ properties:
           type: string
           format: uri
           description: GitLab repo to mirror from
+        imageBuildUrl:
+          type: string
+          format: uri
+          pattern: "^https:\/\/.+(?<!\/)$"
+          description: URL for the component's image build job (jenkins job, rhtap pipeline page, etc.)
       required:
       - name
       - resource


### PR DESCRIPTION
Since we have image builds occurring on different systems at this point (not always on Jenkins), it would be ideal to indicate on a code component where you can find its build job. We plan to reference this field on the developer portal.