### PR TITLE
fix(jumpHost): remove dependencies on automationToken

### DIFF
--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -669,8 +669,6 @@ required:
 - internal
 - auth
 dependencies:
-  jumpHost:
-  - automationToken
   ocm:
   - spec
   - network


### PR DESCRIPTION
During cluster creation, `jumpHost` is added to cluster file creation template for private non internal clusters, `automationToken` is added later by `openshift-cluster-bot` integration. Remove this dependency to avoid validation error `'automationToken' is a dependency of 'jumpHost'`.