### PR TITLE
feat(gitlab-instance): add sharedWithGroups to projectRequests

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -705,10 +705,16 @@ confs:
   - { name: token, type: VaultSecret_v1, isRequired: true }
   - { name: managedTeams, type: string, isList: true, isRequired: false }
 
+- name: GitlabSharedWithGroup_v1
+  fields:
+  - { name: group, type: string, isRequired: true }
+  - { name: accessLevel, type: string, isRequired: true }
+
 - name: GitlabProjects_v1
   fields:
   - { name: group, type: string, isRequired: true }
   - { name: projects, type: string, isList: true, isRequired: true }
+  - { name: sharedWithGroups, type: GitlabSharedWithGroup_v1, isList: true }
 
 - name: GitlabInstance_v1
   datafile: /dependencies/gitlab-instance-1.yml

--- a/schemas/dependencies/gitlab-instance-1.yml
+++ b/schemas/dependencies/gitlab-instance-1.yml
@@ -34,6 +34,24 @@ properties:
           type: array
           items:
             type: string
+        sharedWithGroups:
+          type: array
+          items:
+            type: object
+            properties:
+              group:
+                type: string
+              accessLevel:
+                type: string
+                enum:
+                - owner
+                - maintainer
+                - developer
+                - reporter
+                - guest
+            required:
+            - group
+            - accessLevel
       required:
       - group
       - projects


### PR DESCRIPTION
## Summary

- Add optional `sharedWithGroups` field to `projectRequests` items in `/dependencies/gitlab-instance-1.yml`
- Each entry specifies a GitLab group name and access level (`owner`, `maintainer`, `developer`, `reporter`, `guest`)
- Extend GraphQL types with `GitlabSharedWithGroup_v1` and update `GitlabProjects_v1`

## Motivation

Enables app-interface to declare GitLab project sharing with additional groups (GitLab "shared groups" feature), required for group-based CODEOWNERS enforcement.

## Related

- Jira: APPSRE-14651
- Follow-up PRs: qontract-reconcile and app-interface (blocked on this schema change)

## Test plan

- [x] `make bundle-and-validate-schema` (or equivalent schema validation)
- [ ] Merge and run `make schemas` in app-interface to verify GraphQL generation
