### PR TITLE
remove managePermissions from codeComponents

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2887,7 +2887,6 @@ confs:
   - { name: jira, type: JiraServer_v1 }
   - { name: mirror, type: string }
   - { name: imageBuildUrl, type: string }
-  - { name: managePermissions, type: boolean }
   - { name: blockedVersions, type: string, isList: true }
   - { name: hotfixVersions, type: string, isList: true }
 

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -327,9 +327,6 @@ properties:
           format: uri
           pattern: "^https:\/\/.+(?<!\/)$"
           description: URL for the component's image build job (jenkins job, rhtap pipeline page, etc.)
-        managePermissions:
-          type: boolean
-          description: should permissions be managed on the repository
         blockedVersions:
           type: array
           items:


### PR DESCRIPTION
## Summary

- Remove `managePermissions` field from `schemas/app-sre/app-1.yml`
- Remove `managePermissions` field from `graphql-schemas/schema.yml`

The `gitlab-permissions` integration that consumed this field has been decommissioned in app-sre/qontract-reconcile#5498. No other integration queries or references this field.

## Test plan

- [ ] Schema validation passes (pre-commit hook passed)
- [ ] Verify no other integration selects `managePermissions` in their GraphQL queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)