### PR TITLE
APPSRE-11390 store subscription_id in inventory

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1183,10 +1183,10 @@ confs:
 
 - name: FleetCluster_v1
   fields:
-  - { name: name, type: string, isRequired: true }
-  - { name: serverUrl, type: string, isRequired: true }
-  - { name: clusterId, type: string, isRequired: true }
-  - { name: subscriptionId, type: string, isRequired: true }
+  - { name: name, type: string, isRequired: true, isUnique: true }
+  - { name: serverUrl, type: string, isRequired: true, isUnique: true }
+  - { name: clusterId, type: string, isRequired: true, isUnique: true }
+  - { name: subscriptionId, type: string, isRequired: true, isUnique: true }
   - { name: subscriptionLabels, type: json, isRequired: true }
 
 - name: OpenShiftClusterManagerUpgradePolicyCluster_v1

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1183,9 +1183,9 @@ confs:
 
 - name: FleetCluster_v1
   fields:
-  - { name: name, type: string, isRequired: true, isUnique: true }
-  - { name: serverUrl, type: string, isRequired: true, isUnique: true }
-  - { name: clusterId, type: string, isRequired: true, isUnique: true }
+  - { name: name, type: string, isRequired: true }
+  - { name: serverUrl, type: string, isRequired: true }
+  - { name: clusterId, type: string, isRequired: true }
   - { name: subscriptionId, type: string, isRequired: true }
   - { name: subscriptionLabels, type: json, isRequired: true }
 

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1186,6 +1186,7 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: serverUrl, type: string, isRequired: true, isUnique: true }
   - { name: clusterId, type: string, isRequired: true, isUnique: true }
+  - { name: subscriptionId, type: string, isRequired: true }
   - { name: subscriptionLabels, type: json, isRequired: true }
 
 - name: OpenShiftClusterManagerUpgradePolicyCluster_v1

--- a/schemas/openshift/fleet-labels-spec-1.yml
+++ b/schemas/openshift/fleet-labels-spec-1.yml
@@ -66,6 +66,9 @@ properties:
         clusterId:
           description: cluster ID
           type: string
+        subscriptionId:
+          description: subscription ID
+          type: string
         subscriptionLabels:
           type: object
           additionalProperties:

--- a/schemas/openshift/fleet-labels-spec-1.yml
+++ b/schemas/openshift/fleet-labels-spec-1.yml
@@ -77,6 +77,7 @@ properties:
       - name
       - serverUrl
       - clusterId
+      - subscriptionId
       - subscriptionLabels
 required:
 - name


### PR DESCRIPTION
Fleet labeler needs the subscription ID to properly set subscription labels for clusters.