### PR TITLE
APPSRE-11584 enforce DTP v2 labeling

### DIFF
--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -648,15 +648,19 @@ properties:
             description: request dynatrace-token-provider to issue a token for the cluster
             additionalProperties: false
             properties:
-              tenant:
-                type: string
-                description: dynatrace tenant id to issue tokens for
-              token-spec:
-                type: string
-                description: name of the DTP token-spec to use for this cluster
-            required:
-            - tenant
-            - token-spec
+              v2:
+                type: object
+                additionalProperties: false
+                properties:
+                  tenant:
+                    type: string
+                    description: dynatrace tenant id to issue tokens for
+                  token-spec:
+                    type: string
+                    description: name of the DTP token-spec to use for this cluster
+                required:
+                - tenant
+                - token-spec
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
DTP labeling schema now contains dtp version. That makes it easier for us to stay backwards compatible, as we will see bigger label schema changes in DTP soon.

```
sre-capabilities.dtp.v{X}.{config-labels}
```