### PR TITLE
[tf-repo] Allow for newer versions of TF binary

### DIFF
--- a/schemas/aws/terraform-repo-1.yml
+++ b/schemas/aws/terraform-repo-1.yml
@@ -37,7 +37,10 @@ properties:
     enum:
     - "1.4.5"
     - "1.4.7"
-    - "1.5.7" # last version pre hashicorp license change
+    - "1.5.7"
+    - "1.6.6"
+    - "1.7.5"
+    - "1.8.5"
   forceRerunTimestamp:
     description: force a rerun of tf-repo using ISO8601 format which can be grabbed with https://www.utctime.net/
     type: string


### PR DESCRIPTION
Allow users to specify newer versions of Terraform in their tf-repo spec file.

[APPSRE-11103](https://issues.redhat.com/browse/APPSRE-11103)