### PR TITLE
[APPSRE-15221] Add GitHub organization as source of truth for Slack usergroups

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -3488,6 +3488,7 @@ confs:
   - { name: handle, type: string, isRequired: true, isUnique: true }
   - { name: workspace, type: SlackWorkspace_v1, isRequired: true }
   - { name: pagerduty, type: PagerDutyTarget_v1, isList: true }
+  - { name: github, type: GithubOrg_v1 }
   - { name: channels, type: string, isList: true, isRequired: true }
   - { name: ownersFromRepos, type: string, isList: true }
   - { name: schedule, type: Schedule_v1 }

--- a/schemas/access/permission-1.yml
+++ b/schemas/access/permission-1.yml
@@ -55,6 +55,9 @@ properties:
     items:
       "$ref": "/common-1.json#/definitions/crossref"
       "$schemaRef": "/dependencies/pagerduty-target-1.yml"
+  github:
+    "$ref": "/common-1.json#/definitions/crossref"
+    "$schemaRef": "/dependencies/github-org-1.yml"
   ownersFromRepos:
     type: array
     items:
@@ -163,6 +166,9 @@ oneOf:
       items:
         "$ref": "/common-1.json#/definitions/crossref"
         "$schemaRef": "/dependencies/pagerduty-target-1.yml"
+    github:
+      "$ref": "/common-1.json#/definitions/crossref"
+      "$schemaRef": "/dependencies/github-org-1.yml"
     ownersFromRepos:
       type: array
       items:


### PR DESCRIPTION
## Summary
- Add an optional `github` crossref field to the `SlackUsergroup` permission schema (`schemas/access/permission-1.yml`), referencing `/dependencies/github-org-1.yml`, so Slack usergroup membership can be derived from a GitHub organization's members.
- Add the corresponding `github: GithubOrg_v1` field to the `PermissionSlackUsergroup_v1` type in `graphql-schemas/schema.yml`.

This complements existing sources of truth for Slack usergroups (PagerDuty, OWNERS files, schedules), enabling use cases like paging/notifying an entire GitHub org (e.g. for a security issue).

Jira: https://redhat.atlassian.net/browse/APPSRE-15221

## Test plan
- [x] `make test` (pytest + yamllint + bundle + validate) passes