### PR TITLE
feat(privatelink): add private DNS fields to PrivateLink GQL fragments (APPSRE-14607)

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -2107,6 +2107,7 @@ confs:
   - { name: openshift_service_name, type: string, isRequired: true }
   - { name: allowed_consumer_clusters, type: Cluster_v1, isList: true }
   - { name: allowed_principal_arns, type: string, isList: true }
+  - { name: private_dns_name, type: string }
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }
   - { name: annotations, type: json }
@@ -2121,6 +2122,7 @@ confs:
   - { name: provider, type: string, isRequired: true, isContextUnique: true }
   - { name: identifier, type: string, isRequired: true, isContextUnique: true }
   - { name: endpoint_service_name, type: string, isRequired: true }
+  - { name: private_dns_enabled, type: boolean }
   - { name: vpc, type: AWSVPC_v1, isRequired: true }
   - { name: output_resource_name, type: string }
   - { name: output_format, type: NamespaceTerraformResourceOutputFormat_v1, isInterface: true }

--- a/schemas/aws/terraform-resource-2.yml
+++ b/schemas/aws/terraform-resource-2.yml
@@ -272,6 +272,10 @@ properties:
       type: string
   endpoint_service_name:
     type: string
+  private_dns_name:
+    type: string
+  private_dns_enabled:
+    type: boolean
   insights_callback_urls:
     type: array
     items:
@@ -2095,6 +2099,9 @@ oneOf:
       description: Explicit IAM principal ARNs allowed to connect to the VPC Endpoint Service
       items:
         type: string
+    private_dns_name:
+      type: string
+      description: Private DNS name to associate with the VPC Endpoint Service for automatic DNS resolution in consumer VPCs. Requires domain ownership verification via TXT record.
     output_resource_name:
       "$ref": "/common-1.json#/definitions/longIdentifier"
     tags:
@@ -2123,6 +2130,9 @@ oneOf:
     endpoint_service_name:
       type: string
       description: Name of the VPC Endpoint Service to connect to (e.g. com.amazonaws.vpce.<region>.<service-id>)
+    private_dns_enabled:
+      type: boolean
+      description: Enable private DNS resolution for the VPC Endpoint. Requires the VPC Endpoint Service to have a verified private DNS name.
     vpc:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/aws/vpc-1.yml"


### PR DESCRIPTION
## Summary

Adds two optional fields to the PrivateLink External Resource schemas to support [AWS PrivateLink Private DNS](https://docs.aws.amazon.com/vpc/latest/privatelink/manage-dns-names.html), tracked in [APPSRE-14607](https://issues.redhat.com/browse/APPSRE-14607).

## Changes

### `graphql-schemas/schema.yml`

- `NamespaceTerraformResourceVpcEndpointService_v1`: add optional `private_dns_name: string`
- `NamespaceTerraformResourceVpcEndpoint_v1`: add optional `private_dns_enabled: boolean`

### `schemas/aws/terraform-resource-2.yml`

- `NamespaceTerraformResourceVpcEndpointService_v1` JSON schema: add `private_dns_name` (type: string) with description
- `NamespaceTerraformResourceVpcEndpoint_v1` JSON schema: add `private_dns_enabled` (type: boolean) with description
- Also adds both fields to the shared `vpc-endpoint` defaults block used by the ERv1 path

## Validation

- `make bundle-and-validate-schema` ✅
- `make gql_validate` ✅ (qontract-server started and ran cleanly)
- `make test` ✅ (30 pytest passed, yamllint clean)

## Context

Both fields are already implemented in the module code (merged in [er-aws-vpc-endpoint-service#60](https://github.com/app-sre/er-aws-vpc-endpoint-service/pull/60) and [er-aws-vpc-endpoint#47](https://github.com/app-sre/er-aws-vpc-endpoint/pull/47)) and documented in app-interface. This schema PR is the missing contract piece that allows app-interface data files to declare these fields and qontract-reconcile to query them.

After this merges, a follow-up qontract-reconcile PR will:
1. Add both fields to `external_resources_namespaces.gql`
2. Regenerate the Pydantic model classes via `make gql-query-classes`