### PR TITLE
elasticsearch-defaults: add gp3

### DIFF
--- a/schemas/aws/elasticsearch-defaults-1.yml
+++ b/schemas/aws/elasticsearch-defaults-1.yml
@@ -26,6 +26,7 @@ properties:
         - standard
         - gp2
         - io1
+        - gp3
     required:
     - ebs_enabled
   encrypt_at_rest:


### PR DESCRIPTION
Allow `gp3` volume type.