### PR TITLE
add merge_limit and consecutive_failure_limit to housekeeping s…

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2872,6 +2872,8 @@ confs:
   - { name: rebase, type: boolean, isRequired: true }
   - { name: days_interval, type: int }
   - { name: limit, type: int }
+  - { name: merge_limit, type: int }
+  - { name: consecutive_failure_limit, type: int }
   - { name: enable_closing, type: boolean }
   - { name: pipeline_timeout, type: int }
   - { name: labels_allowed, type: CodeComponentGitlabHousekeepingLabelsAllowed_v1, isList: true }

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -292,6 +292,16 @@ properties:
               not:
                 enum:
                 - 0
+            merge_limit:
+              type: integer
+              not:
+                enum:
+                - 0
+            consecutive_failure_limit:
+              type: integer
+              not:
+                enum:
+                - 0
             enable_closing:
               type: boolean
             pipeline_timeout:

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -294,14 +294,12 @@ properties:
                 - 0
             merge_limit:
               type: integer
-              not:
-                enum:
-                - 0
+              minimum: 1
+              description: "Maximum MRs merged per loop iteration. Defaults to limit if unset."
             consecutive_failure_limit:
               type: integer
-              not:
-                enum:
-                - 0
+              minimum: 1
+              description: "Max consecutive merge failures before halting. Defaults to 3 if unset."
             enable_closing:
               type: boolean
             pipeline_timeout:


### PR DESCRIPTION
### Summary
Add optional `merge_limit` and `consecutive_failure_limit` integer fields to the `gitlabHousekeeping` configuration in both the JSON schema and GraphQL schema.
- `merge_limit`: controls how many MRs can be merged per loop iteration (defaults to `limit` when absent)
- `consecutive_failure_limit`: controls how many consecutive pipeline failures before an MR is flagged (defaults to 3 when absent)
Both fields are optional and backward compatible with existing configs.
### Testing
- `make bundle-and-validate-schema` -- passed
- Bundled against local app-interface data with `qontract-bundler` -- passed
- `qontract-validator --only-errors` -- `[]` (no errors)
### Ticket
[APPSRE-13997](https://redhat.atlassian.net/browse/APPSRE-13997)