### PR TITLE
fix(account): use same regex as aws api for phoneNumber

### DIFF
--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -57,7 +57,11 @@ properties:
         type: string
         format: email
       phoneNumber:
-        "$ref": "/common-1.json#/definitions/phoneNumber"
+        type: string
+        pattern: "^[\\s0-9()+-]{1,25}$"
+        description: |
+          The phone number associated with this alternate contact.
+          https://docs.aws.amazon.com/accounts/latest/reference/API_AlternateContact.html
     required:
     - name
     - email

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -235,11 +235,6 @@
       "pattern": "^\\/[a-zA-Z0-9_ -\\/]+[^\\/]$",
       "description": "A path is a string that starts with a forward slash and contains only alphanumeric characters, hyphens, spaces, and underscores. It does not end with a slash."
     },
-    "phoneNumber": {
-      "type": "string",
-      "pattern": "^\\+[1-9][0-9]{7,14}$",
-      "description": "A phone number is a string that starts with a plus sign followed by a country code and a phone number."
-    },
     "unleash-environments": {
       "type": "object",
       "additionalProperties": {


### PR DESCRIPTION
use pattern from aws doc https://docs.aws.amazon.com/accounts/latest/reference/API_AlternateContact.html

This field is introduced in https://github.com/app-sre/qontract-schemas/pull/663, and only used by aws account, so remove it from common and apply aws format here.

[APPSRE-12218](https://issues.redhat.com/browse/APPSRE-12218)