### PR TITLE
APPSRE-11544 remove saas target image

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3076,7 +3076,6 @@ confs:
   - { name: secretParameters, type: SaasSecretParameters_v1, isList: true }
   - { name: upstream, type: SaasResourceTemplateTargetUpstream_v1 }
   - { name: images, type: SaasResourceTemplateTargetImage_v1, isList: true }
-  - { name: image, type: SaasResourceTemplateTargetImage_v1 }
   - { name: disable, type: boolean }
   - { name: delete, type: boolean }
 

--- a/schemas/app-sre/saas-file-target-1.yml
+++ b/schemas/app-sre/saas-file-target-1.yml
@@ -121,20 +121,6 @@ properties:
       required:
       - org
       - name
-  image:
-    type: object
-    description: wait for image to exist before triggering a deployment
-    additionalProperties: false
-    properties:
-      org:
-        "$ref": "/common-1.json#/definitions/crossref"
-        "$schemaRef": "/dependencies/quay-org-1.yml"
-      name:
-        type: string
-        description: image repository name
-    required:
-    - org
-    - name
   disable:
     type: boolean
   delete:


### PR DESCRIPTION
Time to say goodbye to `saas_file.resource_template.target.image` in favor of the new `images` (https://github.com/app-sre/qontract-schemas/pull/761).

All streams are aware if this change. App-interface data has been migrated to new `images` already.