### PR TITLE
fix: externalOrgId failed unique check

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1249,7 +1249,7 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true, isSearchable: true }
   - { name: description, type: string }
   - { name: orgId, type: string, isRequired: true, isUnique: true }
-  - { name: externalOrgId, type: string, isUnique: true }
+  - { name: externalOrgId, type: string }
   - { name: environment, type: OpenShiftClusterManagerEnvironment_v1, isRequired: true }
   - { name: accessTokenClientId, type: string }
   - { name: accessTokenUrl, type: string }


### PR DESCRIPTION
Field can't be optional and unique, multiple instance without this field populated lead to validation error

```text
[
  {
    "filename": "/dependencies/ocm/crc/insights.yaml",
    "kind": "UNIQUE",
    "result": {
      "summary": "ERROR: /dependencies/ocm/crc/insights.yaml",
      "status": "ERROR",
      "reason": "DUPLICATE_UNIQUE_FIELD",
      "error": "The field 'externalOrgId' is repeated: ['/dependencies/ocm/crc/insights.yaml', '/dependencies/ocm/stage.yml', '/dependencies/ocm/production.yml']",
      "meta_schema_url": null,
      "ref": "/openshift/openshift-cluster-manager-1.yml",
      "schema_url": null,
      "ptr": "externalOrgId"
    }
  }
]
```

Fix https://github.com/app-sre/qontract-schemas/pull/894