### PR TITLE
remove retention field from pipelines provider JSON schemas

### DIFF
--- a/schemas/app-sre/pipelines-provider-1.yml
+++ b/schemas/app-sre/pipelines-provider-1.yml
@@ -53,30 +53,6 @@ properties:
       Reference to the OpenShift namespace where the pipelines provider
       resources will be deployed.
 
-  retention:
-    description: |
-      Describes the retention policy for builds. Specifies how many builds
-      are kept, both by time (days) and by minimum/maximum count.
-    additionalProperties: false
-    properties:
-      days:
-        description: |
-          Maximum retention expressed in days. Builds older than this will
-          be deleted, unless protected by minimum or maximum settings.
-        type: integer
-      minimum:
-        description: |
-          Minimum number of builds that will always be kept, regardless of
-          the 'days' setting.
-        type: integer
-      maximum:
-        description: |
-          Maximum number of builds that will be kept, even if within the
-          retention period.
-        type: integer
-    required:
-    - days
-
   taskTemplates:
     type: array
     description: |
@@ -116,24 +92,6 @@ oneOf:
     namespace:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/openshift/namespace-1.yml"
-    retention:
-      oneOf:
-      - additionalProperties: false
-        properties:
-          days:
-            type: integer
-          minimum:
-            type: integer
-        required:
-        - days
-      - additionalProperties: false
-        properties:
-          days:
-            type: integer
-          maximum:
-            type: integer
-        required:
-        - days
     taskTemplates:
       description: |
         Tekton Task jinja2 templates that will be used to create the corresponding

--- a/schemas/app-sre/tekton-provider-defaults-1.yml
+++ b/schemas/app-sre/tekton-provider-defaults-1.yml
@@ -8,7 +8,7 @@ description: |
   These defaults ensure that all required fields for a Tekton provider are present,
   reducing duplication and simplifying provider definitions. Providers can override
   any field as needed, but will always inherit a complete set of defaults for
-  retention, task and pipeline templates, and deployment resources.
+  task and pipeline templates, and deployment resources.
 
 additionalProperties: false
 
@@ -32,25 +32,6 @@ properties:
     description: |
       A detailed description of the defaults configuration, including its
       intended use and any relevant context.
-
-  retention:
-    additionalProperties: false
-    description: |
-      The retention policy for builds managed by the provider. Specifies how
-      many builds are kept, both by time (days) and by minimum count.
-    properties:
-      days:
-        type: integer
-        description: |
-          Maximum retention expressed in days. Builds older than this will
-          be deleted, unless protected by the minimum setting.
-      minimum:
-        type: integer
-        description: |
-          Minimum number of builds that will always be kept, regardless of
-          the 'days' setting.
-    required:
-    - days
 
   taskTemplates:
     type: array


### PR DESCRIPTION
## Summary
- Fully remove `retention` property from `pipelines-provider-1.yml` (including `oneOf` validation block)
- Fully remove `retention` property from `tekton-provider-defaults-1.yml`
- Depends on #988 (GraphQL schema removal) being merged first

## Test plan
- [ ] `yamllint` passes
- [ ] `make bundle-and-validate-schema` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)