### PR TITLE
introduce vpc-endpoint and vpc-endpoint-service providers to terraform-resource-2.yml

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1919,6 +1919,7 @@ confs:
       msk-connect: NamespaceTerraformResourceMskConnect_v1
       module-poc: NamespaceTerraformResourceModulePoC_v1
       vpc-endpoint-service: NamespaceTerraformResourceVpcEndpointService_v1
+      vpc-endpoint: NamespaceTerraformResourceVpcEndpoint_v1
 
   fields:
   - { name: provider, type: string, isRequired: true }
@@ -2094,6 +2095,21 @@ confs:
   - { name: openshift_service_name, type: string, isRequired: true }
   - { name: allowed_consumer_clusters, type: Cluster_v1, isList: true }
   - { name: allowed_principal_arns, type: string, isList: true }
+  - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
+  - { name: annotations, type: json }
+  - { name: managed_by_erv2, type: boolean }
+  - { name: delete, type: boolean }
+  - { name: module_overrides, type: ExternalResourcesModuleOverrides_v1 }
+  - { name: tags, type: json }
+
+- name: NamespaceTerraformResourceVpcEndpoint_v1
+  interface: NamespaceTerraformResourceAWS_v1
+  fields:
+  - { name: provider, type: string, isRequired: true, isContextUnique: true }
+  - { name: identifier, type: string, isRequired: true, isContextUnique: true }
+  - { name: endpoint_service_name, type: string, isRequired: true }
+  - { name: vpc, type: AWSVPC_v1, isRequired: true }
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1918,6 +1918,7 @@ confs:
       msk: NamespaceTerraformResourceMsk_v1
       msk-connect: NamespaceTerraformResourceMskConnect_v1
       module-poc: NamespaceTerraformResourceModulePoC_v1
+      vpc-endpoint-service: NamespaceTerraformResourceVpcEndpointService_v1
 
   fields:
   - { name: provider, type: string, isRequired: true }
@@ -2079,6 +2080,23 @@ confs:
   - { name: annotations, type: json }
   - { name: msk_cluster, type: string, isRequired: true }
   - { name: service_execution_role, type: string, isRequired: true }
+  - { name: managed_by_erv2, type: boolean }
+  - { name: delete, type: boolean }
+  - { name: module_overrides, type: ExternalResourcesModuleOverrides_v1 }
+  - { name: tags, type: json }
+
+- name: NamespaceTerraformResourceVpcEndpointService_v1
+  interface: NamespaceTerraformResourceAWS_v1
+  fields:
+  - { name: provider, type: string, isRequired: true, isContextUnique: true }
+  - { name: region, type: string, isContextUnique: true }
+  - { name: identifier, type: string, isRequired: true, isContextUnique: true }
+  - { name: openshift_service_name, type: string, isRequired: true }
+  - { name: allowed_consumer_clusters, type: Cluster_v1, isList: true }
+  - { name: allowed_principal_arns, type: string, isList: true }
+  - { name: output_resource_name, type: string }
+  - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
+  - { name: annotations, type: json }
   - { name: managed_by_erv2, type: boolean }
   - { name: delete, type: boolean }
   - { name: module_overrides, type: ExternalResourcesModuleOverrides_v1 }

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -259,6 +259,17 @@ properties:
       type: string
   openshift_ingress_load_balancer_arn:
     type: string
+  openshift_service_name:
+    type: string
+  allowed_consumer_clusters:
+    type: array
+    items:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/openshift/cluster-1.yml"
+  allowed_principal_arns:
+    type: array
+    items:
+      type: string
   insights_callback_urls:
     type: array
     items:
@@ -2058,5 +2069,46 @@ oneOf:
   required:
   - identifier
   - module
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - vpc-endpoint-service
+    identifier:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    region:
+      "$ref": "/aws/regions-1.yml#/properties/region"
+    openshift_service_name:
+      type: string
+      description: Name of the OpenShift Service (type LoadBalancer) in the target namespace whose NLB is exposed via the VPC Endpoint Service
+    allowed_consumer_clusters:
+      type: array
+      description: Clusters allowed to connect to the VPC Endpoint Service. Each cluster's account uid and terraformUsername are used to build an IAM principal ARN of the form arn:aws:iam::<uid>:user/<terraformUsername>
+      items:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "/openshift/cluster-1.yml"
+    allowed_principal_arns:
+      type: array
+      description: Explicit IAM principal ARNs allowed to connect to the VPC Endpoint Service
+      items:
+        type: string
+    output_resource_name:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    tags:
+      "$ref": "/common-1.json#/definitions/labels"
+    annotations:
+      "$ref": "/common-1.json#/definitions/annotations"
+    managed_by_erv2:
+      type: boolean
+      description: Manage the resource with ERv2
+    delete:
+      type: boolean
+      description: Flag a resource to be deleted
+    module_overrides:
+      "$ref": "/external-resources/module-overrides-1.yml"
+  required:
+  - identifier
+  - openshift_service_name
 required:
 - provider

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -270,6 +270,8 @@ properties:
     type: array
     items:
       type: string
+  endpoint_service_name:
+    type: string
   insights_callback_urls:
     type: array
     items:
@@ -2110,5 +2112,38 @@ oneOf:
   required:
   - identifier
   - openshift_service_name
+- additionalProperties: false
+  properties:
+    provider:
+      type: string
+      enum:
+      - vpc-endpoint
+    identifier:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    endpoint_service_name:
+      type: string
+      description: Name of the VPC Endpoint Service to connect to (e.g. com.amazonaws.vpce.<region>.<service-id>)
+    vpc:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/aws/vpc-1.yml"
+      description: VPC in which to create the endpoint. Private subnets are selected automatically.
+    output_resource_name:
+      "$ref": "/common-1.json#/definitions/longIdentifier"
+    tags:
+      "$ref": "/common-1.json#/definitions/labels"
+    annotations:
+      "$ref": "/common-1.json#/definitions/annotations"
+    managed_by_erv2:
+      type: boolean
+      description: Manage the resource with ERv2
+    delete:
+      type: boolean
+      description: Flag a resource to be deleted
+    module_overrides:
+      "$ref": "/external-resources/module-overrides-1.yml"
+  required:
+  - identifier
+  - endpoint_service_name
+  - vpc
 required:
 - provider


### PR DESCRIPTION
Registers two new ERv2 providers that implement AWS PrivateLink connectivity between OpenShift clusters

## Changes

Adds two new provider entries to schemas/aws/terraform-resource-2.yml:

- `vpc-endpoint-service` — provider side. Creates an AWS VPC Endpoint Service attached to an existing NLB provisioned by an OpenShift Service of type LoadBalancer. The NLB is discovered automatically via kubernetes.io/service-name tags.
- `vpc-endpoint` — consumer side. Creates an interface VPC Endpoint connecting to a vpc-endpoint-service resource. Handles private subnet selection and AZ alignment automatically.

## Related

  - Module repos: [er-aws-vpc-endpoint-service](https://github.com/app-sre/er-aws-vpc-endpoint-service), [er-aws-vpc-endpoint](https://github.com/app-sre/er-aws-vpc-endpoint)
  - [Design doc](https://github.com/openshift-online/platform-engineering-enhancements/blob/main/app-sre/design-docs/er-aws-privatelink.md)