### PR TITLE
add optional gov slack username field to user files

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3585,6 +3585,7 @@ confs:
   - { name: quay_username, type: string }
   - { name: pagerduty_username, type: string }
   - { name: aws_username, type: string }
+  - { name: gov_slack_username, type: string, isRequired: false }
   - { name: cloudflare_user, type: string }
   - { name: public_gpg_key, type: string }
   - { name: tag_on_merge_requests, type: boolean }

--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3585,7 +3585,7 @@ confs:
   - { name: quay_username, type: string }
   - { name: pagerduty_username, type: string }
   - { name: aws_username, type: string }
-  - { name: gov_slack_username, type: string, isRequired: false }
+  - { name: gov_slack_email_local_part, type: string, isRequired: false }
   - { name: cloudflare_user, type: string }
   - { name: public_gpg_key, type: string }
   - { name: tag_on_merge_requests, type: boolean }

--- a/schemas/access/user-1.yml
+++ b/schemas/access/user-1.yml
@@ -38,6 +38,8 @@ properties:
     type: boolean
   tag_on_cluster_updates:
     type: boolean
+  gov_slack_username:
+    type: string
 required:
 - $schema
 - labels

--- a/schemas/access/user-1.yml
+++ b/schemas/access/user-1.yml
@@ -38,7 +38,7 @@ properties:
     type: boolean
   tag_on_cluster_updates:
     type: boolean
-  gov_slack_username:
+  gov_slack_email_local_part:
     type: string
 required:
 - $schema


### PR DESCRIPTION
If the FedRAMP environment would like to utilize the `slack-usergroups-api` integration, `org_username` cannot be utilized for setting users into Slack usergroups because of the way profiles are set up in GovSlack. This PR introduces a new optional field that can be used in FedRAMP in order to add GovSlack user into various groups while still allowing other environments to utilize `org_username`.

q-r logic: https://github.com/app-sre/qontract-reconcile/pull/5687