### PR TITLE
[APPSRE-13941] Add automationTokens list fields to cluster schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -430,6 +430,14 @@ confs:
   - { name: format, type: string }
   - { name: version, type: int }
 
+- name: AutomationTokenEntry_v1
+  fields:
+  - { name: name, type: string, isRequired: true }
+  - { name: namespace, type: string, isRequired: true }
+  - { name: active, type: boolean }
+  - { name: delete, type: boolean }
+  - { name: secret, type: VaultSecret_v1 }
+
 - name: KeyValue_v1
   fields:
   - { name: key, type: string, isRequired: true }
@@ -1154,8 +1162,10 @@ confs:
   - { name: insecureSkipTLSVerify, type: boolean }
   - { name: jumpHost, type: ClusterJumpHost_v1 }
   - { name: automationToken, type: VaultSecret_v1 }
+  - { name: automationTokens, type: AutomationTokenEntry_v1, isList: true }
   - { name: clusterAdmin, type: boolean }
   - { name: clusterAdminAutomationToken, type: VaultSecret_v1 }
+  - { name: clusterAdminAutomationTokens, type: AutomationTokenEntry_v1, isList: true }
   - { name: internal, type: boolean }
   - { name: disable, type: DisableClusterAutomations_v1 }
   - { name: awsInfrastructureAccess, type: AWSInfrastructureAccess_v1, isList: true }

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -4,6 +4,40 @@ version: "1.0"
 type: object
 
 additionalProperties: false
+definitions:
+  automationTokenEntry:
+    type: object
+    description: "Automation token entry. Operator declares name/namespace/lifecycle, integration populates secret field."
+    additionalProperties: false
+    properties:
+      name:
+        type: string
+        description: "Kubernetes secret name"
+      namespace:
+        type: string
+        description: "Namespace for this secret"
+      active:
+        type: boolean
+        description: "Mark this secret as active (used by consumers). When multiple entries exist, consumers use the one marked active."
+      delete:
+        type: boolean
+        description: "Mark this secret for deletion. Integration will delete both the K8s secret and Vault entry. Cannot be true when active is true."
+      secret:
+        "$ref": "/common-1.json#/definitions/vaultSecret"
+        description: "Auto-populated by integration after token creation. Read-only for operators."
+    required:
+    - name
+    - namespace
+    allOf:
+    - not:
+        properties:
+          active:
+            const: true
+          delete:
+            const: true
+        required:
+        - active
+        - delete
 properties:
   "$schema":
     type: string
@@ -551,11 +585,19 @@ properties:
     "$schemaRef": "/openshift/jump-host-1.yml"
   automationToken:
     "$ref": "/common-1.json#/definitions/vaultSecret"
+  automationTokens:
+    type: array
+    items:
+      "$ref": "#/definitions/automationTokenEntry"
   clusterAdmin:
     type: boolean
     description: should enable cluster admin for this cluster
   clusterAdminAutomationToken:
     "$ref": "/common-1.json#/definitions/vaultSecret"
+  clusterAdminAutomationTokens:
+    type: array
+    items:
+      "$ref": "#/definitions/automationTokenEntry"
   description:
     type: string
   internal:


### PR DESCRIPTION
## Context

This is **Phase 1 of 5** in the `automationTokens` rotation migration.

> **Design doc:** [Vault Secret Rotation](https://github.com/openshift-online/platform-engineering-enhancements/blob/main/app-sre/design-docs/vault-secret-rotation.md)

### Migration plan

| Phase | Repo | Description | Status |
|-------|------|-------------|--------|
| 1 | qontract-schemas | Add `automationTokens`/`clusterAdminAutomationTokens` fields to cluster schema | **This MR** |
| 2 | qontract-reconcile | Prefer list tokens in `oc_connection_parameters`, implement list-based SA/Vault/MR workflow in `openshift-cluster-bots` | Pending |
| 3 | app-interface | Migrate clusters one-by-one: add `automationTokens` entries, let integration populate secrets, activate | Pending |
| 4 | qontract-schemas + qontract-reconcile | Remove singular fields from schema and all legacy code paths — this must happen together, as ~30 GQL queries across qontract-reconcile still reference the singular `automationToken`/`clusterAdminAutomationToken` fields | Pending |
| 5 | app-interface | Remove singular `automationToken`/`clusterAdminAutomationToken` from all clusters | Pending |

> **Note:** Phase 4 and the former Phase 5 are combined. The singular schema fields cannot be removed until all qontract-reconcile GQL queries referencing them have been updated in the same change.

### Design

The goal is to support **zero-downtime token rotation** for `openshift-cluster-bots`-managed clusters. Today each cluster has a single `automationToken` secret; rotating it requires a cutover window. The new model uses a list where multiple entries can coexist — the consumer picks the first `active: true, delete: false` entry with a populated secret — making rotations seamless.

Operators declare entries with `name`/`namespace`. The `openshift-cluster-bots` integration creates the ServiceAccount and Kubernetes secret, writes the token to Vault, and back-fills the `secret` reference via MR. The `active` flag signals readiness; `delete` flags entries for cleanup.

### Schema changes

- `automationTokens` — list of entries for the dedicated-admin SA token
- `clusterAdminAutomationTokens` — list of entries for the cluster-admin SA token
- `automationTokenEntry` defined inline in `cluster-1.yml` (not in `common-1.json` — it has no other consumers)
- An `allOf/not` constraint prevents `active: true` and `delete: true` from coexisting on the same entry
- `graphql-schemas/schema.yml` auto-updated by the schema generation tooling

## Test plan

- [ ] Schema validation passes for a cluster with `automationTokens` entries (covered by app-interface-dev-data test data)
- [ ] Schema validation rejects an entry with both `active: true` and `delete: true`
- [ ] Existing cluster files without `automationTokens` continue to validate (fields are optional)