### PR TITLE
APPSRE-11690 new AUS sector setting: maxParallelUpgrades

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1154,6 +1154,7 @@ confs:
 - name: OpenShiftClusterManagerSector_v1
   fields:
   - { name: name, type: string, isRequired: true, isContextUnique: true }
+  - { name: maxParallelUpgrades, type: string }
   - { name: dependencies, type: OpenShiftClusterManagerSectorDependencies_v1, isList: true }
 
 - name: OpenShiftClusterManagerUpgradePolicyTemplate_v1

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -128,6 +128,13 @@ properties:
         name:
           description: sector name
           type: string
+        maxParallelUpgrades:
+          description: |
+            The maximum number of upgrades that can happen at any given time within that sector.
+            This string must contain an bare integer or percentage of the number of clusters in the sector.
+            Default is "100%", so any number of parallel upgrades is allowed.
+          type: string
+          pattern: '^([0-9]{1,2}|100)\%?$'
         dependencies:
           description: list of sectors this one is depending on
           type: array


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-11690

This setting allows to limit the number of concurrent upgrades within a sector.

We can the drop mutexes (only one upgrade at a time) and speed up upgrades on large sectors