### PR TITLE
✨ Add alb mutual authentication APPSRE-11698

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2408,6 +2408,12 @@ confs:
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
 
+- name: NamespaceTerraformResourceALBMutualAuthentication_v1
+  fields:
+  - { name: mode, type: string, isRequired: true }
+  - { name: ca_cert_bundle_s3_bucket_name, type: string, isRequired: true }
+  - { name: ca_cert_bundle_s3_bucket_key, type: string, isRequired: true }
+
 - name: NamespaceTerraformResourceALB_v1
   interface: NamespaceTerraformResourceAWS_v1
   fields:
@@ -2422,6 +2428,7 @@ confs:
   - { name: ip_address_type, type: string }
   - { name: access_logs, type: boolean }
   - { name: ssl_policy, type: string }
+  - { name: mutual_authentication, type: NamespaceTerraformResourceALBMutualAuthentication_v1 }
   - { name: targets, type: NamespaceTerraformResourceALBTargets_v1, isRequired: true, isList: true }
   - { name: rules, type: NamespaceTerraformResourceALBRules_v1, isRequired: true, isList: true }
   - { name: vpc, type: AWSVPC_v1, isRequired: true }

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -1227,7 +1227,7 @@ oneOf:
       - ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06
       - ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06
       - ELBSecurityPolicy-TLS13-1-1-2021-06
-      - ELBSecurityPolicy-TLS13-1-0-2021-06 # This will be the defaul value
+      - ELBSecurityPolicy-TLS13-1-0-2021-06 # This will be the default value
       - ELBSecurityPolicy-TLS-1-2-Ext-2018-06
       - ELBSecurityPolicy-TLS-1-2-2017-01
       - ELBSecurityPolicy-TLS-1-1-2017-01

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -202,6 +202,8 @@ properties:
     - dualstack
   access_logs:
     type: boolean
+  mutual_authentication:
+    type: object
   targets:
     type: array
     items:
@@ -1248,6 +1250,26 @@ oneOf:
       - ELBSecurityPolicy-FS-1-2-2019-08
       - ELBSecurityPolicy-FS-1-1-2019-08
       - ELBSecurityPolicy-FS-2018-06
+    mutual_authentication:
+      type: object
+      additionalProperties: false
+      properties:
+        mode:
+          description: Wheter to perform X.509 client certificate authentication or pass the verification to the application.
+          type: string
+          enum:
+            - off
+            - verify
+            - passthrough
+        ca_cert_bundle_s3_bucket_name:
+          type: string
+          description: S3 bucket where the CA bundle file is stored.
+        ca_cert_bundle_s3_bucket_key:
+          type: string
+      required:
+        - mode
+        - ca_cert_bundle_s3_bucket_name
+        - ca_cert_bundle_s3_bucket_key
     targets:
       type: array
       items:


### PR DESCRIPTION
Related ticket: [APPSRE-11698](https://issues.redhat.com/browse/APPSRE-11698)

This adds the changes to schemas to enable [configuration of mTLS for ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/configuring-mtls-with-elb.html)

The CA cert bundle will be stored in a S3 bucket that will be provided by tenant.


qontract-reconcile implementation: https://github.com/app-sre/qontract-reconcile/pull/4951