### PR TITLE
 endPoints: endpoint name must be context unique

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2738,7 +2738,7 @@ confs:
 
 - name: AppEndPoints_v1
   fields:
-  - { name: name, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isContextUnique: true }
   - { name: description, type: string, isRequired: true }
   - { name: url, type: string, isRequired: true }
   - { name: monitoring, type: AppEndPointMonitoring_v1, isList: true }


### PR DESCRIPTION
The `app.endPoints[].name` must be context-unique to be identifiable for automated updates. 

Ticket: [APPSRE-3989](https://issues.redhat.com/browse/APPSRE-3989)