### PR TITLE
chore(acs): make `instance` Required for ACS Policies and Permissions

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -752,7 +752,7 @@ confs:
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
   - { name: name, type: string, isRequired: true }
-  - { name: instance, type: AcsInstance_v1 }
+  - { name: instance, type: AcsInstance_v1, isRequired: true }
   - { name: description, type: string }
   - { name: integrations, type: AcsPolicyIntegrations_v1 }
   - { name: severity, type: string, isRequired: true }
@@ -3400,7 +3400,7 @@ confs:
   - { name: name, type: string, isRequired: true, isUnique: true }
   - { name: service, type: string, isRequired: true }
   - { name: description, type: string, isRequired: true }
-  - { name: instance, type: AcsInstance_v1 }
+  - { name: instance, type: AcsInstance_v1, isRequired: true }
   - { name: permission_set, type: string, isRequired: true }
   - { name: clusters, type: Cluster_v1, isList: true }
   - { name: namespaces, type: Namespace_v1, isList: true }

--- a/schemas/access/oidc-permission-1.yml
+++ b/schemas/access/oidc-permission-1.yml
@@ -95,9 +95,11 @@ oneOf:
   oneOf:
   - required:
     - permission_set
+    - instance
     - clusters
   - required:
     - permission_set
+    - instance
     - namespaces
 required:
 - $schema

--- a/schemas/acs/acs-policy-1.yml
+++ b/schemas/acs/acs-policy-1.yml
@@ -145,6 +145,7 @@ properties:
 required:
 - "$schema"
 - name
+- instance
 - severity
 - categories
 - scope


### PR DESCRIPTION
**Ticket:** [APPSRE-14643](https://redhat.atlassian.net/browse/APPSRE-14643)  
**Phase:** 4 of 5 (Multi-Instance ACS Support)
**Co-authored:** `Claude`

## Summary

This change makes the `instance` field required for all ACS security policies and OIDC permissions. This follows `Phase 3`, which added the `instance` field to all existing ACS data files in app-interface. [[1](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/202408)]

### Phase Coordination

This PR is `Phase 4` of a multi-phase rollout.

1. **Phase 1** (qontract-schemas): Add optional `instance` field to schemas. (✅ Complete)
2. **Phase 2** (qontract-reconcile): Update reconciliation code to support multiple instances. (✅ Complete)
3. **Phase 3** (app-interface): Tag all existing permissions and policies with `instance: app-sre-acs`. (✅ Complete)
4. **Phase 4** (qontract-schemas): Make `instance` required in schemas.
5. **Phase 5** (qontract-reconcile): Switch from permissive to strict filtering.

## Changes

### JSON Schemas

**`schemas/acs/acs-policy-1.yml`**
- Add `instance` to the top-level `required` array

**`schemas/access/oidc-permission-1.yml`**
- Add `instance` to both ACS `oneOf` required arrays (cluster-scoped and namespace-scoped)

### GraphQL Schema

**`graphql-schemas/schema.yml`**
- Set `isRequired: true` on the `instance` field in `AcsPolicy_v1` (line 755)
- Set `isRequired: true` on the `instance` field in `OidcPermissionAcs_v1` (line 3403)

## Impact

After this change:
- All new ACS policies must specify an `instance` field
- All new ACS permissions must specify an `instance` field
- Schema validation rejects policies or permissions without an `instance`

This prevents the creation of policies and permissions without an instance assignment. Policies without an instance cause reconciliation errors in a multi-instance environment.

## Verification

```bash
cd /path/to/qontract-schemas
GIT_COMMIT=$(git rev-parse HEAD) GIT_COMMIT_TIMESTAMP=$(git log -1 --format=%ct) make bundle-and-validate-schema
```

A passing run prints `[]` (zero validation errors).