### PR TITLE
Update identifier pattern in schemas to allow dots in strings

### DIFF
--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -34,7 +34,7 @@
     },
     "identifier": {
       "type": "string",
-      "pattern": "^[A-Za-z0-9][A-Za-z0-9-_]{0,30}[A-Za-z0-9]$"
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9.-_]{0,30}[A-Za-z0-9]$"
     },
     "identifierLowercase64": {
       "type": "string",


### PR DESCRIPTION
This change modifies the identifier pattern to accommodate
 strings with dots (.) such as 'raks.tt' in user-1.yml schema.