### PR TITLE
:sparkles: terraform-resources: MSK ERv2 support

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2078,6 +2078,9 @@ confs:
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
   - { name: users, type: MskSecretParameters_v1, isList: true }
+  - { name: managed_by_erv2, type: boolean}
+  - { name: delete, type: boolean}
+  - { name: module_overrides, type: ExternalResourcesModuleOverrides_v1}
 
 - name: MskSecretParameters_v1
   fields:

--- a/schemas/aws/msk-defaults-1.yml
+++ b/schemas/aws/msk-defaults-1.yml
@@ -18,6 +18,7 @@ properties:
     properties:
       client_subnets:
         type: array
+        minItems: 3
         items:
           type: string
       instance_type:

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -1608,6 +1608,24 @@ oneOf:
         required:
         - name
         - secret
+    managed_by_erv2:
+      type: boolean
+      description: Manage the resource with ERv2
+    delete:
+      type: boolean
+      description: Flag a resource to be deleted
+    module_overrides:
+      type: object
+      additionalProperties: false
+      properties:
+        module_type:
+          type: string
+        image:
+          type: string
+        version:
+          type: string
+        reconcile_timeout_minutes:
+          type: integer
   required:
   - identifier
   - defaults

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -258,17 +258,7 @@ properties:
       ref:
         type: string
   module_overrides:
-    type: object
-    additionalProperties: false
-    properties:
-      module_type:
-        type: string
-      image:
-        type: string
-      version:
-        type: string
-      reconcile_timeout_minutes:
-        type: integer
+    "$ref": "/external-resources/module-overrides-1.yml"
 oneOf:
 - additionalProperties: false
   properties:
@@ -716,17 +706,7 @@ oneOf:
       type: boolean
       description: Flag a resource to be deleted
     module_overrides:
-      type: object
-      additionalProperties: false
-      properties:
-        module_type:
-          type: string
-        image:
-          type: string
-        version:
-          type: string
-        reconcile_timeout_minutes:
-          type: integer
+      "$ref": "/external-resources/module-overrides-1.yml"
   required:
   - identifier
   - defaults
@@ -1615,17 +1595,7 @@ oneOf:
       type: boolean
       description: Flag a resource to be deleted
     module_overrides:
-      type: object
-      additionalProperties: false
-      properties:
-        module_type:
-          type: string
-        image:
-          type: string
-        version:
-          type: string
-        reconcile_timeout_minutes:
-          type: integer
+      "$ref": "/external-resources/module-overrides-1.yml"
   required:
   - identifier
   - defaults


### PR DESCRIPTION
Add external resources version 2 (ERv2) related attributes to the `terraform-resources` MSK  provider.

Ticket: [APPSRE-10598](https://issues.redhat.com/browse/APPSRE-10598)