### PR TITLE
[APPSRE-15234] Add optional url to vault secret schema

### DIFF
--- a/graphql-schemas/schema.yml
+++ b/graphql-schemas/schema.yml
@@ -425,6 +425,7 @@ confs:
 
 - name: VaultSecret_v1
   fields:
+  - { name: url, type: string }
   - { name: path, type: string, isRequired: true }
   - { name: field, type: string, isRequired: true }
   - { name: format, type: string }

--- a/schemas/common-1.json
+++ b/schemas/common-1.json
@@ -140,6 +140,10 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
         "path": {
           "type": "string"
         },


### PR DESCRIPTION
## Summary
- Add an optional `url` field to the shared `vaultSecret` definition (`schemas/common-1.json`) and to `VaultSecret_v1` in `graphql-schemas/schema.yml`, so a secret reference can point at a Vault server other than the default AppSRE instance.
- Needed for [APPSRE-15234](https://redhat.atlassian.net/browse/APPSRE-15234): the Red Hat SSO initial access token is hosted on the IT Vault instance, not the AppSRE one.

## Test plan
- [x] `yamllint graphql-schemas/schema.yml`
- [x] `qontract-bundler` + `qontract-validator --only-errors` against the bundled schema (0 errors)