### PR TITLE
aws account resetPassword depends on sso being false

### DIFF
--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -159,6 +159,14 @@ properties:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/aws/quota-limits-1.yml"
       description: "AWS quota limits for this account"
+dependencies:
+  resetPasswords:
+    properties:
+      sso:
+        enum:
+        - false
+    required:
+    - sso
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10862

this PR will forbid reset password unless `sso` is set to false.