### PR TITLE
chore(glitchtip): remove unused ldapGroups and membersOrganizationRol…

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4170,8 +4170,6 @@ confs:
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: description, type: string, isRequired: true }
-  - { name: ldapGroups, type: string, isList: true }
-  - { name: membersOrganizationRole, type: string }
   - name: roles
     type: Role_v1
     isList: true

--- a/schemas/dependencies/glitchtip-team-1.yml
+++ b/schemas/dependencies/glitchtip-team-1.yml
@@ -15,17 +15,6 @@ properties:
     "$ref": "/common-1.json#/definitions/identifier"
   description:
     type: string
-  ldapGroups:
-    type: array
-    items:
-      type: string
-  membersOrganizationRole:
-    type: string
-    enum:
-    - owner
-    - admin
-    - manager
-    - member
 required:
 - "$schema"
 - name


### PR DESCRIPTION
…e fields

Follow-up to app-sre/qontract-reconcile#5516 which removed all LDAP resolution logic from the glitchtip-api integration. No glitchtip team in app-interface uses these fields, making them dead schema.