### PR TITLE
Kinesis: Add shard_level_metrics attribute

### DIFF
--- a/schemas/aws/kinesis-defaults-1.yml
+++ b/schemas/aws/kinesis-defaults-1.yml
@@ -50,6 +50,18 @@ properties:
   starting_position_timestamp:
     type: string
     format: date-time
+  shard_level_metrics:
+    type: array
+    items:
+      type: string
+      enum:
+      - IncomingBytes
+      - IncomingRecords
+      - IteratorAgeMilliseconds
+      - OutgoingBytes
+      - OutgoingRecords
+      - ReadProvisionedThroughputExceeded
+      - WriteProvisionedThroughputExceeded
 
 required:
 - "$schema"


### PR DESCRIPTION
## Summary
- Add `shard_level_metrics` attribute to the Kinesis defaults schema (`schemas/aws/kinesis-defaults-1.yml`)
- Optional array of strings with an enum of valid CloudWatch shard-level metric names (e.g., `IncomingBytes`, `OutgoingRecords`, `IteratorAgeMilliseconds`)

## Test plan
- [ ] `make bundle-and-validate-schema` passes
- [ ] Existing schemas remain valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)