### PR TITLE
statuspage-maintenances add more fields/features

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4221,7 +4221,10 @@ confs:
   - { name: exclude, type: string, isList: true }
 
 - name: Maintenance_v1
+  datafile: /app-sre/maintenance-1.yml
   fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true }
   - { name: title, type: string, isRequired: true }
   - { name: stage, type: string, isRequired: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4244,6 +4244,7 @@ confs:
   interface: MaintenanceAnnouncement_v1
   fields:
   - { name: provider, type: string, isRequired: true }
+  - { name: page, type: StatusPage_v1, isRequired: true }
   - { name: announceAt, type: string, isRequired: true }
   - { name: message, type: string, isRequired: true }
   - { name: remindSubscribers, type: boolean }

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -173,6 +173,7 @@ properties:
                   - /access/bot-1.yml
                   - /dependencies/dynatrace-environment-1.yml
                   - /app-sre/integration-1.yml
+                  - /app-sre/maintenance-1.yml
   ldapGroup:
     type: object
     properties:

--- a/schemas/app-sre/maintenance-1.yml
+++ b/schemas/app-sre/maintenance-1.yml
@@ -44,6 +44,9 @@ properties:
           type: string
           enum:
           - statuspage
+        page:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/dependencies/status-page-1.yml"
         announceAt:
           type: string
           format: date-time
@@ -67,6 +70,9 @@ properties:
           type: string
           enum:
           - statuspage
+        page:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/dependencies/status-page-1.yml"
         announceAt:
           type: string
           format: date-time
@@ -82,6 +88,7 @@ properties:
           type: boolean
       required:
       - provider
+      - page
       - announceAt
       - message
 required:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10224

adding a page reference to a maintenance for statuspage provider. also adding self-service for the schema.

design doc: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/maintenances.md