### PR TITLE
cluster spec: add fips

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -928,6 +928,7 @@ confs:
   - { name: provision_shard_id, type: string }
   - { name: disable_user_workload_monitoring, type: boolean }
   - { name: hypershift, type: boolean, isRequired: false}
+  - { name: fips, type: boolean}
 
 - name: ClusterSpecOSD_v1
   interface: ClusterSpec_v1
@@ -947,6 +948,7 @@ confs:
   - { name: hypershift, type: boolean, isRequired: false}
   - { name: storage, type: int, isRequired: true }
   - { name: load_balancers, type: int, isRequired: true }
+  - { name: fips, type: boolean}
 
 - name: ClusterSpecROSA_v1
   interface: ClusterSpec_v1
@@ -968,6 +970,7 @@ confs:
   - { name: subnet_ids, type: string, isList: True}
   - { name: availability_zones, type: string, isList: True}
   - { name: oidc_endpoint_url, type: string }
+  - { name: fips, type: boolean}
 
 - name: ClusterSpecAutoScale_v1
   fields:

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -223,6 +223,9 @@ properties:
       oidc_endpoint_url:
         type: string
         format: uri
+      fips:
+        type: boolean
+        description: Create cluster that uses FIPS Validated / Modules in Process cryptographic libraries.
     required:
     - product
     - provider


### PR DESCRIPTION
Add non-required `fips` flag to cluster creation specs.

Ticket: [APPSRE-12451](https://issues.redhat.com/browse/APPSRE-12451)