### PR TITLE
fix(schema): make ai- prefix optional for ldapGroup names

### DIFF
--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -191,7 +191,7 @@
     },
     "ldapGroupName": {
       "type": "string",
-      "pattern": "^ai-[a-z][a-z0-9-_.]+[a-z0-9]*$"
+      "pattern": "^(ai-)?[a-z][a-z0-9-_.]+[a-z0-9]*$"
     },
     "positiveInteger": {
       "type": "number",


### PR DESCRIPTION
## Summary

- Make the `ai-` prefix optional in the `ldapGroupName` pattern in `schemas/common-1.json`
- Changes pattern from `^ai-[a-z][a-z0-9-_.]+[a-z0-9]*$` to `^(ai-)?[a-z][a-z0-9-_.]+[a-z0-9]*$`

## Why

Many existing Rover groups do not follow the `ai-` naming convention. This prevents teams from linking them via `ldapGroup` in app-interface roles. For example:

- `automation-analytics`
- `dataverse-source-aapautomationanalytics`
- `automation-analytics-sonarqube-users`

All of these are valid Rover groups but fail the current schema validation.

## Impact

- Existing `ai-` prefixed groups continue to work unchanged
- Groups without the `ai-` prefix can now be referenced

## Jira

AAP-80318