### PR TITLE
:sparkles: templates: add templateRenderOptions attribute

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4617,6 +4617,13 @@ confs:
   - { name: targetPath, type: string, isRequired: true }
   - { name: template, type: string, isRequired: true }
   - { name: templateTest, type: TemplateTest_v1, isList: true, isRequired: true }
+  - { name: templateRenderOptions, type: TemplateRenderOptions_v1 }
+
+- name: TemplateRenderOptions_v1
+  fields:
+  - { name: trimBlocks, type: boolean }
+  - { name: lstripBlocks, type: boolean }
+  - { name: keepTrailingNewline, type: boolean }
 
 - name: TemplatePatch_v1
   fields:

--- a/schemas/app-interface/template-1.yml
+++ b/schemas/app-interface/template-1.yml
@@ -30,7 +30,7 @@ properties:
         type: string
     required:
     - path
-  template: 
+  template:
     type: string
   templateTest:
     type: array
@@ -39,6 +39,16 @@ properties:
     items:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/app-interface/template-test-1.yml"
+  templateRenderOptions:
+    type: object
+    additionalProperties: false
+    properties:
+      trimBlocks:
+        type: boolean
+      lstripBlocks:
+        type: boolean
+      keepTrailingNewline:
+        type: boolean
 
 required:
 - "$schema"


### PR DESCRIPTION
Make the jinja [whitespace control](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control) behavior configurable for a template by introducing `trim_blocks`, `lstrip_blocks`, and `keep_trailing_newline` as `templateRenderOptions`. The default will still be `False` for all three options.