### PR TITLE
make slack permission channels mandatory

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3311,7 +3311,7 @@ confs:
   - { name: handle, type: string, isRequired: true }
   - { name: workspace, type: SlackWorkspace_v1, isRequired: true }
   - { name: pagerduty, type: PagerDutyTarget_v1, isList: true }
-  - { name: channels, type: string, isList: true }
+  - { name: channels, type: string, isList: true, isRequired: true }
   - { name: ownersFromRepos, type: string, isList: true }
   - { name: schedule, type: Schedule_v1 }
   - { name: skip, type: boolean }

--- a/schemas/access/permission-1.yml
+++ b/schemas/access/permission-1.yml
@@ -178,6 +178,7 @@ oneOf:
   - handle
   - description
   - workspace
+  - channels
 required:
 - $schema
 - labels

--- a/schemas/access/permission-1.yml
+++ b/schemas/access/permission-1.yml
@@ -166,6 +166,7 @@ oneOf:
       type: array
       items:
         type: string
+      minItems: 1
     schedule:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/app-sre/schedule-1.yml"


### PR DESCRIPTION
it would make sense for every usergroup to define in what channels they should be contacted. specifying channels should be at least mandatory to begin with.