### PR TITLE
:sparkles: account-request: add UID attribute to support takeover of existing accounts

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1348,6 +1348,7 @@ confs:
   - { name: quotaLimits, type: AWSQuotaLimits_v1, isList: true }
   - { name: resourcesDefaultRegion, type: string, isRequired: true }
   - { name: supportedDeploymentRegions, type: string, isList: true }
+  - { name: uid, type: string }
 
 - name: AWSQuotaLimits_v1
   datafile: /aws/quota-limits-1.yml

--- a/schemas/aws/account-request-1.yml
+++ b/schemas/aws/account-request-1.yml
@@ -41,6 +41,11 @@ properties:
     type: array
     items:
       type: string
+  uid:
+    type: string
+    description: |
+      Specifying an account UID will takeover an existing account instead of creating a new one.
+      Please make sure you specify the current account owner and the current organization.
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
Add `uid` to `/aws/account-request-1.yml`. If `uid` is specified, `aws-account-manager` will take over an existing account instead of creating a new one.

Ticket: [APPSRE-10430](https://issues.redhat.com/browse/APPSRE-10430)