### PR TITLE
enable wontFixResolution and reopenDuration for a jira board

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -561,6 +561,7 @@ confs:
   - { name: issueResolveState, type: string }
   - { name: issueReopenState, type: string }
   - { name: issueSecurityId, type: string }
+  - { name: wontFixResolution, type: string }
   - { name: disable, type: DisableJiraBoardAutomations_v1 }
   - name: escalationPolicies
     type: AppEscalationPolicy_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -562,6 +562,7 @@ confs:
   - { name: issueReopenState, type: string }
   - { name: issueSecurityId, type: string }
   - { name: wontFixResolution, type: string }
+  - { name: reopenDuration, type: string }
   - { name: disable, type: DisableJiraBoardAutomations_v1 }
   - name: escalationPolicies
     type: AppEscalationPolicy_v1

--- a/schemas/dependencies/jira-board-1.yml
+++ b/schemas/dependencies/jira-board-1.yml
@@ -39,6 +39,8 @@ properties:
     type: string
   issueSecurityId:
     type: string
+  wontFixResolution:
+    type: string
   disable:
     type: object
     additionalProperties: false

--- a/schemas/dependencies/jira-board-1.yml
+++ b/schemas/dependencies/jira-board-1.yml
@@ -41,6 +41,8 @@ properties:
     type: string
   wontFixResolution:
     type: string
+  reopenDuration:
+    type: string
   disable:
     type: object
     additionalProperties: false


### PR DESCRIPTION
to enable per-board definition to override default jiralert definitions