### PR TITLE
:coffin: remove unused per-jira-board sharding strategy

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3675,7 +3675,6 @@ confs:
       per-openshift-cluster: OpenshiftClusterSharding_v1
       per-ocm-organization: OCMOrganizationSharding_v1
       per-cloudflare-dns-zone: CloudflareDNSZoneSharding_v1
-      per-jira-board: JiraBoardSharding_v1
   fields:
   - { name: strategy, type: string, isRequired: true}
 
@@ -3739,19 +3738,6 @@ confs:
 - name: AWSAccountShardSpecOverride_v1
   fields:
     - { name: shard, type: AWSAccount_v1, isRequired: true}
-    - { name: imageRef, type: string, isRequired: false }
-    - { name: resources, type: DeployResources_v1, isRequired: false }
-    - { name: disabled, type: boolean, isRequired: false}
-
-- name: JiraBoardSharding_v1
-  interface: IntegrationSharding_v1
-  fields:
-    - { name: strategy, type: string, isRequired: true }
-    - { name: shardSpecOverrides, type: JiraBoardShardSpecOverride_v1, isList: true}
-
-- name: JiraBoardShardSpecOverride_v1
-  fields:
-    - { name: shard, type: JiraBoard_v1, isRequired: true}
     - { name: imageRef, type: string, isRequired: false }
     - { name: resources, type: DeployResources_v1, isRequired: false }
     - { name: disabled, type: boolean, isRequired: false}

--- a/schemas/app-sre/integration-sharding-1.yml
+++ b/schemas/app-sre/integration-sharding-1.yml
@@ -15,7 +15,6 @@ properties:
     enum:
       - per-aws-account
       - per-cloudflare-dns-zone
-      - per-jira-board
       - per-openshift-cluster
       - per-ocm-organization
       - static


### PR DESCRIPTION
Remove `per-jira-board` sharding strategy because we want to use `static` instead.

Ticket: [APPSRE-11408](https://issues.redhat.com/browse/APPSRE-11408)