### PR TITLE
Introduce externalDocumentation attribute

### DIFF
--- a/schemas/json-schema-spec-draft-06.json
+++ b/schemas/json-schema-spec-draft-06.json
@@ -56,10 +56,6 @@
         "description": {
             "type": "string"
         },
-        "externalDocumentation": {
-            "type": "string",
-            "description": "Link(s) to external documentation specific to this property"
-        },
         "default": {},
         "examples": {
             "type": "array",

--- a/schemas/json-schema-spec-draft-06.json
+++ b/schemas/json-schema-spec-draft-06.json
@@ -56,6 +56,10 @@
         "description": {
             "type": "string"
         },
+        "externalDocumentation": {
+            "type": "string",
+            "description": "Link(s) to external documentation specific to this property"
+        },
         "default": {},
         "examples": {
             "type": "array",

--- a/schemas/metaschema-1.json
+++ b/schemas/metaschema-1.json
@@ -23,6 +23,10 @@
     "description": {
       "type": "string"
     },
+    "externalDocumentation": {
+      "type": "string",
+      "description": "Link(s) to external documentation for this schema"
+    },
     "additionalProperties": {
       "type": "boolean",
       "enum": [


### PR DESCRIPTION
This MR adds `externalDocumentation` attributes to the top-level metaschema and nested schema properties.

Inspired by discussion on documentation for AWS ASG schema - cc https://github.com/app-sre/qontract-schemas/pull/869#discussion_r2168498804.

Example: `schemas/aws/asg-defaults-1.yml`

```yaml
"$schema": /metaschema-1.json
version: '1.0'
type: object
title: "ASG Defaults"
description: |
  Schema for defining default configuration values for AWS Auto Scaling Groups (ASGs).
  This schema enables teams to specify baseline settings for scaling, instance types,
  networking, security, and lifecycle management. These defaults are used to ensure
  consistent and reliable ASG deployments across environments.
externalDocumentation: |
  https://docs.aws.amazon.com/autoscaling/
additionalProperties: false
...
      properties:
      spot_allocation_strategy:
        type: string
        externalDocumentation: |
          https://docs.aws.amazon.com/autoscaling/ec2/userguide/allocation-strategies.html
        enum:
        - lowest-price
        - price-capacity-optimized
        - capacity-optimized
        - capacity-optimized-prioritized
```