### PR TITLE
feat(schema): add action-detail/action-cancel automated-action types

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -5016,6 +5016,8 @@ confs:
     strategy: fieldMap
     field: type
     fieldMap:
+      action-cancel: AutomatedActionActionCancel_v1
+      action-detail: AutomatedActionActionDetail_v1
       action-list: AutomatedActionActionList_v1
       create-token: AutomatedActionCreateToken_v1
       external-resource-flush-elasticache: AutomatedActionExternalResourceFlushElastiCache_v1
@@ -5040,6 +5042,48 @@ confs:
     synthetic:
       schema: /access/permission-1.yml
       subAttr: actions
+
+- name: AutomatedActionActionCancel_v1
+  interface: AutomatedAction_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: type, type: string, isRequired: true }
+  - { name: description, type: string }
+  - { name: maxOps, type: int, isRequired: true }
+  - { name: instances, type: AutomatedActionsInstance_v1, isList: true, isRequired: true }
+  - name: permissions
+    type: PermissionAutomatedActions_v1
+    isList: true
+    synthetic:
+      schema: /access/permission-1.yml
+      subAttr: actions
+  - { name: arguments, type: AutomatedActionActionCancelArgument_v1, isList: true }
+
+- name: AutomatedActionActionCancelArgument_v1
+  fields:
+  - { name: owner, type: string }
+
+- name: AutomatedActionActionDetail_v1
+  interface: AutomatedAction_v1
+  fields:
+  - { name: schema, type: string, isRequired: true }
+  - { name: path, type: string, isRequired: true }
+  - { name: type, type: string, isRequired: true }
+  - { name: description, type: string }
+  - { name: maxOps, type: int, isRequired: true }
+  - { name: instances, type: AutomatedActionsInstance_v1, isList: true, isRequired: true }
+  - name: permissions
+    type: PermissionAutomatedActions_v1
+    isList: true
+    synthetic:
+      schema: /access/permission-1.yml
+      subAttr: actions
+  - { name: arguments, type: AutomatedActionActionDetailArgument_v1, isList: true }
+
+- name: AutomatedActionActionDetailArgument_v1
+  fields:
+  - { name: owner, type: string }
 
 - name: AutomatedActionActionList_v1
   interface: AutomatedAction_v1

--- a/schemas/app-sre/automated-action-1.yml
+++ b/schemas/app-sre/automated-action-1.yml
@@ -51,6 +51,10 @@ properties:
         namespace:
           "$ref": "/common-1.json#/definitions/crossref"
           "$schemaRef": "/openshift/namespace-1.yml"
+        # action-cancel and action-detail specific arguments
+        owner:
+          type: string
+          description: The action owner (username) regex pattern to match.
         # action-list specific arguments
         action_user:
           type: string
@@ -85,6 +89,32 @@ required:
 
 # Keep in alphabetical order!!
 oneOf:
+- properties:
+    type:
+      enum:
+      - action-cancel
+    arguments:
+      type: array
+      items:
+        type: object
+        properties:
+          owner:
+            type: string
+            description: The action owner (username) regex pattern to match.
+
+- properties:
+    type:
+      enum:
+      - action-detail
+    arguments:
+      type: array
+      items:
+        type: object
+        properties:
+          owner:
+            type: string
+            description: The action owner (username) regex pattern to match.
+
 - properties:
     type:
       enum:


### PR DESCRIPTION
## Summary

- Adds two new automated-action types, `action-cancel` and `action-detail`, to `schemas/app-sre/automated-action-1.yml` (JSON schema `oneOf`) and `graphql-schemas/schema.yml` (GraphQL interface + type blocks), each with an optional `owner` regex argument.
- Mirrors the existing `action-list` type's `action_user` argument shape exactly.

## Why

Part of fixing an IDOR in `app-sre/automated-actions` (APPSRE-14974): any authenticated user can currently view/cancel any other user's action. The fix restricts the default role to the action's own owner, but app-sre support staff need to retain cross-user visibility for incident response — this schema change lets app-interface express that grant via a real `owner: .*` argument (not left unused), the same pattern already used for `action-list`.

## Sequencing note

This PR is safe to merge standalone (the new types are unused until referenced). Downstream:
1. `qontract-reconcile` needs a `compile_roles()` case added to turn the `owner` argument into role params (separate PR, blocked on this one's image being introspectable).
2. `app-interface` needs new `actions/app-sre/action-detail.yml`/`action-cancel.yml` files (separate PR, blocked on this schema being available in app-interface's pinned `SCHEMAS_IMAGE_TAG`).
3. `automated-actions` needs the actual owner-check enforcement (separate PR, must deploy last).

## Test plan

- [x] `make test` (Docker): pytest, yamllint, `qontract-bundler` + `qontract-validator --only-errors` all pass clean against the new schema.

Jira: APPSRE-14974