### PR TITLE
prometheus_rule: Add rule_group as a supported alert label

### DIFF
--- a/schemas/openshift/prometheus-rule-1.yml
+++ b/schemas/openshift/prometheus-rule-1.yml
@@ -149,6 +149,8 @@ properties:
                           type: string
                         jiralert:
                           type: string
+                        rule_group:
+                          type: string
                       dependencies:
                         app_team:
                         - service


### PR DESCRIPTION
This commit adds rule_group as a supported alert label.

In RHOBS team, we run several Thanos Rulers, that evaluate rules for our tenants. In certain cases, due to config issues, a rule may be configured and fail to evaluate in a rule group.

We would like to define alerts that specify which rule_group fails.