### PR TITLE
[ERv2] support switchover timeout for blue/green deployment

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2176,6 +2176,7 @@ confs:
   fields:
   - { name: enabled, type: boolean }
   - { name: switchover, type: boolean }
+  - { name: switchover_timeout, type: int }
   - { name: delete, type: boolean }
   - { name: target, type: RDSBlueGreenDeploymentTarget_v1 }
 

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -64,6 +64,16 @@ properties:
         type: boolean
       switchover:
         type: boolean
+      switchover_timeout:
+        type: integer
+        minimum: 30
+        maximum: 3600
+        description: |
+          The amount of time, in seconds, for the switchover to complete.
+          If the switchover takes longer than the specified duration,
+          then any changes are rolled back, and no changes are made to the environments.
+          The default timeout period is 300 seconds (5 minutes).
+          This is the max allowed downtime, use it to plan maintenance window.
       delete:
         type: boolean
       target:
@@ -562,6 +572,8 @@ oneOf:
           type: boolean
         switchover:
           type: boolean
+        switchover_timeout:
+          type: integer
         delete:
           type: boolean
         target:


### PR DESCRIPTION
Default 5 mins is not enough for some RDS instances. Support `switchover_timeout` to customize it.

[APPSRE-11434](https://issues.redhat.com/browse/APPSRE-11434)