### PR TITLE
[AFL] Add optional title, description properties to metaschema

### DIFF
--- a/schemas/metaschema-1.json
+++ b/schemas/metaschema-1.json
@@ -2,6 +2,8 @@
   "$schema": "/json-schema-spec-draft-06.json",
   "version": "1.0",
   "type": "object",
+  "title": "metaschema",
+  "description": "Defines the structure of a qontract-schema",
   "properties": {
     "$schema": {
       "type": "string",
@@ -14,6 +16,12 @@
     },
     "labels": {
       "type": "object"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
     },
     "additionalProperties": {
       "type": "boolean",


### PR DESCRIPTION
AFL - Automated Feature List
---

This MR adds optional title and description properties to `metaschema-1.json` child schemas. The MR also adds title and description pairs to `metaschema-1.json`, which are already defined in `/json-schema-spec-draft-06.json`.

The design doc did not include title field. I think it will be easier to source JSON/YAML property values versus depending on the filename and extracting the correct content. 