### PR TITLE
APPSRE-11487 Allow to query namespaces related to an account

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1372,6 +1372,12 @@ confs:
     synthetic:
       schema: /aws/policy-1.yml
       subAttr: account
+  - name: namespaces
+    type: Namespace_v1
+    isList: true
+    synthetic:
+      schema: /openshift/namespace-1.yml
+      subAttr: externalResources.provisioner
 
 - name: AWSAutomationRole_v1
   fields:


### PR DESCRIPTION
ie having externalResources deployed on that account

[APPSRE-11487](https://issues.redhat.com/browse/APPSRE-11487)

This will allow this type of queries:
```
{
  accounts: awsaccounts_v1(filter: { name: "{{ accountRequest.name }}" }) {
    name
    terraformState {
      provider
    }
    namespaces {
      name
      externalResources {
        ... on NamespaceTerraformProviderResourceAWS_v1 {
          provisioner {
            name
          }
          resources {
            provider
            identifier
            output_resource_name
          }
        }
      }
    }
  }
}
```