### PR TITLE
hotfix(quay-org): expose managedRobotAccounts on GraphQL QuayOrg_v1

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -487,6 +487,7 @@ confs:
   - { name: mirror, type: QuayOrg_v1 }
   - { name: mirrorFilters, type: QuayOrgMirrorFilter_v1, isList: true }
   - { name: managedRepos, type: boolean, isRequired: true }
+  - { name: managedRobotAccounts, type: boolean }
   - { name: instance, type: QuayInstance_v1, isRequired: true }
   - { name: serverUrl, type: string }
   - { name: managedTeams, type: string, isList: true, isRequired: true }


### PR DESCRIPTION
## Summary
- Add optional `managedRobotAccounts` to `QuayOrg_v1` in `graphql-schemas/schema.yml`.
- #1051 only updated the JSON schema (`quay-org-1.yml`). qontract-server GraphQL types come from this file, so live GraphQL still rejected the field and broke every integration using shared `QUAY_ORGS_QUERY` (`quay-repos`, `quay-membership`, etc.).

## Test plan
- [ ] After merge + schemas promote, GraphQL accepts:
  `{ quay_orgs_v1 { name managedRobotAccounts } }`
- [ ] quay-repos / quay-membership dry-runs succeed again

APPSRE-11883

Made with [Cursor](https://cursor.com)