### PR TITLE
APPSRE-11584 fleet-labeler label synch flag

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1221,6 +1221,7 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
   - { name: description, type: string }
   - { name: ocm, type: OpenShiftClusterManager_v1, isRequired: true }
+  - { name: disableLabelSynchronization, type: boolean }
   - { name: managedSubscriptionLabelPrefix, type: string, isRequired: true }
   - { name: labelDefaults, type: FleetLabelDefault_v1, isList: true, isRequired: true }
   - { name: clusters, type: FleetCluster_v1, isList: true, isRequired: true }

--- a/schemas/openshift/fleet-labels-spec-1.yml
+++ b/schemas/openshift/fleet-labels-spec-1.yml
@@ -18,6 +18,12 @@ properties:
   ocm:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/openshift/openshift-cluster-manager-1.yml"
+  disableLabelSynchronization:
+    description: |
+      Disable the synchronization of labels from the subscription to the cluster.
+      This is useful if you want to let fleet labeler render the inventory first and
+      investigate/change any desired labels manually before the synchronization starts.
+    type: boolean
   labelDefaults:
     description: List of default labels to apply to clusters by external configuration labels
     type: array


### PR DESCRIPTION
Extra flag for the fleet-labeler integration. 

Disable the synchronization of labels from the subscription to the cluster. This is useful if you want to let fleet labeler render the inventory first and investigate/change any desired labels manually before the first synchronization starts.