### PR TITLE
Add delete flag to vpc-request

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1544,6 +1544,7 @@ confs:
   - { name: labels, type: json }
   - { name: identifier, type: string, isRequired: true }
   - { name: description, type: string }
+  - { name: delete, type: boolean }
   - { name: region, type: string, isRequired: true }
   - { name: cidr_block, type: Network_v1, isRequired: true }
   - { name: account, type: AWSAccount_v1, isRequired: true }

--- a/schemas/aws/vpc-request-1.yml
+++ b/schemas/aws/vpc-request-1.yml
@@ -17,6 +17,8 @@ properties:
     type: string
   description:
     type: string
+  delete:
+    type: boolean
   cidr_block:
     description: "Reference to a network reservation file"
     "$ref": "/common-1.json#/definitions/crossref"


### PR DESCRIPTION
To make it easier to remove VPCs in `app-interface` we are going to use the `delete: true` pattern.

That is necessaire because if all `vpc-request` from an account are removed the integration will skip the run and not remove the VPCs in the Terraform plan/apply stept