### PR TITLE
Adds `dev` to the list of valid ref

### DIFF
--- a/schemas/app-sre/saas-file-target-1.yml
+++ b/schemas/app-sre/saas-file-target-1.yml
@@ -37,7 +37,7 @@ properties:
       - include
   ref:
     type: string
-    pattern: '^([0-9a-f]{40}|master|main|internal|stable|release-4\.\d+)$'
+    pattern: '^([0-9a-f]{40}|master|main|internal|stable|dev|release-4\.\d+)$'
   promotion:
     type: object
     additionalProperties: false


### PR DESCRIPTION
We started a big change in one of our services that lead us to start the service from scratch, but keeping the same repository.
Our previous iteration is still in prod and so is still on the main branch in case any change is required.
We have been working on the `dev` branch and we're ready to start deploying it on stage along with the previous version.

