### PR TITLE
APPSRE-10767 displayName for saas file

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2923,7 +2923,7 @@ confs:
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true, isSearchable: true, isUnique: true }
-  - { name: display_name, type: string, isRequired: true }
+  - { name: displayName, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
   - { name: app, type: App_v1, isRequired: true }
   - { name: pipelinesProvider, type: PipelinesProvider_v1, isRequired: true, isInterface: true }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2923,6 +2923,7 @@ confs:
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true, isSearchable: true, isUnique: true }
+  - { name: display_name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
   - { name: app, type: App_v1, isRequired: true }
   - { name: pipelinesProvider, type: PipelinesProvider_v1, isRequired: true, isInterface: true }

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -15,7 +15,7 @@ properties:
   name:
     type: string
     maxLength: 39
-  display_name:
+  displayName:
     type: string
   description:
     type: string
@@ -166,7 +166,7 @@ required:
 - "$schema"
 - labels
 - name
-- display_name
+- displayName
 - description
 - app
 - pipelinesProvider

--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -15,6 +15,8 @@ properties:
   name:
     type: string
     maxLength: 39
+  display_name:
+    type: string
   description:
     type: string
   app:
@@ -164,6 +166,7 @@ required:
 - "$schema"
 - labels
 - name
+- display_name
 - description
 - app
 - pipelinesProvider


### PR DESCRIPTION
Due to saas progressive delivery efforts, it is likely that saas file names are more and more used in visualizations. That probably leads to more ppl trying to rename saas files. However, renaming saas files is hard and essentially means migrating targets from one saas to another (including auto promotions being stuck in current ref ...).

We introduce extra field display_name that can be used by visualizations (like backstage and our own grafana dashboard). I.e., we can keep `name` stable as currently we use it like an id.

Note, that `displayName` is required, so any external tooling can be sure it is available. We can add a simple migration script in app-interface to add this to all saas files.