### PR TITLE
chore(access): remove PermissionGithubOrg_v1 from graphql and permission schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3372,7 +3372,6 @@ confs:
     strategy: fieldMap
     field: service
     fieldMap:
-      github-org: PermissionGithubOrg_v1
       github-org-team: PermissionGithubOrgTeam_v1
       quay-membership: PermissionQuayOrgTeam_v1
       jenkins-role: PermissionJenkinsRole_v1
@@ -3386,18 +3385,6 @@ confs:
   - { name: name, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
   - { name: service, type: string, isRequired: true }
-
-- name: PermissionGithubOrg_v1
-  interface: Permission_v1
-  fields:
-  - { name: schema, type: string, isRequired: true }
-  - { name: path, type: string, isRequired: true }
-  - { name: labels, type: json }
-  - { name: name, type: string, isRequired: true }
-  - { name: description, type: string, isRequired: true }
-  - { name: service, type: string, isRequired: true }
-  - { name: org, type: string, isRequired: true }
-  - { name: role, type: string }
 
 - name: PermissionGithubOrgTeam_v1
   interface: Permission_v1

--- a/schemas/access/permission-1.yml
+++ b/schemas/access/permission-1.yml
@@ -78,18 +78,6 @@ oneOf:
 - properties:
     service:
       enum:
-      - github-org
-    org:
-      type: string
-    role:
-      type: string
-      enum:
-      - owner
-  required:
-  - org
-- properties:
-    service:
-      enum:
       - github-org-team
     org:
       type: string


### PR DESCRIPTION
## Summary
- Remove `PermissionGithubOrg_v1` type definition from `graphql-schemas/schema.yml`
- Remove `github-org: PermissionGithubOrg_v1` entry from the `Permission_v1` interface fieldMap
- Remove the `github-org` `oneOf` variant from `schemas/access/permission-1.yml`

https://redhat.atlassian.net/browse/APPSRE-14122

🤖 Generated with [Claude Code](https://claude.com/claude-code)