### PR TITLE
feat(cluster-integrations): add openshift-upgrade-watcher to disable enum

### DIFF
--- a/schemas/openshift/cluster-integrations-1.yml
+++ b/schemas/openshift/cluster-integrations-1.yml
@@ -51,5 +51,6 @@ properties:
       - cluster-auth-rhidp
       - endpoints-discovery
       - automated-actions
+      - openshift-upgrade-watcher
 required:
 - integrations


### PR DESCRIPTION
## What

Add `openshift-upgrade-watcher` to the allowed integration names in
`schemas/openshift/cluster-integrations-1.yml` so it can be listed
under a cluster's `disable.integrations` block in app-interface.

## Why

The integration already exists in app-interface
(`data/integrations/qontract-reconcile-openshift-upgrade-watcher.yml`)
and qontract-reconcile already checks `cluster.disable.integrations`
via `OCMap._is_cluster_disabled()` before making any API calls
against a cluster.

The omission from the schema enum means that any cluster needing
to temporarily suppress the watcher (e.g. during initial
provisioning when RBAC is still incomplete) cannot be disabled
per-cluster — the validator rejects the entry.

## Context

`rhobsp01ue2` (a new ROSA cluster) is missing the OLM-generated
`upgradeconfigs.upgrade.managed.openshift.io-v1alpha1-view` ClusterRole
that normally aggregates into the `dedicated-admins-cluster` binding.
The watcher's service account therefore receives a 403 when it tries
to list `UpgradeConfig` resources. A per-cluster disable entry in
`cluster.yml` is the surgical temporary mitigation while the
platform provisioning issue is resolved.

## Testing

- `make test` (30/30 pytest, yamllint): passes ✅
