### PR TITLE
extend the imagePattern regex to include registry.connect.redhat.com

### DIFF
--- a/schemas/app-sre/saas-file-2.yml
+++ b/schemas/app-sre/saas-file-2.yml
@@ -149,9 +149,10 @@ properties:
       # allowed patterns:
       # - quay.io
       # - registry.redhat.io
+      # - registry.connect.redhat.com
       # - ECR
       # - dynatrace.com
-      pattern: '^(quay\.io|registry\.redhat\.io|[^.]+\.dkr\.ecr\.[^.]+\.amazonaws\.com|[^.]+\.live\.dynatrace\.com).*$'
+      pattern: '^(quay\.io|registry\.redhat\.io|registry\.connect\.redhat\.com|[^.]+\.dkr\.ecr\.[^.]+\.amazonaws\.com|[^.]+\.live\.dynatrace\.com).*$'
   use_channel_in_image_tag:
     type: boolean
   deployResources:


### PR DESCRIPTION
`registry.connect.redhat.com` hosts a lot of useful images.  This updates the regular expression used to validate allowed image registries by adding support for `registry.connect.redhat.com`. This change ensures that images from this registry are correctly identified and allowed by our validation logic.