### PR TITLE
elasticache: service_updates_types setting

### DIFF
--- a/schemas/aws/elasticache-defaults-1.yml
+++ b/schemas/aws/elasticache-defaults-1.yml
@@ -132,7 +132,7 @@ properties:
     description: "Enable or disable automatic service updates for the ElastiCache cluster. Default: true"
   service_updates_types:
     type: array
-    description: "A list of the service update types that will be applied automatically for the replication group."
+    description: "A list of the service update types that will be applied automatically for the replication group. Default: ['security-update', 'engine-update']"
     items:
       type: string
   service_updates_severities:


### PR DESCRIPTION
This PR introduces the `service_updates_types` setting to specify which types of ElastiCache service updates are allowed to be applied.
The default setting excludes the `engine-major-version-update` type to avoid any future major engine upgrades like `elasticache-redis-oss-v4-v5-eol-replication-groups`.

Ticket: [APPSRE-12377](https://issues.redhat.com/browse/APPSRE-12377)

