### PR TITLE
:recycle: glitchtip-project: replace jira board reference with escalation policy

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4054,8 +4054,9 @@ confs:
 
 - name: GlitchtipProjectJira_v1
   fields:
+  - { name: escalationPolicy, type: AppEscalationPolicy_v1 }
   - { name: project, type: string }
-  - { name: board, type: JiraBoard_v1 }
+  - { name: components, type: string, isList: true }
   - { name: labels, type: string, isList: true }
 
 - name: GlitchtipProject_v1

--- a/schemas/dependencies/glitchtip-project-1.yml
+++ b/schemas/dependencies/glitchtip-project-1.yml
@@ -97,18 +97,22 @@ properties:
   jira:
     type: object
     properties:
-      board:
+      escalationPolicy:
         "$ref": "/common-1.json#/definitions/crossref"
-        "$schemaRef": "/dependencies/jira-board-1.yml"
+        "$schemaRef": "/app-sre/escalation-policy-1.yml"
       project:
         type: string
+      components:
+        type: array
+        items:
+          type: string
       labels:
         type: array
         items:
           type: string
     oneOf:
     - required:
-      - board
+      - escalationPolicy
     - required:
       - project
 required:


### PR DESCRIPTION
Use `escalationPolicy` instead of own jira board definition in `glitchtip-project-alert-1`. This enables jira components support for glitchtip jira tickets.

Ticket: [APPSRE-10356](https://issues.redhat.com/browse/APPSRE-10356)