### PR TITLE
Add multi_merge boolean field

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2912,6 +2912,7 @@ confs:
   - { name: pipeline_timeout, type: int }
   - { name: labels_allowed, type: CodeComponentGitlabHousekeepingLabelsAllowed_v1, isList: true }
   - { name: must_pass, type: string, isList: true }
+  - { name: multi_merge, type: boolean }
 
 - name: CodeComponentGitlabHousekeepingLabelsAllowed_v1
   fields:

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -320,6 +320,9 @@ properties:
               items:
                 type: string
                 description: List of tests must pass before merging.
+            multi_merge:
+              type: boolean
+              description: "Enable optimistic multi-merge (OMM) for this repo. Defaults to false if unset."
           required:
           - enabled
           - rebase

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -322,7 +322,7 @@ properties:
                 description: List of tests must pass before merging.
             multi_merge:
               type: boolean
-              description: "Enable optimistic multi-merge (OMM) for this repo. Defaults to false if unset."
+              description: "Enable optimistic multi-merge (OMM) for this repo."
           required:
           - enabled
           - rebase


### PR DESCRIPTION
Ticket: [APPSRE-14571](https://redhat.atlassian.net/browse/APPSRE-14571)
Add a nullable multi_merge boolean to the gitlabHousekeeping configuration. This enables per-repo opt-in for optimistic multi-merge (OMM) in gitlab-housekeeping, so tenant repos are never affected unless they explicitly set multi_merge: true. 