### PR TITLE
APPSRE-7516 flag for saas files holding tests

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2942,6 +2942,7 @@ confs:
   - { name: skipSuccessfulDeployNotifications, type: boolean, isRequired: false }
   - { name: timeout, type: string }
   - { name: publishJobLogs, type: boolean }
+  - { name: hasTestJobs, type: boolean }
   - { name: clusterAdmin, type: boolean }
   - { name: use_channel_in_image_tag, type: boolean }
   - { name: deployResources, type: DeployResources_v1 }

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -140,6 +140,8 @@ properties:
       PipelineRun pods, hence destroying logs.
   publishJobLogs:
     type: boolean
+  hasTestJobs:
+    type: boolean
   clusterAdmin:
     type: boolean
   imagePatterns:

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -141,6 +141,10 @@ properties:
   publishJobLogs:
     type: boolean
   hasTestJobs:
+    description: |
+      Specify whether this saas file is defining any test jobs. Test jobs are treated differently
+      in (auto-)promotions (they use target_config_hash). If not set, then we assume the saas file
+      holds no tests
     type: boolean
   clusterAdmin:
     type: boolean


### PR DESCRIPTION
Cleaning up tech debt. We currently use `publishJobLogs` flag in saas files to identify whether a saas file holds test jobs. This also has effects on whether target_config_hash is used. However, this is very hidden knowledge and caused confusion in the past.

This PR introduces the flag `hasTestJobs` for saas files, which explicitly states whether tests are part of this saas file. This flag will then be used by integrations (e.g., saasherder, SAPM).