### PR TITLE
add aws billing account to aws account

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1296,6 +1296,7 @@ confs:
   - { name: cleanup, type: AWSAccountCleanupOption_v1, isList: true, isInterface: true }
   - { name: terraformState, type: TerraformStateAWS_v1, isRequired: false }
   - { name: rosa, type: RosaOcmSpec_v1, isRequired: false}
+  - { name: billingAccount, type: AWSAccount_v1 }
   - { name: sso, type: boolean }
   - { name: alias, type: string }
   - { name: quotaLimits, type: AWSQuotaLimits_v1, isList: true }

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -141,6 +141,10 @@ properties:
     description: "Rosa related attributes in the aws account."
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/dependencies/rosa-ocm-1.yml"
+  billingAccount:
+    description: AWS account to be used as the Billing account for ROSA HCP cluster provisioning
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/aws/account-1.yml"
   sso:
     type: boolean
     description: "Enable single sign on for the account. Default is enabled."


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10457

to be able to use a specified aws account as the billing account in a ROSA HCP cluster provisioning flow