### PR TITLE
Introduce sqlQuery.jobImage attribute

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -150,6 +150,7 @@ confs:
 - name: SqlQuerySettings_v1
   fields:
   - { name: imageRepository, type: string, isRequired: true }
+  - { name: jobImage, type: string }
   - { name: pullSecret, type: NamespaceOpenshiftResourceVaultSecret_v1, isRequired: true }
 
 - name: AppInterfaceEmail_v1

--- a/schemas/app-interface/app-interface-settings-1.yml
+++ b/schemas/app-interface/app-interface-settings-1.yml
@@ -181,6 +181,10 @@ properties:
         type: string
         description: |
           The repository for the SQL query image.
+      jobImage:
+        type: string
+        description: |
+          The image for the SQL query job.
       pullSecret:
         "$ref": "/openshift/openshift-resource-vault-secret-1.yml"
         description: |


### PR DESCRIPTION
This is to replace `sqlQuery.imageRepo` which is the base to use mysql and postgres mirrors, which we need to stop doing in the Konflux days in which we no longer can use mirrors from docker hub and the RedHat registry mirrors are not up to date soon enough.

We introduce the new field `sqlQuery.jobImage` in a non-breaking way making it non-mandatory. The related integrations have `quay.io/app-sre/debug-container` as default.

APPSRE-12189