### PR TITLE
aws-account-request: add accountFileTargetPath

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1406,6 +1406,7 @@ confs:
   - { name: supportedDeploymentRegions, type: string, isList: true }
   - { name: uid, type: string }
   - { name: additionalFeatures, type: json }
+  - { name: accountFileTargetPath, type: string }
 
 - name: AWSQuotaLimits_v1
   datafile: /aws/quota-limits-1.yml

--- a/schemas/aws/account-request-1.yml
+++ b/schemas/aws/account-request-1.yml
@@ -50,6 +50,10 @@ properties:
     type: object
     description: |
       Enable/disable additional features for this account. See account template for all available feature options.
+  accountFileTargetPath:
+    type: string
+    description: |
+      Specifying the target path for the new account file. Default: `/aws/<account_name>/account.yml`
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
The resulting account file path in app-interface must be configurable. This PR adds `accountFileTargetPath` to customize the path.

Ticket: [APPSRE-11540](https://issues.redhat.com/browse/APPSRE-11540)