### PR TITLE
:sparkles: account-request: add additionalFeatures attribute

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1349,6 +1349,7 @@ confs:
   - { name: resourcesDefaultRegion, type: string, isRequired: true }
   - { name: supportedDeploymentRegions, type: string, isList: true }
   - { name: uid, type: string }
+  - { name: additionalFeatures, type: json }
 
 - name: AWSQuotaLimits_v1
   datafile: /aws/quota-limits-1.yml

--- a/schemas/aws/account-request-1.yml
+++ b/schemas/aws/account-request-1.yml
@@ -46,6 +46,10 @@ properties:
     description: |
       Specifying an account UID will takeover an existing account instead of creating a new one.
       Please make sure you specify the current account owner and the current organization.
+  additionalFeatures:
+    type: object
+    description: |
+      Enable/disable additional features for this account. See account template for all available feature options.
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
Add `additionalFeatures` attribute to `account-requests`. With the help of this attribute, we can control which templates must be rendered for a new account. E.g. 

```
$schema: /aws/account-request-1.yml
...

additionalFeatures:
  rosa: false
  aws_resource_exporter:
    rds: true
```

will disable rosa quota limits and enable AWS resource exporter with RDS metrics.


Ticket: https://issues.redhat.com/browse/APPSRE-10384