### PR TITLE
feat(quay-org): add optional managedRobotAccounts flag

### DIFF
--- a/schemas/dependencies/quay-org-1.yml
+++ b/schemas/dependencies/quay-org-1.yml
@@ -57,6 +57,13 @@ properties:
     type: string
   managedRepos:
     type: boolean
+  managedRobotAccounts:
+    type: boolean
+    description: |
+      When true, quay-robot-accounts may inventory and reconcile robot accounts
+      for this organization. Defaults to false (opt-in). Requires an
+      automationToken with Administer Organization (and Administer Repositories
+      if repository permissions are managed).
   serverUrl:
     type: string
     format: uri


### PR DESCRIPTION
## Summary
- Add optional `managedRobotAccounts` boolean to `/dependencies/quay-org-1.yml`.
- Opt-in gate for `quay-robot-accounts` (defaults to false when omitted).

Companion: https://github.com/app-sre/qontract-reconcile/pull/5760

APPSRE-11883

## Test plan
- [ ] Schema validation passes in CI
- [ ] After merge, pull schemas into app-interface / qontract-server before merging the reconcile PR


Made with [Cursor](https://cursor.com)