### PR TITLE
add bound_service_account_namespace_selector to k8s role for vault

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -346,6 +346,7 @@ confs:
   - { name: audience, type: string }
   - { name: bound_service_account_names, type: string, isList: true, isRequired: true }
   - { name: bound_service_account_namespaces, type: string, isList: true, isRequired: true }
+  - { name: bound_service_account_namespace_selector, type: string, isRequired: true }
   - { name: token_ttl, type: string, isRequired: true }
   - { name: token_max_ttl, type: string, isRequired: true }
   - { name: token_explicit_max_ttl, type: string, isRequired: true }

--- a/schemas/vault-config/role-1.yml
+++ b/schemas/vault-config/role-1.yml
@@ -217,6 +217,8 @@ properties:
           type: array
           items:
             type: string
+        bound_service_account_namespace_selector:
+          type: string
         token_ttl:
           type: string
           pattern: '^\d+$'
@@ -249,6 +251,7 @@ properties:
       - alias_name_source
       - bound_service_account_names
       - bound_service_account_namespaces
+      - bound_service_account_namespace_selector
       - token_ttl
       - token_max_ttl
       - token_explicit_max_ttl


### PR DESCRIPTION
Add `bound_service_account_namespace_selector` to schema.  Required by vault-manager to successfully reconcile k8s auth method roles.

```
[bound_service_account_namespace_selector](https://developer.hashicorp.com/vault/api-docs/auth/kubernetes#bound_service_account_namespace_selector) (string: "") - A label selector for Kubernetes namespaces allowed to access this role. Accepts either a JSON or YAML object. The value should be of type [LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta). Currently, label selectors with matchExpressions are not supported. To use label selectors, Vault must have permission to read namespaces on the Kubernetes cluster. If set with bound_service_account_namespaces, the conditions are ORed.
```

