### PR TITLE
Add kubernetes.io/basic-auth to vault-secret type enum

### DIFF
--- a/schemas/openshift/openshift-resource-vault-secret-1.yml
+++ b/schemas/openshift/openshift-resource-vault-secret-1.yml
@@ -29,6 +29,7 @@ properties:
     - Opaque
     - kubernetes.io/dockercfg
     - kubernetes.io/dockerconfigjson
+    - kubernetes.io/basic-auth
     - kubernetes.io/tls
     - kubernetes.io/ssh-auth
   validate_alertmanager_config:


### PR DESCRIPTION
## Summary

- Adds `kubernetes.io/basic-auth` to the allowed `type` enum in `openshift-resource-vault-secret-1.yml`
- Pipelines-as-Code requires secrets of type `kubernetes.io/basic-auth` for SCM credential nudging
- Without this, app-interface validation rejects the type and secrets default to `Opaque`, breaking PaC nudging
- Needed for: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/203019

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>