### PR TITLE
Add ssl_policy alb resource schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2340,6 +2340,7 @@ confs:
   - { name: ingress_cidr_blocks, type: string, isRequired: true, isList: true }
   - { name: ip_address_type, type: string }
   - { name: access_logs, type: boolean }
+  - { name: ssl_policy, type: string }
   - { name: targets, type: NamespaceTerraformResourceALBTargets_v1, isRequired: true, isList: true }
   - { name: rules, type: NamespaceTerraformResourceALBRules_v1, isRequired: true, isList: true }
   - { name: vpc, type: AWSVPC_v1, isRequired: true }

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -1099,6 +1099,38 @@ oneOf:
       - dualstack
     access_logs:
       type: boolean
+    # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html
+    ssl_policy:
+      type: string
+      enum:
+      # TLS security policies
+      - ELBSecurityPolicy-TLS13-1-3-2021-06
+      - ELBSecurityPolicy-TLS13-1-2-2021-06
+      - ELBSecurityPolicy-TLS13-1-2-Res-2021-06
+      - ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06
+      - ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06
+      - ELBSecurityPolicy-TLS13-1-1-2021-06
+      - ELBSecurityPolicy-TLS13-1-0-2021-06 # This will be the defaul value
+      - ELBSecurityPolicy-TLS-1-2-Ext-2018-06
+      - ELBSecurityPolicy-TLS-1-2-2017-01
+      - ELBSecurityPolicy-TLS-1-1-2017-01
+      - ELBSecurityPolicy-2016-08
+      - ELBSecurityPolicy-2015-05
+      # FIPS security policies
+      - ELBSecurityPolicy-TLS13-1-3-FIPS-2023-04
+      - ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04
+      - ELBSecurityPolicy-TLS13-1-2-Res-FIPS-2023-04
+      - ELBSecurityPolicy-TLS13-1-2-Ext2-FIPS-2023-04
+      - ELBSecurityPolicy-TLS13-1-2-Ext1-FIPS-2023-04
+      - ELBSecurityPolicy-TLS13-1-2-Ext0-FIPS-2023-04
+      - ELBSecurityPolicy-TLS13-1-1-FIPS-2023-04
+      - ELBSecurityPolicy-TLS13-1-0-FIPS-2023-04
+      # FS supported policies
+      - ELBSecurityPolicy-FS-1-2-Res-2020-10
+      - ELBSecurityPolicy-FS-1-2-Res-2019-08
+      - ELBSecurityPolicy-FS-1-2-2019-08
+      - ELBSecurityPolicy-FS-1-1-2019-08
+      - ELBSecurityPolicy-FS-2018-06
     targets:
       type: array
       items:


### PR DESCRIPTION
[APPSRE-10769]https://issues.redhat.com/browse/APPSRE-10769

Adding all default values to ssl_policy.
Source: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html#fs-supported-policies

I put it along side with the [aws_lb_listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) values.