### PR TITLE
:bug: glitchtip-alert: drop uniqueness

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4194,7 +4194,7 @@ confs:
   - { name: path, type: string, isRequired: true }
   - { name: schema, type: string, isRequired: true }
   - { name: labels, type: json }
-  - { name: name, type: string, isRequired: true, isContextUnique: true }
+  - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
   - { name: quantity, type: int, isRequired: true }
   - { name: timespanMinutes, type: int, isRequired: true }


### PR DESCRIPTION
Drop `name` uniqueness to support inline and referenced `/dependencies/glitchtip-project-alert-1.yml`. Qontract-server can't handle it `Cannot return null for non-nullable field GlitchtipProjectAlert_v1.name`. Nevertheless, we can live without the uniqueness; in the worst case, a Glitchtip project overrides its own alerts.