### PR TITLE
Add mysql8.4 in available mysql families

### DIFF
--- a/schemas/aws/parameter-group-1.yml
+++ b/schemas/aws/parameter-group-1.yml
@@ -17,6 +17,7 @@ properties:
     enum:
     - mysql5.7
     - mysql8.0
+    - mysql8.4
     - postgres9.6
     - postgres10
     - postgres11


### PR DESCRIPTION
Needed to support an RDS MySQL 8.0 -> 8.4 major version upgrade
(devlake-stage EOL fix, DPROD-1366). MySQL parameter groups are
tied to an engine major-version family, so 8.4 needs its own
family entry distinct from `mysql8.0`.

Follows the same pattern as the `postgres18` addition.

Ref: DPROD-1366