### PR TITLE
APPSRE-10844 DTP token-spec label

### DIFF
--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -648,9 +648,13 @@ properties:
             properties:
               tenant:
                 type: string
-                description: tenant id to issue token for
+                description: dynatrace tenant id to issue tokens for
+              token-spec:
+                type: string
+                description: name of the DTP token-spec to use for this cluster
             required:
             - tenant
+            - token-spec
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
We need to label our cluster subscriptions accordingly for Dynatrace Token Provider (DTP). By doing so, DTP will provision proper dynatrace tokens for our clusters.

We are adding the `token-spec` field which defines what token spec DTP should use.