### PR TITLE
Breaking change that adds Artifact Registry support to App Interface

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -438,7 +438,8 @@ confs:
   - { name: description, type: string, isRequired: true }
   - { name: managedTeams, type: string, isList: true, isRequired: true }
   - { name: automationToken, type: VaultSecret_v1 }
-  - { name: pushCredentials, type: VaultSecret_v1 }
+  - { name: gcrPushCredentials, type: VaultSecret_v1 }
+  - { name: artifactPushCredentials, type: VaultSecret_v1, isRequired: true }
 
 - name: GrafanaDashboardUrls_v1
   fields:
@@ -2778,6 +2779,16 @@ confs:
   - { name: public, type: boolean, isRequired: true }
   - { name: mirror, type: ContainerImageMirror_v1, isRequired: false }
 
+- name: AppArtifactRegistryMirrorsItems_v1
+  fields:
+  - { name: imageURL, type: string, isRequired: true }
+  - { name: mirror, type: ContainerImageMirror_v1, isRequired: true }
+
+- name: AppArtifactRegistryMirrors_v1
+  fields:
+  - { name: project, type: GcpProject_v1, isRequired: true }
+  - { name: items, type: AppArtifactRegistryMirrorsItems_v1, isRequired: true, isList: true }
+
 - name: ContainerImageMirror_v1
   datafile: /dependencies/container-image-mirror-1.yml
   fields:
@@ -2969,6 +2980,7 @@ confs:
   - { name: serviceNotifications, type: Owner_v1, isList: true }
   - { name: dependencies, type: Dependency_v1, isList: true }
   - { name: gcrRepos, type: AppGcrRepos_v1, isList: true }
+  - { name: artifactRegistryMirrors, type: AppArtifactRegistryMirrors_v1, isList: true }
   - { name: quayRepos, type: AppQuayRepos_v1, isList: true }
   - { name: escalationPolicy, type: AppEscalationPolicy_v1, isRequired: true }
   - { name: endPoints, type: AppEndPoints_v1, isList: true }

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -119,6 +119,32 @@ properties:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/dependencies/dependency-1.yml"
 
+  artifactRegistryMirrors:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        project:
+          "$ref": "/common-1.json#/definitions/crossref"
+          "$schemaRef": "/gcp/project-1.yml"
+        items:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              imageURL:
+                type: string
+              mirror:
+                "$schemaRef": "/dependencies/container-image-mirror-1.yml"
+            required:
+            - imageURL
+            - mirror
+      required:
+      - project
+      - items
+
   gcrRepos:
     type: array
     items:

--- a/schemas/gcp/project-1.yml
+++ b/schemas/gcp/project-1.yml
@@ -21,7 +21,9 @@ properties:
     type: string
   automationToken:
     "$ref": "/common-1.json#/definitions/vaultSecret"
-  pushCredentials:
+  gcrPushCredentials:
+    "$ref": "/common-1.json#/definitions/vaultSecret"
+  artifactPushCredentials:
     "$ref": "/common-1.json#/definitions/vaultSecret"
 required:
 - "$schema"


### PR DESCRIPTION
[APPSRE-11221](https://issues.redhat.com/browse/APPSRE-11221)

Adds Artifact Registry support to App-Interface. This is necessarily a breaking change due to renaming of existing properties to conform both AR & GCR support (although GCR is now just using AR under the hood and proxied to the existing gcr.io endpoints).

QR PR: https://github.com/app-sre/qontract-reconcile/pull/4931