### PR TITLE
APPSRE-11583 Fleet Labeler use OCMEnv

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1220,7 +1220,7 @@ confs:
   - { name: path, type: string, isRequired: true }
   - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
   - { name: description, type: string }
-  - { name: ocm, type: OpenShiftClusterManager_v1, isRequired: true }
+  - { name: ocmEnv, type: OpenShiftClusterManagerEnvironment_v1, isRequired: true }
   - { name: dryRunLabelSynchronization, type: boolean }
   - { name: managedSubscriptionLabelPrefix, type: string, isRequired: true }
   - { name: labelDefaults, type: FleetLabelDefault_v1, isList: true, isRequired: true }

--- a/schemas/openshift/fleet-labels-spec-1.yml
+++ b/schemas/openshift/fleet-labels-spec-1.yml
@@ -15,9 +15,9 @@ properties:
     type: string
   managedSubscriptionLabelPrefix:
     type: string
-  ocm:
+  ocmEnv:
     "$ref": "/common-1.json#/definitions/crossref"
-    "$schemaRef": "/openshift/openshift-cluster-manager-1.yml"
+    "$schemaRef": "/openshift/openshift-cluster-manager-environment-1.yml"
   dryRunLabelSynchronization:
     description: |
       Disable the synchronization of labels from the subscription to the cluster.
@@ -87,7 +87,7 @@ properties:
       - subscriptionLabels
 required:
 - name
-- ocm
+- ocmEnv
 - managedSubscriptionLabelPrefix
 - labelDefaults
 - clusters


### PR DESCRIPTION
Fleet Labeler should use `OCMEnvironment` directly instead of going via `ClusterManager`. We currently have no need for any `ClusterManager` attributes.

This will also ease spec validation in Fleet Labeler, as OCMEnvironment is more strict in attributes.