### PR TITLE
feat(erv2): limit allocated_storage range for blue_green_deployment

### DIFF
--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -88,6 +88,12 @@ properties:
             type: string
           allocated_storage:
             type: integer
+            description: |
+              The amount of storage in gibibytes (GiB) to allocate for the green DB instance.
+              You can choose to increase or decrease the allocated storage on the green DB instance.
+              Range from 20GiB to 16TiB (20-16384).
+            minimum: 20
+            maximum: 16384
           storage_type:
             type: string
             enum:


### PR DESCRIPTION
Specify range in schema to avoid runtime error

```text
botocore.exceptions.ClientError: An error occurred (InvalidParameterValue) when calling the CreateBlueGreenDeployment operation: The specified allocated storage of 10 is not valid. Specify an allocated storage value between 20 and 16384
```

[APPSRE-11434](https://issues.redhat.com/browse/APPSRE-11434)