### PR TITLE
[tf-repo secrets] update schema to use oneOf

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1891,8 +1891,8 @@ confs:
 
 - name: TerraformRepoVariables_v1
   fields:
-  - { name: inputs, type: VaultSecret_v1, isRequired: true }
-  - { name: outputs, type: VaultSecret_v1, isRequired: true }
+  - { name: inputs, type: VaultSecret_v1 }
+  - { name: outputs, type: VaultSecret_v1 }
 
 - name: NamespaceTerraformProviderResourceGCPProject_v1
   interface: NamespaceExternalResource_v1

--- a/schemas/aws/terraform-repo-1.yml
+++ b/schemas/aws/terraform-repo-1.yml
@@ -51,14 +51,28 @@ properties:
   variables:
     type: object
     description: Vault paths defining where Terraform inputs are read from and where Terraform outputs are written to
-    properties:
-      inputs:
-        "$ref": "/common-1.json#/definitions/vaultSecret"
-      outputs:
-        "$ref": "/common-1.json#/definitions/vaultSecret"
-    required:
-    - inputs
-    - outputs
+    oneOf:
+    - additionalProperties: false
+      properties:
+        inputs:
+          "$ref": "/common-1.json#/definitions/vaultSecret"
+        outputs:
+          "$ref": "/common-1.json#/definitions/vaultSecret"
+      required:
+      - inputs
+      - outputs
+    - additionalProperties: false
+      properties:
+        inputs:
+          "$ref": "/common-1.json#/definitions/vaultSecret"
+      required:
+      - inputs
+    - additionalProperties: false
+      properties:
+        outputs:
+          "$ref": "/common-1.json#/definitions/vaultSecret"
+      required:
+      - outputs
 required:
 - "$schema"
 - account


### PR DESCRIPTION
[APPSRE-11333](https://issues.redhat.com/browse/APPSRE-11333)

Allow our tenants using secrets for inputs/outputs to have the flexibility to specify one or the other, or both. Basically a [logical "disjunction"](https://en.wikipedia.org/wiki/Logical_disjunction)

![image](https://github.com/user-attachments/assets/5fa169a7-be4c-44f5-934f-6e47ece7accb)

Dependent MR:
- [Qontract Reconcile](https://github.com/app-sre/qontract-reconcile/pull/4799)