### PR TITLE
docs(cluster): doc private and internal field description

### DIFF
--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -175,6 +175,7 @@ properties:
         type: boolean
       private:
         type: boolean
+        description: kube API (load balancer) and router is private, access require peering
       storage:
         type: integer
         enum:
@@ -546,6 +547,7 @@ properties:
     type: string
   internal:
     type: boolean
+    description: the cluster is attached to the transit gateway to the VPN, only private cluster can be internal
   disable:
     type: object
     additionalProperties: false


### PR DESCRIPTION
This pull request includes updates to the `schemas/openshift/cluster-1.yml` file to enhance the documentation of the schema properties. The most important changes include adding descriptions to the `private` and `internal` properties to clarify their usage and requirements.

Documentation updates:

* [`schemas/openshift/cluster-1.yml`](diffhunk://#diff-a09b65a72bf4f7457cb806d201e443ec6694862d5769e9066d32db0feb43fbc5R178): Added a description to the `private` property to specify that the kube API (load balancer) and router are private, and access requires peering.
* [`schemas/openshift/cluster-1.yml`](diffhunk://#diff-a09b65a72bf4f7457cb806d201e443ec6694862d5769e9066d32db0feb43fbc5R550): Added a description to the `internal` property to explain that the cluster is attached to the transit gateway to the VPN and that only private clusters can be internal.