### PR TITLE
remove retention from pipelines provider schemas

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3206,16 +3206,9 @@ confs:
   - { name: provider, type: string, isRequired: true }
   - { name: defaults, type: PipelinesProviderTektonProviderDefaults_v1, isRequired: true }
   - { name: namespace, type: Namespace_v1, isRequired: true }
-  - { name: retention, type: PipelinesProviderRetention_v1 }
   - { name: taskTemplates, type: PipelinesProviderTektonObjectTemplate_v1, isList: true }
   - { name: pipelineTemplates, type: PipelinesProviderPipelineTemplates_v1 }
   - { name: deployResources, type: DeployResources_v1 }
-
-- name: PipelinesProviderRetention_v1
-  fields:
-  - { name: days, type: int }
-  - { name: minimum, type: int }
-  - { name: maximum, type: int }
 
 - name: PipelinesProviderTektonObjectTemplate_v1
   fields:
@@ -3236,7 +3229,6 @@ confs:
   - { name: name, type: string, isRequired: true }
   - { name: labels, type: json, isRequired: true }
   - { name: description, type: string, isRequired: true }
-  - { name: retention, type: PipelinesProviderRetention_v1, isRequired: true }
   - { name: taskTemplates, type: PipelinesProviderTektonObjectTemplate_v1, isRequired: true, isList: true }
   - { name: pipelineTemplates, type: PipelinesProviderPipelineTemplates_v1, isRequired: true }
   - { name: deployResources, type: DeployResources_v1 }

--- a/schemas/app-sre/tekton-provider-defaults-1.yml
+++ b/schemas/app-sre/tekton-provider-defaults-1.yml
@@ -87,6 +87,5 @@ required:
 - labels
 - name
 - description
-- retention
 - taskTemplates
 - pipelineTemplates


### PR DESCRIPTION
## Summary
- Remove `retention` field and `PipelinesProviderRetention_v1` type from GraphQL schema
- Remove `retention` from required fields in `tekton-provider-defaults-1.yml`
- Step 1 of fully deprecating the retention field from pipelines provider schemas

## Test plan
- [ ] `yamllint` passes
- [ ] `make bundle-and-validate-schema` passes
- [ ] Verify qontract-server starts with updated GraphQL schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://redhat.atlassian.net/browse/APPSRE-11692