### PR TITLE
Revert "__identifier field on crossrefs to enable validation of context uniqeness in lists of crossref objects"

### DIFF
--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -149,10 +149,6 @@
         "$ref": {
           "type": "string",
           "format": "uri-reference"
-        },
-        "__identifier": {
-          "type": "string",
-          "description": "this is the field that holds the context uniqueness hash for a crossref. it is managed by qontract-bundler during the bundling process if a crossref datafile defines at least one isContextUnique field"
         }
       },
       "required": [


### PR DESCRIPTION
Reverts app-sre/qontract-schemas#515

`__identifier` is inserted inside datafile root instead of the same level as `$ref`, so this is not needed anymore. https://github.com/app-sre/qontract-validator/pull/99

[APPSRE-12342](https://issues.redhat.com/browse/APPSRE-12342)