### PR TITLE
feat(housekeeping): add rebase_limit as alias for limit

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2906,6 +2906,7 @@ confs:
   - { name: rebase, type: boolean, isRequired: true }
   - { name: days_interval, type: int }
   - { name: limit, type: int }
+  - { name: rebase_limit, type: int }
   - { name: merge_limit, type: int }
   - { name: consecutive_failure_limit, type: int }
   - { name: enable_closing, type: boolean }

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -292,14 +292,19 @@ properties:
               not:
                 enum:
                 - 0
+              description: "Deprecated: use rebase_limit instead. Maximum MRs rebased per loop iteration."
+            rebase_limit:
+              type: integer
+              minimum: 1
+              description: "Maximum MRs rebased per loop iteration. Takes precedence over limit."
             merge_limit:
               type: integer
               minimum: 1
-              description: "Maximum MRs merged per loop iteration. Defaults to limit if unset."
+              description: "Maximum MRs merged per loop iteration. Defaults to rebase_limit if unset."
             consecutive_failure_limit:
               type: integer
               minimum: 1
-              description: "Max consecutive merge failures before halting. Defaults to 3 if unset."
+              description: "Maximum consecutive pipeline failures before halting. Defaults to 3 if unset."
             enable_closing:
               type: boolean
             pipeline_timeout:


### PR DESCRIPTION
## Summary

- Add `rebase_limit` as a new optional field alongside `limit` in the housekeeping JSON schema and GraphQL type
- Mark `limit` as deprecated in its description
- Update `merge_limit` description to reference `rebase_limit`
- Fix `consecutive_failure_limit` description ("pipeline failures" not "merge failures")

Step 1 of 3 for APPSRE-14266. Both `limit` and `rebase_limit` are accepted during the transition period.

## Test plan

- [x] `make bundle-and-validate-schema` passes
- [x] yamllint passes

APPSRE-14266

Made with [Cursor](https://cursor.com)