### PR TITLE
chore(cloudflare): remove type field from account schemas

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -1471,7 +1471,6 @@ confs:
   - { name: accountOwners, type: Owner_v1, isList: true, isRequired: true }
   - { name: apiCredentials, type: VaultSecret_v1, isRequired: true }
   - { name: enforceTwofactor, type: boolean }
-  - { name: type, type: string }
 
 - name: CloudflareAccountRole_v1
   datafile: /cloudflare/account-role-1.yml

--- a/schemas/cloudflare/account-1.yml
+++ b/schemas/cloudflare/account-1.yml
@@ -65,15 +65,6 @@ properties:
       If true, enforces two-factor authentication for all users in this
       Cloudflare account to meet security and compliance requirements.
 
-  type:
-    type: string
-    enum:
-    - standard
-    - enterprise
-    description: |
-      The type of Cloudflare account. Use 'standard' for regular accounts
-      or 'enterprise' for accounts with enterprise features and support.
-
 required:
 - "$schema"
 - name

--- a/schemas/cloudflare/account-defaults-1.yml
+++ b/schemas/cloudflare/account-defaults-1.yml
@@ -14,12 +14,6 @@ properties:
   name:
     type: string
     description: "Account name"
-  type:
-    description: |
-      Account type, available values: "standard", "enterprise"
-    enum:
-    - standard
-    - enterprise
   enforce_twofactor:
     description: |
       Indicates whether membership in this account requires that Two-Factor Authentication is enabled


### PR DESCRIPTION
## Summary

- Remove unused `type` field (enum: `standard`/`enterprise`) from `schemas/cloudflare/account-1.yml`
- Remove unused `type` field from `schemas/cloudflare/account-defaults-1.yml`
- Remove corresponding `type` field from `CloudflareAccount_v1` in `graphql-schemas/schema.yml`

## Test plan

- [x] `make test` passes (pytest + yamllint + schema bundling + validation)


https://redhat.atlassian.net/browse/APPSRE-14100