### PR TITLE
aws-iam-role support managed policies

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2167,6 +2167,7 @@ confs:
   - { name: assume_role, type: AssumeRole_v1, isRequired: true }
   - { name: assume_condition, type: json }
   - { name: assume_action, type: string }
+  - { name: policies, type: string, isList: true }
   - { name: inline_policy, type: json }
   - { name: role_policy, type: json }
   - { name: output_resource_name, type: string }

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -461,6 +461,10 @@ oneOf:
     assume_action:
       description: alternate sts call instead of AssumeRole
       type: string
+    policies:
+      type: array
+      items:
+        type: string
     inline_policy:
       type: object
     role_policy:


### PR DESCRIPTION
same functionality intended as for aws-iam-service-account

to be able to associate managed policies to a role.