### PR TITLE
Add secret_format to AWS Secrets Manager

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2102,6 +2102,7 @@ confs:
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
   - { name: tags, type: json }
+  - { name: secret_format, type: json }
 
 - name: NamespaceTerraformResourceS3CloudFrontPublicKey_v1
   interface: NamespaceTerraformResourceAWS_v1

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -321,6 +321,11 @@ properties:
     type: integer
     minimum: 3600
     maximum: 43200
+  secret_format:
+    description: |
+      A jinja2 templated object to define the shape of the secret to be created in Secrets
+      Manager instead of copying the vault secret as is.
+    "$ref": "/common-1.json#/definitions/labels"
 
 oneOf:
 - additionalProperties: false
@@ -1617,6 +1622,11 @@ oneOf:
       "$ref": "/openshift/terraform-output-format-1.yml"
     annotations:
       "$ref": "/common-1.json#/definitions/annotations"
+    secret_format:
+      description: |
+        A jinja2 templated object to define the shape of the secret to be created in Secrets
+        Manager instead of copying the vault secret as is.
+      "$ref": "/common-1.json#/definitions/labels"
   required:
   - identifier
   - secret


### PR DESCRIPTION
The idea is to be able to create templated secrets to copy from Vault to AWS Secrets Manager

This work is needed in the context of APPSRE-12414, since AWS expects the RDS credentials for AWS RDS Proxy in a defined format that cannot be configured.