### PR TITLE
elasticache: drop redis 7 support

### DIFF
--- a/schemas/aws/parameter-group-1.yml
+++ b/schemas/aws/parameter-group-1.yml
@@ -28,7 +28,6 @@ properties:
     - postgres17
     - redis5.0
     - redis6.x
-    - redis7
     - valkey7
     - valkey8
   description:


### PR DESCRIPTION
In favor of Valkey 7+, we won't support Redis 7 anymore.

Ticket: [APPSRE-11489](https://issues.redhat.com/browse/APPSRE-11489)