### PR TITLE
elasticache: add service updates related fields

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2852,7 +2852,7 @@ confs:
   fields:
   - { name: schema, type: string, isRequired: true }
   - { name: path, type: string, isRequired: true }
-  - { name: labels, type: json }
+  - { name: labels, type: json, isRequired: true }
   - { name: name, type: string, isRequired: true, isSearchable: true, isUnique: true }
   - { name: description, type: string, isRequired: true }
   - { name: product, type: Product_v1, isRequired: true }

--- a/schemas/aws/elasticache-defaults-1.yml
+++ b/schemas/aws/elasticache-defaults-1.yml
@@ -128,9 +128,24 @@ properties:
     enum:
     - preferred
     - required
+  service_updates_enabled:
+    type: boolean
+    description: "Enable or disable automatic service updates for the ElastiCache cluster. Default: true"
+  service_updates_severities:
+    type: array
+    description: "A list of the service update severity levels that can be applied for the replication group. Default: ['critical', 'important']"
+    items:
+      type: string
+      enum:
+      - critical
+      - important
+      - medium
+      - low
+  service_updates_cooldown_days:
+    type: integer
+    description: "The number of days that ElastiCache will wait before applying a service update to the replication group. Default: 14 days for production, 7 days for staging, and 5 days for others."
 required:
 - "$schema"
-- auto_minor_version_upgrade
 - engine
 - engine_version
 - node_type


### PR DESCRIPTION
Add some service updates related fields to the Elasticache resource files.
Additionally, `auto_minor_version_upgrade` isn't required anymore and will default to `true`.

Ticket: [APPSRE-11432](https://issues.redhat.com/browse/APPSRE-11432)