### PR TITLE
Bot org_username needs to accept gitlab usernames

### DIFF
--- a/schemas/access/bot-1.yml
+++ b/schemas/access/bot-1.yml
@@ -16,7 +16,7 @@ properties:
   description:
     type: string
   org_username:
-    "$ref": "/common-1.json#/definitions/identifier"
+    "$ref": "/common-1.json#/definitions/gitlabUsername"
   github_username:
     "$ref": "/common-1.json#/definitions/botIdentifier"
   openshift_serviceaccount:

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -48,6 +48,10 @@
       "type": "string",
       "pattern": "^[A-Za-z0-9][A-Za-z0-9-_\\.]{0,30}[A-Za-z0-9]$"
     },
+    "gitlabUsername": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9-_\\.]{0,253}[A-Za-z0-9-_]$"
+    },
     "longIdentifier": {
       "type": "string",
       "pattern": "^[a-z0-9][a-z0-9-]{3,63}[a-z0-9]$"


### PR DESCRIPTION
see rules in https://docs.gitlab.com/user/profile/

In particular this is important with project bots, with fancy names like `project_111131_bot_280c1319501ea648fc40189519f2d430`

related to APPSRE-11467