### PR TITLE
SLOD doc: set prometheusAccess creds as optional

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4288,8 +4288,8 @@ confs:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
   - { name: url, type: string, isRequired: true }
-  - { name: username, type: VaultSecret_v1, isRequired: true }
-  - { name: password, type: VaultSecret_v1, isRequired: true }
+  - { name: username, type: VaultSecret_v1 }
+  - { name: password, type: VaultSecret_v1 }
 
 - name: StatusPage_v1
   fields:

--- a/schemas/app-sre/slo-document-1.yml
+++ b/schemas/app-sre/slo-document-1.yml
@@ -52,8 +52,6 @@ properties:
               "$ref": "/common-1.json#/definitions/vaultSecret"
           required:
           - url
-          - username
-          - password
       required:
       - namespace
   slos:


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-8513

Allows unauthenticated local token-refresher svc access, much like what grafana does.

Something like
```yaml
$schema: /app-sre/slo-document-1.yml

name: rosa-classic-fleet-wide

namespaces:
- namespace:
    $ref: /services/rosa-fleet-wide/classic/namespaces/rosa-fleet-wide.yml
  prometheusAccess:
    url: http://osd-token-refresher-prod.app-sre-observability-production.svc.cluster.local
  SLONamespace:
    $ref: /services/rhobs/observatorium-mst/namespaces/telemeter-prod-01/observatorium-mst-production.yml
```