### PR TITLE
remove integrations enum from slack workspace

### DIFF
--- a/schemas/dependencies/slack-workspace-1.yml
+++ b/schemas/dependencies/slack-workspace-1.yml
@@ -49,16 +49,6 @@ properties:
       properties:
         name:
           type: string
-          enum:
-          - jira-watcher
-          - openshift-saas-deploy
-          - unleash-watcher
-          - slack-sender
-          - openshift-upgrade-watcher
-          - slack-usergroups
-          - qontract-cli
-          - sd-app-sre-alert-report
-          - ocm-internal-notifications
       token:
         "$ref": "/common-1.json#/definitions/vaultSecret"
       channel:


### PR DESCRIPTION
this is quite annoying, honestly