### PR TITLE
feat: :lock: add schema definitions for disabling IAM keys

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1356,6 +1356,7 @@ confs:
   - { name: deletionApprovals, type: DeletionApproval_v1, isList: true }
   - { name: disable, type: DisableClusterAutomations_v1 }
   - { name: deleteKeys, type: string, isList: true }
+  - { name: disableKeys, type: string, isList: true }
   - { name: resetPasswords, type: AWSAccountResetPassword_v1, isList: true }
   - { name: premiumSupport, type: boolean, isRequired: true }
   - { name: partition, type: string }

--- a/schemas/aws/account-1.yml
+++ b/schemas/aws/account-1.yml
@@ -106,6 +106,10 @@ properties:
     type: array
     items:
       type: string
+  disableKeys:
+    type: array
+    items:
+      type: string
   resetPasswords:
     type: array
     items:


### PR DESCRIPTION
https://issues.redhat.com/browse/PROJQUAY-9354

Adding support to `aws-iam-keys` integration for disabling keys, in addition to deleting them for use cases where we aren't using the access keys.