### PR TITLE
APPSRE-14629: Add env field to SLO document

### DIFF
--- a/schemas/app-sre/slo-document-1.yml
+++ b/schemas/app-sre/slo-document-1.yml
@@ -21,6 +21,16 @@ properties:
   labels:
     "$ref": "/common-1.json#/definitions/labels"
 
+  env:
+    type: string
+    description: |
+      Optional environment identifier (e.g. "prod" or "stage") injected as the
+      `env` label on every alert rule generated for this document by the sloth
+      integration. Alertmanager routes SLO alerts to per-environment receivers
+      using this label. Stage and prod are typically modelled as separate SLO
+      documents, each with its own `env` value. When omitted, generated alerts
+      carry no `env` label and cannot be routed by environment.
+
   name:
     "$ref": "/common-1.json#/definitions/identifier"
     description: |


### PR DESCRIPTION
Why

Sloth-generated SLO alerts need an env label so the shared Alertmanager config can route them to per-environment receivers. The SLO document schema had no field to carry that value.

What

Add an optional, free-form env string to the SLO document schema. It is free-form because Alertmanager routing keys on arbitrary env values chosen by teams. The field is not required, so existing documents remain valid and their generated alerts are unchanged.

The consuming logic lives in qontract-reconcile; this change only teaches the schema to accept the field. Merge and deploy this before the qontract-reconcile change.

PR 1 of 3 for this (part 2 will be in https://github.com/app-sre/qontract-reconcile)