### PR TITLE
Fix make it so CA bundle is only required on verify mode

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1757,7 +1757,7 @@ confs:
   - { name: enable_query_support, type: boolean }
   - { name: tests, type: string, isList: true, isResource: true }
   - { name: promtool_version, type: string }
-  
+
 - name: NamespaceExternalResource_v1
   isInterface: true
   interfaceResolve:
@@ -2410,8 +2410,8 @@ confs:
 - name: NamespaceTerraformResourceALBMutualAuthentication_v1
   fields:
   - { name: mode, type: string, isRequired: true }
-  - { name: ca_cert_bundle_s3_bucket_name, type: string, isRequired: true }
-  - { name: ca_cert_bundle_s3_bucket_key, type: string, isRequired: true }
+  - { name: ca_cert_bundle_s3_bucket_name, type: string }
+  - { name: ca_cert_bundle_s3_bucket_key, type: string }
 
 - name: NamespaceTerraformResourceALB_v1
   interface: NamespaceTerraformResourceAWS_v1

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -1260,24 +1260,37 @@ oneOf:
       - ELBSecurityPolicy-FS-2018-06
     mutual_authentication:
       type: object
-      additionalProperties: false
       properties:
         mode:
-          description: Wheter to perform X.509 client certificate authentication or pass the verification to the application.
           type: string
           enum:
-            - off
-            - verify
-            - passthrough
-        ca_cert_bundle_s3_bucket_name:
-          type: string
-          description: S3 bucket where the CA bundle file is stored.
-        ca_cert_bundle_s3_bucket_key:
-          type: string
-      required:
-        - mode
-        - ca_cert_bundle_s3_bucket_name
-        - ca_cert_bundle_s3_bucket_key
+          - "off"
+          - verify
+          - passthrough
+      oneOf:
+      - additionalProperties: false
+        properties:
+          mode:
+            type: string
+            enum:
+              - "off"
+              - passthrough
+        required:
+          - mode
+      - additionalProperties: false
+        properties:
+          mode:
+            type: string
+            enum:
+              - verify
+          ca_cert_bundle_s3_bucket_name:
+            type: string
+          ca_cert_bundle_s3_bucket_key:
+            type: string
+        required:
+          - mode
+          - ca_cert_bundle_s3_bucket_name
+          - ca_cert_bundle_s3_bucket_key
     targets:
       type: array
       items:


### PR DESCRIPTION
To fix this [error](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/151341/diffs#note_16951660
) message on reconcile:

```
(...) api error ValidationError: Mutual Authentication mode passthrough does not support trust store
```