### PR TITLE
feat(housekeeping): remove deprecated limit field

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2905,7 +2905,6 @@ confs:
   - { name: enabled, type: boolean, isRequired: true }
   - { name: rebase, type: boolean, isRequired: true }
   - { name: days_interval, type: int }
-  - { name: limit, type: int }
   - { name: rebase_limit, type: int }
   - { name: merge_limit, type: int }
   - { name: consecutive_failure_limit, type: int }

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -287,16 +287,10 @@ properties:
               not:
                 enum:
                 - 0
-            limit:
-              type: integer
-              not:
-                enum:
-                - 0
-              description: "Deprecated: use rebase_limit instead. Maximum MRs rebased per loop iteration."
             rebase_limit:
               type: integer
               minimum: 1
-              description: "Maximum MRs rebased per loop iteration. Takes precedence over limit."
+              description: "Maximum MRs rebased per loop iteration."
             merge_limit:
               type: integer
               minimum: 1


### PR DESCRIPTION
## Summary

- Remove `limit` field from housekeeping JSON schema and GraphQL type
- All configs already migrated to `rebase_limit` (step 2, app-interface !198161)

Step 3a of APPSRE-14266 (schema side). The companion reconcile PR reads `rebase_limit` and should merge after this.

## Test plan

- [x] `make bundle-and-validate-schema` passes
- [x] yamllint passes

APPSRE-14266

Made with [Cursor](https://cursor.com)