### PR TITLE
APPSRE-11326 support multiple image waits in saas

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3038,6 +3038,7 @@ confs:
   - { name: parameters, type: json }
   - { name: secretParameters, type: SaasSecretParameters_v1, isList: true }
   - { name: upstream, type: SaasResourceTemplateTargetUpstream_v1 }
+  - { name: images, type: SaasResourceTemplateTargetImage_v1, isList: true }
   - { name: image, type: SaasResourceTemplateTargetImage_v1 }
   - { name: disable, type: boolean }
   - { name: delete, type: boolean }

--- a/schemas/app-sre/saas-file-target-1.yml
+++ b/schemas/app-sre/saas-file-target-1.yml
@@ -105,6 +105,22 @@ properties:
     required:
     - instance
     - name
+  images:
+    type: array
+    description: wait for all images to exist before triggering a deployment
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        org:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/dependencies/quay-org-1.yml"
+        name:
+          type: string
+          description: image repository name
+      required:
+      - org
+      - name
   image:
     type: object
     description: wait for image to exist before triggering a deployment


### PR DESCRIPTION
Saas triggers currently allow us to wait for a single image. However, in Konflux we cannot stuff multiple images into a single pipeline, i.e., we must wait for multiple images to wait.

We introduce the `images` field where tenants can specify a list of images to wait for. We keep the old `image` field for backwards compatibility. We will then gradually move `image` usage towards `images`. We will remove `image` once everything is migrated to new list schema.
