### PR TITLE
:sparkles: ERv2: make outputs-secret image and version configurable

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4742,6 +4742,8 @@ confs:
   - { name: tf_state_bucket, type: string, isRequired: false}
   - { name: tf_state_dynamodb_table, type: string, isRequired: false }
   - { name: tf_state_region, type: string, isRequired: false }
+  - { name: outputs_secret_image, type: string, isRequired: true }
+  - { name: outputs_secret_version, type: string, isRequired: true }
 
 - name: ExternalResourcesModule_v1
   datafile: /external-resources/module-1.yml
@@ -4756,6 +4758,8 @@ confs:
   - { name: reconcile_drift_interval_minutes, type: int, isRequired: true}
   - { name: reconcile_timeout_minutes, type: int, isRequired: true}
   - { name: outputs_secret_sync, type: boolean, isRequired: true}
+  - { name: outputs_secret_image, type: string }
+  - { name: outputs_secret_version, type: string }
 
 - name: ExternalResourcesModuleOverrides_v1
   datafile: /external-resources/module-overrides-1.yml
@@ -4766,6 +4770,8 @@ confs:
   - { name: image, type: string, isRequired: false}
   - { name: version, type: string, isRequired: false}
   - { name: reconcile_timeout_minutes, type: int, isRequired: false}
+  - { name: outputs_secret_image, type: string }
+  - { name: outputs_secret_version, type: string }
 
 - name: MaintenanceStatusProvider_v1
   interface: StatusProvider_v1

--- a/schemas/external-resources/module-1.yml
+++ b/schemas/external-resources/module-1.yml
@@ -27,6 +27,12 @@ properties:
     type: integer
   outputs_secret_sync:
     type: boolean
+  outputs_secret_image:
+    type: string
+    description: Docker image to use for the outputs secret container
+  outputs_secret_version:
+    type: string
+    description: Version of the outputs secret container to use
 required:
 - "$schema"
 - provision_provider

--- a/schemas/external-resources/module-overrides-1.yml
+++ b/schemas/external-resources/module-overrides-1.yml
@@ -19,5 +19,11 @@ properties:
     type: string
   reconcile_timeout_minutes:
     type: integer
+  outputs_secret_image:
+    type: string
+    description: Docker image to use for the outputs secret container
+  outputs_secret_version:
+    type: string
+    description: Version of the outputs secret container to use
 required:
 - "$schema"

--- a/schemas/external-resources/settings-1.yml
+++ b/schemas/external-resources/settings-1.yml
@@ -36,6 +36,14 @@ properties:
   vault_secrets_path:
     type: string
 
+  outputs_secret_image:
+    type: string
+    description: Docker image to use for the outputs secret container
+
+  outputs_secret_version:
+    type: string
+    description: Version of the outputs secret container to use
+
 required:
 - "$schema"
 - state_dynamodb_account
@@ -44,3 +52,5 @@ required:
 - workers_cluster
 - workers_namespace
 - vault_secrets_path
+- outputs_secret_image
+- outputs_secret_version


### PR DESCRIPTION
Remove hardcoded `er-outputs-secrets` image and version.

The image and the version must be configured in `/external-resources/settings-1.yml` but can be overridden in `/external-resources/module-1.yml` and `/external-resources/module-overrides-1.yml`

Ticket: [APPSRE-11049](https://issues.redhat.com/browse/APPSRE-11049)