### PR TITLE
add OCM external org id

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1249,6 +1249,7 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
   - { name: description, type: string }
   - { name: orgId, type: string, isRequired: true, isUnique: true }
+  - { name: externalOrgId, type: string, isUnique: true }
   - { name: environment, type: OpenShiftClusterManagerEnvironment_v1, isRequired: true }
   - { name: accessTokenClientId, type: string }
   - { name: accessTokenUrl, type: string }

--- a/schemas/openshift/openshift-cluster-manager-1.yml
+++ b/schemas/openshift/openshift-cluster-manager-1.yml
@@ -20,6 +20,11 @@ properties:
     description: |
       The internal OCM organization ID that can be found via
       ocm whoami | jq .organization.id
+  externalOrgId:
+    type: string
+    description: |
+      The external OCM organization ID that can be found via
+      ocm whoami | jq .organization.external_id
   environment:
     "$ref": "/common-1.json#/definitions/crossref"
     "$schemaRef": "/openshift/openshift-cluster-manager-environment-1.yml"


### PR DESCRIPTION
while we can obtain this information through the OCM API, this data is static and can be used for additional purposes.

for example, authenticating to the RH User Service to manage OCM access management.

ref: https://gitlab.cee.redhat.com/ciam-s/user-service