### PR TITLE
feat(prometheus-rule): add monitoring.rhobs/v1 to apiVersion enum

### DIFF
--- a/schemas/openshift/prometheus-rule-1.yml
+++ b/schemas/openshift/prometheus-rule-1.yml
@@ -12,6 +12,7 @@ properties:
     type: string
     enum:
     - monitoring.coreos.com/v1
+    - monitoring.rhobs/v1
   kind:
     type: string
     enum:


### PR DESCRIPTION
## Summary
- Adds `monitoring.rhobs/v1` to the allowed `apiVersion` enum values in `schemas/openshift/prometheus-rule-1.yml`

## Test plan
- [ ] Run `make bundle-and-validate-schema` to verify schema validation passes
- [ ] Verify that PrometheusRule resources with `apiVersion: monitoring.rhobs/v1` pass validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)