### PR TITLE
APPSRE-11390 fleet labeler schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1169,6 +1169,25 @@ confs:
   - { name: upgradePolicy, type: ClusterUpgradePolicy_v1 }
   - { name: upgradePolicyTemplate, type: OpenShiftClusterManagerUpgradePolicyTemplate_v1 }
 
+- name: FleetLabelTemplate_v1
+  fields:
+  - { name: path, type: string, isRequired: true, isResource: true, resolveResource: true }
+  - { name: type, type: string }
+  - { name: variables, type: json }
+
+- name: FleetLabelDefault_v1
+  fields:
+  - { name: name, type: string, isRequired: true, isUnique: true }
+  - { name: matchLabels, type: json, isRequired: true }
+  - { name: labelTemplate, type: FleetLabelTemplate_v1 }
+
+- name: FleetCluster_v1
+  fields:
+  - { name: name, type: string, isRequired: true, isUnique: true }
+  - { name: serverUrl, type: string, isRequired: true, isUnique: true }
+  - { name: serverId, type: string, isRequired: true, isUnique: true }
+  - { name: labels, type: json, isRequired: true }
+
 - name: OpenShiftClusterManagerUpgradePolicyCluster_v1
   fields:
   - { name: name, type: string, isRequired: true, isUnique: true }
@@ -1192,6 +1211,17 @@ confs:
   fields:
   - { name: provider, type: string, isRequired: true }
   - { name: enforced, type: boolean, isRequired: true }
+
+- name: FleetLabels_v1
+  datafile: /openshift/fleet-labels-1.yml
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
+  - { name: description, type: string }
+  - { name: ocm, type: OpenShiftClusterManager_v1, isRequired: true }
+  - { name: labelDefaults, type: FleetLabelDefault_v1, isList: true, isRequired: true }
+  - { name: clusters, type: FleetCluster_v1, isList: true, isRequired: true }
 
 - name: OpenShiftClusterManager_v1
   datafile: /openshift/openshift-cluster-manager-1.yml
@@ -4025,6 +4055,7 @@ confs:
   - { name: external_resources_settings_v1, type: ExternalResourcesSettings_v1, isList: true, datafileSchema: /external-resources/settings-1.yml }
   - { name: external_resources_modules_v1, type: ExternalResourcesModule_v1, isList: true, datafileSchema: /external-resources/module-1.yml }
   - { name: app_changelog_v1, type: AppChangelog_v1, isList: true, datafileSchema: /app-sre/app-changelog-1.yml }
+  - { name: fleet_labels_v1, type: FleetLabels_v1, isList: true, datafileSchema: /dynatrace/managed-dynatrace-token-provider-labels-1.yml }
 
 - name: GlitchtipInstance_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1179,7 +1179,7 @@ confs:
   fields:
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: matchSubscriptionLabels, type: json, isRequired: true }
-  - { name: subscriptionLabelTemplate, type: FleetSubscriptionLabelTemplate_v1 }
+  - { name: subscriptionLabelTemplate, type: FleetSubscriptionLabelTemplate_v1, isRequired: true }
 
 - name: FleetCluster_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1169,7 +1169,7 @@ confs:
   - { name: upgradePolicy, type: ClusterUpgradePolicy_v1 }
   - { name: upgradePolicyTemplate, type: OpenShiftClusterManagerUpgradePolicyTemplate_v1 }
 
-- name: FleetLabelTemplate_v1
+- name: FleetSubscriptionLabelTemplate_v1
   fields:
   - { name: path, type: string, isRequired: true, isResource: true, resolveResource: true }
   - { name: type, type: string }
@@ -1178,15 +1178,15 @@ confs:
 - name: FleetLabelDefault_v1
   fields:
   - { name: name, type: string, isRequired: true, isUnique: true }
-  - { name: matchLabels, type: json, isRequired: true }
-  - { name: labelTemplate, type: FleetLabelTemplate_v1 }
+  - { name: matchSubscriptionLabels, type: json, isRequired: true }
+  - { name: subscriptionLabelTemplate, type: FleetSubscriptionLabelTemplate_v1 }
 
 - name: FleetCluster_v1
   fields:
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: serverUrl, type: string, isRequired: true, isUnique: true }
   - { name: serverId, type: string, isRequired: true, isUnique: true }
-  - { name: labels, type: json, isRequired: true }
+  - { name: subscriptionLabels, type: json, isRequired: true }
 
 - name: OpenShiftClusterManagerUpgradePolicyCluster_v1
   fields:
@@ -1219,7 +1219,8 @@ confs:
   - { name: path, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
   - { name: description, type: string }
-  - { name: ocm, type: OpenShiftClusterManager_v1, isRequired: true }
+  - { name: ocms, type: OpenShiftClusterManager_v1, isList: true, isRequired: true }
+  - { name: managedSubscriptionLabelPrefix, type: string, isRequired: true }
   - { name: labelDefaults, type: FleetLabelDefault_v1, isList: true, isRequired: true }
   - { name: clusters, type: FleetCluster_v1, isList: true, isRequired: true }
 
@@ -4055,7 +4056,7 @@ confs:
   - { name: external_resources_settings_v1, type: ExternalResourcesSettings_v1, isList: true, datafileSchema: /external-resources/settings-1.yml }
   - { name: external_resources_modules_v1, type: ExternalResourcesModule_v1, isList: true, datafileSchema: /external-resources/module-1.yml }
   - { name: app_changelog_v1, type: AppChangelog_v1, isList: true, datafileSchema: /app-sre/app-changelog-1.yml }
-  - { name: fleet_labels_v1, type: FleetLabels_v1, isList: true, datafileSchema: /dynatrace/managed-dynatrace-token-provider-labels-1.yml }
+  - { name: fleet_labels_v1, type: FleetLabels_v1, isList: true, datafileSchema: /openshift/fleet-labels-1.yml }
 
 - name: GlitchtipInstance_v1
   fields:

--- a/schemas/openshift/fleet-labels-1.yml
+++ b/schemas/openshift/fleet-labels-1.yml
@@ -1,0 +1,84 @@
+---
+"$schema": /metaschema-1.json
+version: '1.0'
+type: object
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /openshift/fleet-labels-1.yml
+  name:
+    type: string
+  description:
+    type: string
+  ocm:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/openshift/openshift-cluster-manager-1.yml"
+  labelDefaults:
+    description: List of default labels to apply to clusters by external configuration labels
+    type: array
+    items:
+      oneOf:
+      - additionalProperties: false
+        properties:
+          name:
+            type: string
+          matchLabels:
+            type: object
+            additionalProperties:
+              type: string
+          labelTemplate:
+            type: object
+            properties:
+              path:
+                "$ref": "/common-1.json#/definitions/resourceref"
+              type:
+                type: string
+                enum:
+                - jinja2
+                - extracurlyjinja2
+              variables:
+                type: object
+            required:
+            - path
+        required:
+        - name
+        - matchLabels
+        - labelTemplate
+  clusters:
+    description: List of clusters to define dynatrace token provider labels for
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          description: cluster name
+          type: string
+        serverUrl:
+          description: cluster server url
+          type: string
+          format: uri
+        clusterId:
+          description: cluster ID
+          type: string
+        labels:
+          type: object
+          additionalProperties: false
+          properties:
+            tenant:
+              type: string
+            token-spec:
+              type: string
+      required:
+      - name
+      - serverUrl
+      - clusterId
+      - labels
+required:
+- name
+- ocm
+- labelDefaults
+- clusters

--- a/schemas/openshift/fleet-labels-1.yml
+++ b/schemas/openshift/fleet-labels-1.yml
@@ -13,40 +13,44 @@ properties:
     type: string
   description:
     type: string
-  ocm:
-    "$ref": "/common-1.json#/definitions/crossref"
-    "$schemaRef": "/openshift/openshift-cluster-manager-1.yml"
+  managedSubscriptionLabelPrefix:
+    type: string
+  ocms:
+    type: array
+    items:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/openshift/openshift-cluster-manager-1.yml"
   labelDefaults:
     description: List of default labels to apply to clusters by external configuration labels
     type: array
     items:
-      oneOf:
-      - additionalProperties: false
-        properties:
-          name:
+      additionalProperties: false
+      type: object
+      properties:
+        name:
+          type: string
+        matchSubscriptionLabels:
+          type: object
+          additionalProperties:
             type: string
-          matchLabels:
-            type: object
-            additionalProperties:
+        subscriptionLabelTemplate:
+          type: object
+          properties:
+            path:
+              "$ref": "/common-1.json#/definitions/resourceref"
+            type:
               type: string
-          labelTemplate:
-            type: object
-            properties:
-              path:
-                "$ref": "/common-1.json#/definitions/resourceref"
-              type:
-                type: string
-                enum:
-                - jinja2
-                - extracurlyjinja2
-              variables:
-                type: object
-            required:
-            - path
-        required:
-        - name
-        - matchLabels
-        - labelTemplate
+              enum:
+              - jinja2
+              - extracurlyjinja2
+            variables:
+              type: object
+          required:
+          - path
+      required:
+      - name
+      - matchSubscriptionLabels
+      - subscriptionLabelTemplate
   clusters:
     description: List of clusters to define dynatrace token provider labels for
     type: array
@@ -64,7 +68,7 @@ properties:
         clusterId:
           description: cluster ID
           type: string
-        labels:
+        subscriptionLabels:
           type: object
           additionalProperties: false
           properties:
@@ -76,9 +80,10 @@ properties:
       - name
       - serverUrl
       - clusterId
-      - labels
+      - subscriptionLabels
 required:
 - name
-- ocm
+- ocms
+- managedSubscriptionLabelPrefix
 - labelDefaults
 - clusters


### PR DESCRIPTION
Schema for the Fleet Labeler Integration.

[Design doc](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/fleet-labeler.md?ref_type=heads)

[Example Use](https://gitlab.cee.redhat.com/service/sre-capabilities/-/merge_requests/2223)

Note, I would like to add this schema to main ahead of the integration implementation itself, as it would ease development by not needing to stay in sync with schema changes. Further, it helps to separate implementation into incremental PRs instead of single large PR. The schema does not change any existing behavior and is fully dedicated to fleet labeler, so merging ahead has no real downsides.
