### PR TITLE
Add a new field subnets for machine pool 

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -961,6 +961,7 @@ confs:
   - { name: replicas, type: int }
   - { name: autoscale, type: ClusterSpecAutoScale_v1 }
   - { name: subnet, type: string }
+  - { name: subnets, type: string, isList: true }
   - { name: labels, type: json }
   - { name: taints, type: Taint_v1, isList: true }
 

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -284,6 +284,10 @@ properties:
           "$ref": "/common-1.json#/definitions/labels"
         subnet:
           type: string
+        subnets:
+          type: array
+          items:
+            type: string
         taints:
           type: array
           items:


### PR DESCRIPTION
They can span across more than one subnet for multi-az cluster. This way it's backwards compatible until we are ready to migrate to this new field.