### PR TITLE
Revert "APPSRE-7516 flag for saas files holding tests (#700)"

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2942,7 +2942,6 @@ confs:
   - { name: skipSuccessfulDeployNotifications, type: boolean, isRequired: false }
   - { name: timeout, type: string }
   - { name: publishJobLogs, type: boolean }
-  - { name: hasTestJobs, type: boolean }
   - { name: clusterAdmin, type: boolean }
   - { name: use_channel_in_image_tag, type: boolean }
   - { name: deployResources, type: DeployResources_v1 }

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -140,12 +140,6 @@ properties:
       PipelineRun pods, hence destroying logs.
   publishJobLogs:
     type: boolean
-  hasTestJobs:
-    description: |
-      Specify whether this saas file is defining any test jobs. Test jobs are treated differently
-      in (auto-)promotions (they use target_config_hash). If not set, then we assume the saas file
-      holds no tests
-    type: boolean
   clusterAdmin:
     type: boolean
   imagePatterns:


### PR DESCRIPTION
This reverts commit 5db9e797fa44c122ebd8910d8a9e237a66ee7704.

After discussion with @hemslo we decided to refine this a little. This feature is not used yet so it is safe to remove from schema.

I will open a follow up PR