### PR TITLE
:recycle: jira-board: introduce general issue fields attribute

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -577,10 +577,10 @@ confs:
   - { name: issueType, type: string }
   - { name: issueResolveState, type: string }
   - { name: issueReopenState, type: string }
-  - { name: issueSecurityId, type: string }
   - { name: wontFixResolution, type: string }
   - { name: reopenDuration, type: string }
   - { name: disable, type: DisableJiraBoardAutomations_v1 }
+  - { name: issueFields, type: JiraBoardIssueField_v1, isList: true }
   - name: escalationPolicies
     type: AppEscalationPolicy_v1
     isList: true
@@ -591,6 +591,11 @@ confs:
 - name: DisableJiraBoardAutomations_v1
   fields:
   - { name: integrations, type: string, isList: true }
+
+- name: JiraBoardIssueField_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: value, type: string, isRequired: true }
 
 - name: SendGridAccount_v1
   fields:

--- a/schemas/dependencies/jira-board-1.yml
+++ b/schemas/dependencies/jira-board-1.yml
@@ -37,8 +37,6 @@ properties:
     type: string
   issueReopenState:
     type: string
-  issueSecurityId:
-    type: string
   wontFixResolution:
     type: string
   reopenDuration:
@@ -53,6 +51,21 @@ properties:
           type: string
           enum:
           - jira-permissions-validator
+  issueFields:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: The Jira field name as shown in the UI
+        value:
+          type: string
+          description: The value to set the field to as a string as shown in the UI
+      required:
+      - name
+      - value
 required:
 - "$schema"
 - labels


### PR DESCRIPTION
Refactor the `/dependencies/jira-board-1.yml` definition and replace the `issueSecurityId` attribute with a general `issueFields` one.
This allows us to add and verify any arbitrary Jira issue field via `jira-permissions-validator` and `jiralert`, e.g., the new `Work Type` attribute.

Ticket: [APPSRE-12034](https://issues.redhat.com/browse/APPSRE-12034)