### PR TITLE
Add postgres18 in available postgres families

### DIFF
--- a/schemas/aws/parameter-group-1.yml
+++ b/schemas/aws/parameter-group-1.yml
@@ -26,6 +26,7 @@ properties:
     - postgres15
     - postgres16
     - postgres17
+    - postgres18
     - redis5.0
     - redis6.x
     - valkey7


### PR DESCRIPTION
## Summary
- Add `postgres18` to the `family` enum in `schemas/aws/parameter-group-1.yml`, following the same pattern used for postgres16 (#593) and postgres17 (#758).

Context: https://redhat-internal.slack.com/archives/C098G63A9JQ/p1783684148888009