### PR TITLE
:sparkles: aws-account: add organizationAccountTags

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1350,6 +1350,7 @@ confs:
   - { name: alias, type: string }
   - { name: quotaLimits, type: AWSQuotaLimits_v1, isList: true }
   - { name: organization, type: AWSOrganization_v1 }
+  - { name: organizationAccountTags, type: json }
   - name: account_requests
     type: AWSAccountRequest_v1
     isList: true

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -162,7 +162,7 @@ properties:
       description: "AWS quota limits for this account"
   organizationAccountTags:
     "$ref": "/common-1.json#/definitions/labels"
-    description: "Apply these tags to all accounts in the organization. This is useful for tagging all accounts in the organization with the same tags."
+    description: "For payer accounts only! Apply these tags to all accounts in the organization. This is useful for tagging all accounts in the organization with the same tags."
 dependencies:
   resetPasswords:
     properties:

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -160,6 +160,9 @@ properties:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/aws/quota-limits-1.yml"
       description: "AWS quota limits for this account"
+  organizationAccountTags:
+    "$ref": "/common-1.json#/definitions/labels"
+    description: "Apply these tags to all accounts in the organization. This is useful for tagging all accounts in the organization with the same tags."
 dependencies:
   resetPasswords:
     properties:
@@ -168,6 +171,11 @@ dependencies:
         - false
     required:
     - sso
+  organizationAccountTags:
+    properties:
+      organization:
+        enum:
+        - null
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
This PR adds `organizationAccountTags` to the `/aws/account-1.yml` schema. This enables the `aws-account-manager` to use this attribute to tag all accounts within a payer account with common tags, e.g. `cost-center: xxx`

Ticket: [APPSRE-11633](https://issues.redhat.com/browse/APPSRE-11633)