### PR TITLE
APPSRE-7516 redeploy on config change

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3040,6 +3040,7 @@ confs:
 - name: SaasResourceTemplateTargetPromotion_v1
   fields:
   - { name: auto, type: boolean }
+  - { name: reDeployOnPublisherConfigChange, type: boolean }
   - { name: publish, type: string, isList: true }
   - { name: subscribe, type: string, isList: true }
   - { name: soakDays, type: int }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3040,7 +3040,7 @@ confs:
 - name: SaasResourceTemplateTargetPromotion_v1
   fields:
   - { name: auto, type: boolean }
-  - { name: reDeployOnPublisherConfigChange, type: boolean }
+  - { name: redeployOnPublisherConfigChange, type: boolean }
   - { name: publish, type: string, isList: true }
   - { name: subscribe, type: string, isList: true }
   - { name: soakDays, type: int }

--- a/schemas/app-sre/saas-file-target-1.yml
+++ b/schemas/app-sre/saas-file-target-1.yml
@@ -44,6 +44,11 @@ properties:
     properties:
       auto:
         type: boolean
+      reDeployOnPublisherConfigChange:
+        description: |
+          Whether to redeploy if a config change happened in a publisher. This will set
+          target_config_hash in promotion_data. This is mainly intended for test jobs.
+        type: boolean
       publish:
         type: array
         items:

--- a/schemas/app-sre/saas-file-target-1.yml
+++ b/schemas/app-sre/saas-file-target-1.yml
@@ -44,7 +44,7 @@ properties:
     properties:
       auto:
         type: boolean
-      reDeployOnPublisherConfigChange:
+      redeployOnPublisherConfigChange:
         description: |
           Whether to redeploy if a config change happened in a publisher. This will set
           target_config_hash in promotion_data. This is mainly intended for test jobs.


### PR DESCRIPTION
Explicit flag to declare whether a target should be re-deployed if there was a config change in the publisher. Previously, this was defined saas file wide via `publishJobLogs` flags.

Follow-up on https://github.com/app-sre/qontract-schemas/pull/700

cc @hemslo 

If desired, we can also have this flag on saas file level instead (i.e., enable/disable for all targets in a saas file).