### PR TITLE
Allow pulling image from Dynatrace registry.

### DIFF
--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -147,7 +147,8 @@ properties:
       # - quay.io
       # - registry.redhat.io
       # - ECR
-      pattern: '^(quay\.io|registry\.redhat\.io|[^.]+\.dkr\.ecr\.[^.]+\.amazonaws\.com).*$'
+      # - dynatrace.com
+      pattern: '^(quay\.io|registry\.redhat\.io|[^.]+\.dkr\.ecr\.[^.]+\.amazonaws\.com|[^.]+\.live\.dynatrace\.com).*$'
   use_channel_in_image_tag:
     type: boolean
   deployResources:


### PR DESCRIPTION
To support ActiveGate images coming from each Dynatrace tenant, we'd like to allow pulling directly from there. 

Context: [APPSRE-10517](https://issues.redhat.com/browse/APPSRE-10517)