### PR TITLE
fix quay repo schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2872,6 +2872,8 @@ confs:
 - name: AppQuayRepos_v1
   datafile: /app-sre/app-quay-repos-1.yml
   fields:
+  - { name: path, type: string, isRequired: true }
+  - { name: schema, type: string, isRequired: true }
   - { name: org, type: QuayOrg_v1, isRequired: true }
   - { name: teams, type: AppQuayReposTeams_v1, isList: true }
   - { name: items, type: AppQuayReposItems_v1, isRequired: true, isList: true }


### PR DESCRIPTION
`path` and `schema` missing

```
qontract-server               | /opt/app-root/src/node_modules/graphql/type/validate.js:71
qontract-server               |     throw new Error(errors.map(function (error) {
qontract-server               |           ^
qontract-server               |
qontract-server               | Error: Interface field DatafileObject_v1.schema expected but AppQuayRepos_v1 does not provide it.
```