### PR TITLE
Add quay robot account schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3614,6 +3614,23 @@ confs:
       schema: /app-sre/sre-checkpoint-1.yml
       subAttr: sre
 
+- name: QuayRepository_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: permission, type: string, isRequired: true }
+
+- name: QuayRobot_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: labels, type: json }
+  - { name: name, type: string, isRequired: true }
+  - { name: description, type: string }
+  - { name: quay_username, type: string }
+  - { name: quay_org, type: QuayOrg_v1 }
+  - { name: repositories, type: QuayRepository_v1, isList: true }
+  - { name: teams, type: string, isList: true }
+
 - name: Bot_v1
   datafile: /access/bot-1.yml
   fields:
@@ -4071,6 +4088,7 @@ confs:
   - { name: users_v1, type: User_v1, isList: true, datafileSchema: /access/user-1.yml }
   - { name: external_users_v1, type: ExternalUser_v1, isList: true, datafileSchema: /access/external-user-1.yml }
   - { name: bots_v1, type: Bot_v1, isList: true, datafileSchema: /access/bot-1.yml }
+  - { name: quay_robots_v1, type: QuayRobot_v1, isList: true, datafileSchema: /access/quay-robot-1.yml }
   - { name: roles_v1, type: Role_v1, isList: true, datafileSchema: /access/role-1.yml }
   - { name: permissions_v1, type: Permission_v1, isList: true, isRequired: true, isInterface: true, datafileSchema: /access/permission-1.yml }
   - { name: oidc_permissions_v1, type: OidcPermission_v1, isList: true, isRequired: true, isInterface: true, datafileSchema: /access/oidc-permission-1.yml }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3698,6 +3698,13 @@ confs:
     synthetic:
       schema: /access/external-user-1.yml
       subAttr: roles
+  - name: quay_robots
+    type: QuayRobot_v1
+    isList: true
+    isRequired: true
+    synthetic:
+      schema: /access/quay-robot-1.yml
+      subAttr: roles
 
 - name: LdapGroup_v1
   fields:

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3630,6 +3630,7 @@ confs:
   - { name: quay_org, type: QuayOrg_v1 }
   - { name: repositories, type: QuayRepository_v1, isList: true }
   - { name: teams, type: string, isList: true }
+  - { name: delete, type: boolean }
 
 - name: Bot_v1
   datafile: /access/bot-1.yml

--- a/schemas/access/quay-robot-1.yml
+++ b/schemas/access/quay-robot-1.yml
@@ -1,0 +1,67 @@
+---
+"$schema": /metaschema-1.json
+version: "1.0"
+type: object
+title: "Quay Robot Account"
+description: |
+  Schema for defining Quay robot account in app-interface.
+  This includes details about the robot account's usernames
+  and associated teams and repositories.
+
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /access/quay-robot-1.yml
+  labels:
+    "$ref": "/common-1.json#/definitions/labels"
+  name:
+    type: string
+    description: |
+      The name of the robot account.
+  description:
+    type: string
+    description: |
+      A brief description of the robot account.
+  quay_username:
+    "$ref": "/common-1.json#/definitions/identifier"
+    description: |
+      The Quay robot account name.
+      In Quay will be shown as org_name+quay_username.
+  quay_org:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/dependencies/quay-org-1.yml"
+    description: |
+      Reference to the Quay organization that the robot account belongs to.
+  repositories:
+    type: array
+    description: |
+      A list of repositories that the robot account has access to.
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+          description: |
+            The name of the repository.
+        permission:
+          type: string
+          enum:
+          - read
+          - write
+          - admin
+          description: |
+            The permission level for the repository.
+  teams:
+    type: array
+    description: |
+      A list of teams that the robot account has access to.
+    items:
+      type: string
+      description: |
+        The name of the team.
+required:
+- $schema
+- labels
+- name

--- a/schemas/access/quay-robot-1.yml
+++ b/schemas/access/quay-robot-1.yml
@@ -61,6 +61,12 @@ properties:
       type: string
       description: |
         The name of the team.
+  delete:
+    type: boolean
+    description: |
+      When true, the robot account will be deleted from Quay.
+      Use this to explicitly remove a robot account managed by app-interface.
+      Robots absent from app-interface are never automatically deleted.
 required:
 - $schema
 - labels


### PR DESCRIPTION
JIRA: [APPSRE-11883](https://issues.redhat.com/browse/APPSRE-11883)

Based on robot accounts definitions on [quay-access-management](https://gitlab.cee.redhat.com/exd/quay/quay-access-management/-/blob/master/redhat-services-prod.yml?ref_type=heads#L496).

We want to add a new schema to `app-interface` where a user can define a robot account with a `name` and links it to a `role` that will through `permissions` add the account to orgs.

Currently `qontract-reconcile` doesn't manage repository members.  