### PR TITLE
Improve terraform-resources provider exclusions

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -34,7 +34,14 @@ confs:
   - { name: jiralert, type: JiralertSettings_v1 }
   - { name: customMessages, type: AppInterfaceCustomMessage_v1, isList: true }
   - { name: costReport, type: CostReportSettings_v1 }
+  - { name: terraformResourcesProviderExclusions, type: TerraformResourcesProviderExclusions_v1, isList: true}
   - { name: terraformResourcesProviderExclusionsByProvisioner, type: TerraformResourcesProviderExclusionsByProvisioner_v1, isList: true}
+
+- name: TerraformResourcesProviderExclusions_v1
+  fields:
+    - { name: provider, type: string, isRequired: true}
+    - { name: excludeProvisioners, type: ExternalResourcesProvisioner_v1 , isList: true, isInterface: true}
+    - { name: excludeAllProvisioners, type: boolean}
 
 - name: TerraformResourcesProviderExclusionsByProvisioner_v1
   fields:

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -265,12 +265,36 @@ properties:
       required:
       - id
       - content
-  terraformResourcesProviderExclusionsByProvisioner:
+  terraformResourcesProviderExclusions:
     type: array
     description: |
-      Object to hold provider exclusions on provisioners.
+      Object to hold provisioner exclusions by provider.
       e.g: RDS is not managed by terraform-resources on app-sre-stage.
       The use-case is the Erv2 resources migration
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        provider:
+          type: string
+        excludeAllProvisioners:
+          type: boolean
+        excludeProvisioners:
+          type: array
+          items:
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef": "/aws/account-1.yml"
+      required:
+        - provider
+      oneOf:
+      - required:
+        - excludeAllProvisioners
+      - required:
+        - excludeProvisioners
+
+  terraformResourcesProviderExclusionsByProvisioner:
+    type: array
+    description: deprecated object. Just here to rollout new changes
     items:
       type: object
       additionalProperties: false
@@ -279,12 +303,14 @@ properties:
           "$ref": "/common-1.json#/definitions/crossref"
           "$schemaRef": "/aws/account-1.yml"
         excludedProviders:
-          type: array
-          items:
-            type: string
+           type: array
+           items:
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef": "/aws/account-1.yml"
       required:
         - provisioner
-        - excludedProviders
+        - excludedProvideres
+
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
Adding both deprecated and new schema is necessary because some integrations rely on the production bundle to work. `integrations_manager` also queries app-interface settings to roll out a new version. 

The deprecated object will be removed after QR is deployed.

Related: https://github.com/app-sre/qontract-reconcile/pull/4748