### PR TITLE
glitchtip-project: app is required

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4211,7 +4211,7 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: projectId, type: string }
   - { name: description, type: string, isRequired: true }
-  - { name: app, type: App_v1 }
+  - { name: app, type: App_v1, isRequired: true }
   - { name: platform, type: string, isRequired: true }
   - { name: teams, type: GlitchtipTeam_v1, isRequired: true, isList: true }
   - { name: organization, type: GlitchtipOrganization_v1, isRequired: true }

--- a/schemas/dependencies/glitchtip-project-1.yml
+++ b/schemas/dependencies/glitchtip-project-1.yml
@@ -121,3 +121,4 @@ required:
 - platform
 - teams
 - organization
+- app


### PR DESCRIPTION
Mark `glitchtip-project.app` attribute as required. This will help us find the Jira board for a Glitchtip project in case it's spamming Glitchtip with events.

Ticket: https://issues.redhat.com/browse/APPSRE-11684