### PR TITLE
fix: allow dot in secrete data fields

### DIFF
--- a/schemas/openshift/terraform-output-format-1.yml
+++ b/schemas/openshift/terraform-output-format-1.yml
@@ -19,7 +19,7 @@ properties:
     type: object
     additionalProperties: false
     patternProperties: {
-      "^[a-zA-Z0-9_-]{0,253}$": {
+      "^[a-zA-Z0-9_.-]{0,253}$": {
         "type": "string"
       }
     }
@@ -34,7 +34,7 @@ oneOf:
       type: object
       additionalProperties: false
       patternProperties: {
-        "^[a-zA-Z0-9_-]{0,253}$": {
+        "^[a-zA-Z0-9_.-]{0,253}$": {
           "type": "string"
         }
       }


### PR DESCRIPTION
`.` is supported as secret data key name. Fix [mr](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/139441).

https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-config-file/#create-the-config-file