### PR TITLE
[APPSRE-15181] add optional prefixStartSlaveCmd to Jenkins SSHConnector

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -530,6 +530,7 @@ confs:
   - { name: launchTimeoutSeconds, type: int, isRequired: false }
   - { name: maxNumRetries, type: int, isRequired: false}
   - { name: port, type: int, isRequired: false}
+  - { name: prefixStartSlaveCmd, type: string, isRequired: false}
   - { name: retryWaitTime, type: int, isRequired: false}
   - { name: sshHostKeyVerificationStrategy, type: string, isRequired: false}
 

--- a/schemas/dependencies/jenkins-instance-1.yml
+++ b/schemas/dependencies/jenkins-instance-1.yml
@@ -80,6 +80,9 @@ properties:
               type: integer
             port:
               type: integer
+            prefixStartSlaveCmd:
+              type: string
+              description: Prefix to the launch command.
             retryWaitTime:
               type: integer
             sshHostKeyVerificationStrategy:


### PR DESCRIPTION
What

The Jenkins EC2 Fleet worker fleets launch agents over SSH via the ssh-slaves plugin's SSHConnector. That connector supports a prefixStartSlaveCmd option that prepends a command to the agent launch. This change enables use of this field.

Why

We want to use this field to make the agent wait until the environment is ready.