### PR TITLE
feat: add schema and GraphQL types for RDS start/stop actions (APPSRE-14721)

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -4995,6 +4995,8 @@ confs:
       external-resource-flush-elasticache: AutomatedActionExternalResourceFlushElastiCache_v1
       external-resource-rds-reboot: AutomatedActionExternalResourceRdsReboot_v1
       external-resource-rds-snapshot: AutomatedActionExternalResourceRdsSnapshot_v1
+      external-resource-rds-start: AutomatedActionExternalResourceRdsStart_v1
+      external-resource-rds-stop: AutomatedActionExternalResourceRdsStop_v1
       no-op: AutomatedActionNoOp_v1
       openshift-trigger-cronjob: AutomatedActionOpenshiftTriggerCronjob_v1
       openshift-workload-delete: AutomatedActionOpenshiftWorkloadDelete_v1
@@ -5086,6 +5088,40 @@ confs:
   - { name: arguments, type: AutomatedActionExternalResourceArgument_v1, isList: true, isRequired: true }
 
 - name: AutomatedActionExternalResourceRdsSnapshot_v1
+  interface: AutomatedAction_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: type, type: string, isRequired: true }
+  - { name: description, type: string }
+  - { name: maxOps, type: int, isRequired: true }
+  - { name: instances, type: AutomatedActionsInstance_v1, isList: true, isRequired: true }
+  - name: permissions
+    type: PermissionAutomatedActions_v1
+    isList: true
+    synthetic:
+      schema: /access/permission-1.yml
+      subAttr: actions
+  - { name: arguments, type: AutomatedActionExternalResourceArgument_v1, isList: true, isRequired: true }
+
+- name: AutomatedActionExternalResourceRdsStart_v1
+  interface: AutomatedAction_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: type, type: string, isRequired: true }
+  - { name: description, type: string }
+  - { name: maxOps, type: int, isRequired: true }
+  - { name: instances, type: AutomatedActionsInstance_v1, isList: true, isRequired: true }
+  - name: permissions
+    type: PermissionAutomatedActions_v1
+    isList: true
+    synthetic:
+      schema: /access/permission-1.yml
+      subAttr: actions
+  - { name: arguments, type: AutomatedActionExternalResourceArgument_v1, isList: true, isRequired: true }
+
+- name: AutomatedActionExternalResourceRdsStop_v1
   interface: AutomatedAction_v1
   fields:
   - { name: schema, type: string, isRequired: true }

--- a/schemas/app-sre/automated-action-1.yml
+++ b/schemas/app-sre/automated-action-1.yml
@@ -153,6 +153,50 @@ oneOf:
 - properties:
     type:
       enum:
+      - external-resource-rds-start
+    arguments:
+      type: array
+      items:
+        type: object
+        properties:
+          namespace:
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef": "/openshift/namespace-1.yml"
+            description: "The namespace where the RDS instance is located."
+          identifier:
+            type: string
+            description: "The RDS identifier regex pattern to match."
+        required:
+        - namespace
+        - identifier
+  required:
+  - arguments
+
+- properties:
+    type:
+      enum:
+      - external-resource-rds-stop
+    arguments:
+      type: array
+      items:
+        type: object
+        properties:
+          namespace:
+            "$ref": "/common-1.json#/definitions/crossref"
+            "$schemaRef": "/openshift/namespace-1.yml"
+            description: "The namespace where the RDS instance is located."
+          identifier:
+            type: string
+            description: "The RDS identifier regex pattern to match."
+        required:
+        - namespace
+        - identifier
+  required:
+  - arguments
+
+- properties:
+    type:
+      enum:
       - external-resource-rds-snapshot
     arguments:
       type: array


### PR DESCRIPTION
## Summary

- Add JSON schema `oneOf` blocks for `external-resource-rds-start` and `external-resource-rds-stop`
- Add GraphQL fieldMap entries and type definitions

## Related

- Jira: https://redhat.atlassian.net/browse/APPSRE-14721

## Test plan

- [x] Schema validation passes