### PR TITLE
feat: add msk-connect provider schema for ERv2

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1916,6 +1916,7 @@ confs:
       rosa-authenticator: NamespaceTerraformResourceRosaAuthenticator_V1
       rosa-authenticator-vpce: NamespaceTerraformResourceRosaAuthenticatorVPCE_V1
       msk: NamespaceTerraformResourceMsk_v1
+      msk-connect: NamespaceTerraformResourceMskConnect_v1
       module-poc: NamespaceTerraformResourceModulePoC_v1
 
   fields:
@@ -2064,6 +2065,23 @@ confs:
   - { name: managed_by_erv2, type: boolean}
   - { name: delete, type: boolean}
   - { name: module_overrides, type: ExternalResourcesModuleOverrides_v1}
+  - { name: tags, type: json }
+
+- name: NamespaceTerraformResourceMskConnect_v1
+  interface: NamespaceTerraformResourceAWS_v1
+  fields:
+  - { name: provider, type: string, isRequired: true, isContextUnique: true }
+  - { name: region, type: string, isContextUnique: true }
+  - { name: identifier, type: string, isRequired: true, isContextUnique: true }
+  - { name: defaults, type: string, isRequired: true, isResource: true }
+  - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
+  - { name: annotations, type: json }
+  - { name: msk_cluster, type: string, isRequired: true }
+  - { name: service_execution_role, type: string, isRequired: true }
+  - { name: managed_by_erv2, type: boolean }
+  - { name: delete, type: boolean }
+  - { name: module_overrides, type: ExternalResourcesModuleOverrides_v1 }
   - { name: tags, type: json }
 
 - name: MskSecretParameters_v1

--- a/schemas/aws/msk-connect-defaults-1.yml
+++ b/schemas/aws/msk-connect-defaults-1.yml
@@ -39,64 +39,71 @@ properties:
     description: Kafka Connect version (default 3.7.1, set by ERv2 module)
   capacity:
     type: object
-    additionalProperties: false
     description: Connector capacity configuration (default provisioned 1 MCU 1 worker, set by ERv2 module)
-    properties:
-      autoscaling:
-        type: object
-        additionalProperties: false
-        properties:
-          min_worker_count:
-            type: integer
-            minimum: 1
-          max_worker_count:
-            type: integer
-            minimum: 1
-          mcu_count:
-            type: integer
-            enum:
-            - 1
-            - 2
-            - 4
-            - 8
-          scale_in_policy:
-            type: object
-            additionalProperties: false
-            properties:
-              cpu_utilization_percentage:
-                type: integer
-                minimum: 1
-                maximum: 100
-          scale_out_policy:
-            type: object
-            additionalProperties: false
-            properties:
-              cpu_utilization_percentage:
-                type: integer
-                minimum: 1
-                maximum: 100
-        required:
-        - min_worker_count
-        - max_worker_count
-      provisioned_capacity:
-        type: object
-        additionalProperties: false
-        properties:
-          worker_count:
-            type: integer
-            minimum: 1
-          mcu_count:
-            type: integer
-            enum:
-            - 1
-            - 2
-            - 4
-            - 8
-        required:
-        - worker_count
+    oneOf:
+    - additionalProperties: false
+      required:
+      - autoscaling
+      properties:
+        autoscaling:
+          type: object
+          additionalProperties: false
+          properties:
+            min_worker_count:
+              type: integer
+              minimum: 1
+            max_worker_count:
+              type: integer
+              minimum: 1
+            mcu_count:
+              type: integer
+              enum:
+              - 1
+              - 2
+              - 4
+              - 8
+            scale_in_policy:
+              type: object
+              additionalProperties: false
+              properties:
+                cpu_utilization_percentage:
+                  type: integer
+                  minimum: 1
+                  maximum: 100
+            scale_out_policy:
+              type: object
+              additionalProperties: false
+              properties:
+                cpu_utilization_percentage:
+                  type: integer
+                  minimum: 1
+                  maximum: 100
+          required:
+          - min_worker_count
+          - max_worker_count
+    - additionalProperties: false
+      required:
+      - provisioned_capacity
+      properties:
+        provisioned_capacity:
+          type: object
+          additionalProperties: false
+          properties:
+            worker_count:
+              type: integer
+              minimum: 1
+            mcu_count:
+              type: integer
+              enum:
+              - 1
+              - 2
+              - 4
+              - 8
+          required:
+          - worker_count
   worker_configuration:
     type: string
-    description: Worker configuration properties (optional, default JSON converter no schemas)
+    description: Optional multiline worker configuration properties
   log_delivery:
     type: object
     additionalProperties: false

--- a/schemas/aws/msk-connect-defaults-1.yml
+++ b/schemas/aws/msk-connect-defaults-1.yml
@@ -1,0 +1,135 @@
+---
+"$schema": /metaschema-1.json
+version: "1.0"
+type: object
+additionalProperties: false
+properties:
+  "$schema":
+    type: string
+    enum:
+    - /aws/msk-connect-defaults-1.yml
+  custom_plugin:
+    type: object
+    additionalProperties: false
+    properties:
+      s3_bucket:
+        type: string
+        description: S3 bucket name where the plugin archive is stored
+      s3_key:
+        type: string
+        description: S3 object key of the plugin archive
+      s3_object_version:
+        type: string
+        description: S3 object version of the plugin archive
+      content_type:
+        type: string
+        enum:
+        - zip
+        - jar
+        description: Content type of the plugin archive
+    required:
+    - s3_bucket
+    - s3_key
+    - content_type
+  connector_configuration:
+    type: object
+    description: Kafka Connect connector configuration properties (key-value pairs, plugin-specific)
+  kafka_connect_version:
+    type: string
+    description: Kafka Connect version (default 3.7.1, set by ERv2 module)
+  capacity:
+    type: object
+    additionalProperties: false
+    description: Connector capacity configuration (default provisioned 1 MCU 1 worker, set by ERv2 module)
+    properties:
+      autoscaling:
+        type: object
+        additionalProperties: false
+        properties:
+          min_worker_count:
+            type: integer
+            minimum: 1
+          max_worker_count:
+            type: integer
+            minimum: 1
+          mcu_count:
+            type: integer
+            enum:
+            - 1
+            - 2
+            - 4
+            - 8
+          scale_in_policy:
+            type: object
+            additionalProperties: false
+            properties:
+              cpu_utilization_percentage:
+                type: integer
+                minimum: 1
+                maximum: 100
+          scale_out_policy:
+            type: object
+            additionalProperties: false
+            properties:
+              cpu_utilization_percentage:
+                type: integer
+                minimum: 1
+                maximum: 100
+        required:
+        - min_worker_count
+        - max_worker_count
+      provisioned_capacity:
+        type: object
+        additionalProperties: false
+        properties:
+          worker_count:
+            type: integer
+            minimum: 1
+          mcu_count:
+            type: integer
+            enum:
+            - 1
+            - 2
+            - 4
+            - 8
+        required:
+        - worker_count
+  worker_configuration:
+    type: string
+    description: Worker configuration properties (optional, default JSON converter no schemas)
+  log_delivery:
+    type: object
+    additionalProperties: false
+    description: Log delivery configuration (optional)
+    properties:
+      cloudwatch_logs:
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            type: boolean
+          retention_in_days:
+            type: integer
+        required:
+        - enabled
+        - retention_in_days
+      s3:
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            type: boolean
+          bucket:
+            type: string
+          prefix:
+            type: string
+        required:
+        - enabled
+        - bucket
+    required:
+    - cloudwatch_logs
+required:
+- "$schema"
+- custom_plugin
+- connector_configuration
+- log_delivery

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -326,6 +326,12 @@ properties:
       A jinja2 templated object to define the shape of the secret to be created in Secrets
       Manager instead of copying the vault secret as is.
     "$ref": "/common-1.json#/definitions/labels"
+  msk_cluster:
+    type: string
+    description: Identifier of the MSK cluster resource in the same externalResources block
+  service_execution_role:
+    type: string
+    description: Identifier of the aws-iam-role resource in the same externalResources block
 
 oneOf:
 - additionalProperties: false
@@ -1978,6 +1984,45 @@ oneOf:
   required:
   - identifier
   - defaults
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - msk-connect
+    region:
+      "$ref": "/aws/regions-1.yml#/properties/region"
+    identifier:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    output_resource_name:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    tags:
+      "$ref": "/common-1.json#/definitions/labels"
+    output_format:
+      "$ref": "/openshift/terraform-output-format-1.yml"
+    defaults:
+      "$ref": "/common-1.json#/definitions/resourceref"
+    annotations:
+      "$ref": "/common-1.json#/definitions/annotations"
+    msk_cluster:
+      type: string
+      description: Identifier of the MSK cluster resource in the same externalResources block
+    service_execution_role:
+      type: string
+      description: Identifier of the aws-iam-role resource in the same externalResources block
+    managed_by_erv2:
+      type: boolean
+      description: Manage the resource with ERv2
+    delete:
+      type: boolean
+      description: Flag a resource to be deleted
+    module_overrides:
+      "$ref": "/external-resources/module-overrides-1.yml"
+  required:
+  - identifier
+  - defaults
+  - msk_cluster
+  - service_execution_role
 - additionalProperties: false
   properties:
     provider:


### PR DESCRIPTION
## Summary

Adds schema definitions for **AWS MSK Connect** as a new ERv2 external resource provider. MSK Connect enables tenants to deploy managed Kafka Connect connectors alongside their existing MSK clusters — no custom consumer/producer code needed.

- New defaults schema: `schemas/aws/msk-connect-defaults-1.yml`
- New `msk-connect` provider block in `schemas/aws/terraform-resource-2.yml`
- New `NamespaceTerraformResourceMskConnect_v1` GraphQL type in `graphql-schemas/schema.yml`

## What is MSK Connect?

AWS MSK Connect is a managed Kafka Connect service. It runs connectors that move data **into** or **out of** Kafka topics — e.g., streaming topic data to S3, DynamoDB, OpenSearch, or ingesting CDC events from PostgreSQL via Debezium. The connector runs fully AWS-side; no application in the OpenShift cluster connects to it.

## How to use

### Prerequisites

- An existing MSK cluster managed via app-interface (provider: `msk`)
- A Kafka Connect plugin archive (ZIP/JAR) uploaded to an S3 bucket

### 1. Create a defaults file

Create a defaults file (e.g., `resources/terraform/resources/myteam/msk-connect-s3-sink.yml`):

```yaml
$schema: /aws/msk-connect-defaults-1.yml

custom_plugin:
  s3_bucket: my-plugins-bucket
  s3_key: plugins/confluentinc-kafka-connect-s3-10.5.7.zip
  content_type: zip

worker_configuration: |
  key_converter: org.apache.kafka.connect.storage.StringConverter
  value_converter: org.apache.kafka.connect.json.JsonConverter

connector_configuration:
  topics: orders
  s3.bucket.name: my-data-lake-prod
  s3.region: us-east-1
  flush.size: "10000"
  storage.class: io.confluent.connect.s3.storage.S3Storage
  format.class: io.confluent.connect.s3.format.parquet.ParquetFormat
```

### 2. Add the connector to your namespace

The MSK Connect connector **must** be in the same `externalResources` block as the MSK cluster it references (same AWS account, same VPC):

```yaml
externalResources:
- provider: aws
  provisioner:
    $ref: /aws/myteam-prod/account.yml
  resources:
  # Existing MSK cluster
  - provider: msk
    identifier: my-kafka-cluster
    defaults: /terraform/resources/myteam/msk-prod.yml
    output_resource_name: my-kafka-msk
    managed_by_erv2: true

  # NEW: MSK Connect connector
  - provider: msk-connect
    identifier: my-s3-sink
    defaults: /terraform/resources/myteam/msk-connect-s3-sink.yml
    msk_cluster: my-kafka-cluster    # ← references the MSK cluster identifier above
    managed_by_erv2: true
```

### Key points

| Aspect | Detail |
|---|---|
| **`msk_cluster` field** | References the `identifier` of an MSK cluster in the **same** `externalResources` block. The ERv2 module resolves bootstrap brokers, subnets, and security groups from the cluster automatically. |
| **No output secret** | MSK Connect runs autonomously AWS-side. There is no meaningful output secret for the tenant (no bootstrap URLs, no credentials). The connector reads/writes Kafka topics and pushes to the configured sink/source. |
| **Networking** | Automatically derived from the referenced MSK cluster (same VPC, subnets, security groups). No manual network configuration needed. |
| **Auth** | The connector authenticates to the MSK cluster via its IAM service execution role, managed by the ERv2 module. |
| **Plugin** | Must be uploaded to S3 by the tenant. AWS does not provide pre-built plugins. Common plugins: `confluentinc-kafka-connect-s3`, `debezium-connector-postgres`, `kafka-connect-elasticsearch`. |
| **connector_configuration** | Free-form key-value object. The properties are plugin-specific (see the plugin's documentation). |
| **worker_configuration** | Optional multiline string worker configuration.  |

### Capacity options

**Provisioned** (fixed worker count):
```yaml
capacity:
  provisioned_capacity:
    mcu_count: 1
    worker_count: 2
```

**Autoscaled** (scales based on CPU):
```yaml
capacity:
  autoscaling:
    mcu_count: 1
    min_worker_count: 1
    max_worker_count: 4
    scale_in_policy:
      cpu_utilization_percentage: 20
    scale_out_policy:
      cpu_utilization_percentage: 80
```

## Schema design decisions

1. **`msk_cluster` as identifier reference** — follows the established `replica_source` pattern from RDS read replicas. Avoids manual copy&paste of broker URLs that would break on cluster changes.
2. **No cross-namespace support** — MSK Connect must run in the same AWS account and VPC as the cluster. If it's in the same account, the cluster should be managed via app-interface too.
3. **`connector_configuration` as free-form object** — every Kafka Connect plugin has different configuration properties. Constraining this in the schema would be impractical.
4. **`capacity` uses `oneOf`** — AWS MSK Connect requires exactly one capacity mode. The schema enforces mutual exclusivity between `autoscaling` and `provisioned_capacity` via `oneOf`.

## Test plan

- [ ] Validate schema bundle builds successfully (`make bundle`)
- [ ] Verify GraphQL schema is consistent (`make test`)
- [ ] Test with a sample namespace definition containing both `msk` and `msk-connect` resources
- [ ] Validate that `msk_cluster` field is required and rejects missing values