### PR TITLE
feat(acs): add optional instance field to ACS schemas

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -751,6 +751,7 @@ confs:
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
+  - { name: instance, type: AcsInstance_v1 }
   - { name: description, type: string }
   - { name: integrations, type: AcsPolicyIntegrations_v1 }
   - { name: severity, type: string, isRequired: true }
@@ -3398,6 +3399,7 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: service, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
+  - { name: instance, type: AcsInstance_v1 }
   - { name: permission_set, type: string, isRequired: true }
   - { name: clusters, type: Cluster_v1, isList: true }
   - { name: namespaces, type: Namespace_v1, isList: true }

--- a/schemas/access/oidc-permission-1.yml
+++ b/schemas/access/oidc-permission-1.yml
@@ -73,6 +73,9 @@ oneOf:
     service:
       enum:
       - acs
+    instance:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/dependencies/acs-instance-1.yml"
     clusters:
       type: array
       items:

--- a/schemas/acs/acs-policy-1.yml
+++ b/schemas/acs/acs-policy-1.yml
@@ -25,6 +25,11 @@ properties:
     type: string
     description: |
       The name of the policy. This should be unique and descriptive.
+  instance:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/dependencies/acs-instance-1.yml"
+    description: |
+      Reference to the ACS instance this policy applies to.
   integrations:
     type: object
     description: |


### PR DESCRIPTION
## Overview

> **Ticket:** [APPSRE-14643](https://redhat.atlassian.net/browse/APPSRE-14643)
> **Phase:** 1 of 4

This MR adds an optional `instance` field to the ACS permission and policy schemas. The field links a permission or policy to a specific ACS instance.

The field is optional in this MR. A follow-up MR (Phase 4) makes it required after the app-interface data migration.

## Why

The `acs-rbac` and `acs-policies` integrations support only one ACS instance. The code raises an error when more than one `acs-instance-1.yml` datafile exists. This blocks onboarding of new ACS instances. Adding the `instance` field is the first step to support multiple instances.

## Files changed

#### `schemas/access/oidc-permission-1.yml`

Adds an optional `instance` crossref to the ACS `oneOf` branch. The ref points to `/dependencies/acs-instance-1.yml`. The existing ACS `required` arrays (`permission_set + clusters` and `permission_set + namespaces`) do not change.

#### `schemas/acs/acs-policy-1.yml`

Adds an optional `instance` crossref property. The ref points to `/dependencies/acs-instance-1.yml`. The top-level `required` array does not change.

#### `graphql-schemas/schema.yml`

Adds an optional `instance: AcsInstance_v1` field to two types:

- `AcsPolicy_v1`
- `OidcPermissionAcs_v1`

## Merge order

Merge this MR before the qontract-reconcile MR. The qontract-reconcile CI pipeline validates against these schemas.

1. **This MR** — schemas (instance optional)
2. **qontract-reconcile MR** — code reads and uses the instance field
3. **app-interface MR** — tags all existing permissions and policies with `instance: app-sre-acs`
4. **Follow-up schema MR** — makes `instance` required after Phase 3 merges

## Validation

```bash
GIT_COMMIT=$(git rev-parse HEAD) GIT_COMMIT_TIMESTAMP=$(git log -1 --format=%ct) \
make bundle-and-validate-schema
```

A passing run prints `[]`.